### PR TITLE
Handle any exception that gets thrown during JWT verification

### DIFF
--- a/examples/basic-api/index.php
+++ b/examples/basic-api/index.php
@@ -76,6 +76,11 @@
       header('HTTP/1.0 401 Unauthorized');
       echo "Invalid token";
       exit();
+    } catch(Exception $e) {
+      header('HTTP/1.0 500 Internal Server Error');
+      echo $e->getMessage();
+      echo "\n\nMost likely thrown because configured client secret must be public signing key, not client secret";
+      exit();
     }
 
 


### PR DESCRIPTION
The seed project's CLIENT_SECRET is the app's client secret.
However, in the case of using RS256, this is the wrong secret. So,
when verification occurs, a DomainException is thrown from the
openssl code as the secret is not a valid public key. So, at least
handle the exception and return a 500 so the frontend can treat it
as an error, rather than a 200 OK when it didn't actually work
(I've submitted a pull-request to handle the error through the
angular seed project too)