### PR TITLE
Readme file call URL port fixed

### DIFF
--- a/examples/basic-api/README.md
+++ b/examples/basic-api/README.md
@@ -23,4 +23,4 @@ composer install
 php -S localhost:30001
 ````
 
-Now, try calling [http://localhost:3001/ping](http://localhost:3001/ping)
+Now, try calling [http://localhost:30001/ping](http://localhost:30001/ping)


### PR DESCRIPTION
Changed Readme file to indicate to call the same port in which it
indicated to install and start the server.