### PR TITLE
Fix Closure namespace issue

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -435,13 +435,13 @@ class Auth0 {
     }
 
     /**
-     * If debug mode is set, sends $info to debugger Closure.
+     * If debug mode is set, sends $info to debugger \Closure.
      *
      * @param  mixed $info  Info to debug. It will be converted to string.
      */
     public function debugInfo($info)
     {
-        if ($this->debug_mode && (is_object($this->debugger) && ($this->debugger instanceof Closure))) {
+        if ($this->debug_mode && (is_object($this->debugger) && ($this->debugger instanceof \Closure))) {
             list(, $caller) = debug_backtrace(false);
 
             $caller_function = $caller['function'];
@@ -589,7 +589,7 @@ class Auth0 {
      *
      * @return Auth0\SDK\BaseAuth0
      */
-    final public function setDebugger(Closure $debugger)
+    final public function setDebugger(\Closure $debugger)
     {
         $this->debugger = $debugger;
 


### PR DESCRIPTION
Closures cannot currently be passed in to the debugger, because the type hinting is not using the base namespace, and thus the debugger would have to be of type \Auth0\SDK\Closure.  This PR fixes that by adding the base namespace to those type hints.