### PR TITLE
Fix ApiConnections class name

### DIFF
--- a/src/API/ApiConnections.php
+++ b/src/API/ApiConnections.php
@@ -6,7 +6,7 @@ use Auth0\SDK\API\ApiClient;
 use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
 
-class ApiConnection {
+class ApiConnections {
 
     protected static function getApiV2Client($domain) {
 


### PR DESCRIPTION
Class cannot be auto-loaded due to not matching the file name.