### PR TITLE
$this->access_token is an array, not object

### DIFF
--- a/src/Auth0AuthApi.php
+++ b/src/Auth0AuthApi.php
@@ -258,7 +258,7 @@ class Auth0AuthApi {
       ->users($user_id)
       ->impersonate()
       ->withHeader(new ContentType('application/json'))
-      ->withHeader(new AuthorizationBearer($this->access_token->access_token))
+      ->withHeader(new AuthorizationBearer($this->access_token['access_token']))
       ->withBody(json_encode($data))
       ->call();
 


### PR DESCRIPTION
As ``requestBuilder->call`` applies json_decode($body, **true**);

if you ever tested it, you'd get 

> Trying to get property of non-object in auth0\auth0-php\src\Auth0AuthApi.php on line 261