### PR TITLE
Correctly build logout url query string

### DIFF
--- a/src/Auth0AuthApi.php
+++ b/src/Auth0AuthApi.php
@@ -56,9 +56,7 @@ class Auth0AuthApi {
       $aditional_params['state'] = $state;
     }
 
-    $query_string = implode('&', array_map(function($key,$value){
-      return "$key=$value";
-    }, array_keys($aditional_params), $aditional_params));
+    $query_string = Psr7\build_query($aditional_params);
 
     return "https://{$this->domain}/authorize?$query_string";
   }

--- a/src/Auth0AuthApi.php
+++ b/src/Auth0AuthApi.php
@@ -5,6 +5,7 @@ use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\Exception\ApiException;
+use GuzzleHttp\Psr7;
 
 class Auth0AuthApi {
 
@@ -95,10 +96,10 @@ class Auth0AuthApi {
     if ($client_id !== null) {
       $params['client_id'] = $client_id;
     }
-    $query_string = implode('&', $params);
+
+    $query_string = Psr7\build_query($params);
 
     return "https://{$this->domain}/logout?$query_string";
-
   }
 
   public function authorize_with_accesstoken($access_token, $connection, $scope = 'openid', $aditional_params = []){

--- a/tests/AuthApiTest.php
+++ b/tests/AuthApiTest.php
@@ -14,11 +14,11 @@ class AuthApiTest extends ApiTests {
 
         $authorize_url = $api->get_authorize_link('code', 'http://lala.com');
 
-        $this->assertEquals("https://dummy.auth0.com/authorize?response_type=code&redirect_uri=http://lala.com&client_id=123456", $authorize_url);
+        $this->assertEquals("https://dummy.auth0.com/authorize?response_type=code&redirect_uri=http%3A%2F%2Flala.com&client_id=123456", $authorize_url);
 
         $authorize_url2 = $api->get_authorize_link('token', 'http://lala.com', 'facebook', 'dastate');
 
-        $this->assertEquals("https://dummy.auth0.com/authorize?response_type=token&redirect_uri=http://lala.com&client_id=123456&connection=facebook&state=dastate", $authorize_url2);
+        $this->assertEquals("https://dummy.auth0.com/authorize?response_type=token&redirect_uri=http%3A%2F%2Flala.com&client_id=123456&connection=facebook&state=dastate", $authorize_url2);
     }
 
     public function testAuthorizeWithRO() {

--- a/tests/AuthApiTest.php
+++ b/tests/AuthApiTest.php
@@ -71,4 +71,14 @@ class AuthApiTest extends ApiTests {
 
         $this->assertStringStartsWith("https://" . $env['DOMAIN'], $url);
     }
+
+    public function testLogoutLink() {
+        $env = $this->getEnv();
+
+        $api = new Auth0AuthApi($env['DOMAIN'], $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET']);
+
+        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?", $api->get_logout_link());
+        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?returnTo=http%3A%2F%2Fexample.com", $api->get_logout_link("http://example.com"));
+        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?returnTo=http%3A%2F%2Fexample.com&client_id=" . $env['GLOBAL_CLIENT_ID'], $api->get_logout_link("http://example.com", $env['GLOBAL_CLIENT_ID']));
+    }
 }


### PR DESCRIPTION
Hi there,

The querystring for the logout url was incorrectly generated, this is a fix for that with help of Guzzle's build_query() function;

before: `https://auth0.com/logout?http%3A%2F%2Flocalhost%3A8000%2F` 
after: `https://auth0.com/logout?returnTo=http%3A%2F%2Flocalhost%3A8000%2F` 

I've also added unit tests to prove the case.

Cheers,
Robin