### PR TITLE
Logout link depreciated

### DIFF
--- a/src/Auth0AuthApi.php
+++ b/src/Auth0AuthApi.php
@@ -97,7 +97,7 @@ class Auth0AuthApi {
 
     $query_string = Psr7\build_query($params);
 
-    return "https://{$this->domain}/logout?$query_string";
+    return "https://{$this->domain}/v2/logout?$query_string";
   }
 
   public function authorize_with_accesstoken($access_token, $connection, $scope = 'openid', $aditional_params = []){

--- a/tests/AuthApiTest.php
+++ b/tests/AuthApiTest.php
@@ -77,10 +77,10 @@ class AuthApiTest extends ApiTests {
 
         $api = new Auth0AuthApi($env['DOMAIN'], $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET']);
 
-        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?", $api->get_logout_link());
+        $this->assertSame("https://" . $env['DOMAIN'] . "/v2/logout?", $api->get_logout_link());
         
-        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?returnTo=http%3A%2F%2Fexample.com", $api->get_logout_link("http://example.com"));
+        $this->assertSame("https://" . $env['DOMAIN'] . "/v2/logout?returnTo=http%3A%2F%2Fexample.com", $api->get_logout_link("http://example.com"));
 
-        $this->assertSame("https://" . $env['DOMAIN'] . "/logout?returnTo=http%3A%2F%2Fexample.com&client_id=" . $env['GLOBAL_CLIENT_ID'], $api->get_logout_link("http://example.com", $env['GLOBAL_CLIENT_ID']));
+        $this->assertSame("https://" . $env['DOMAIN'] . "/v2/logout?returnTo=http%3A%2F%2Fexample.com&client_id=" . $env['GLOBAL_CLIENT_ID'], $api->get_logout_link("http://example.com", $env['GLOBAL_CLIENT_ID']));
     }
 }


### PR DESCRIPTION
From your own documentation (https://auth0.com/docs/api/authentication#!#get--logout), /logout is depreciated, replaced with /v2/logout