### PR TITLE
Fixed token validation

### DIFF
--- a/src/Auth0JWT.php
+++ b/src/Auth0JWT.php
@@ -41,7 +41,7 @@ class Auth0JWT {
         $body64 = $tks[1];
         $head = json_decode(JWT::urlsafeB64Decode($headb64));
 
-        if ( !($head instanceof stdClass) || ! isset($head->alg))
+        if ( !is_object($head) || ! isset($head->alg))
         {
             throw new InvalidTokenException("Invalid token");
         }


### PR DESCRIPTION
On PHP 5.6.24 / Debian Jessie testing

```
$head instanceof stdClass
```

fails, whereas

```
is_object($head)
```

succeeds.

Don't ask me why ...
