### PR TITLE
Replace file_get_contents by cURL

### DIFF
--- a/src/Auth0JWT.php
+++ b/src/Auth0JWT.php
@@ -17,13 +17,22 @@ class Auth0JWT {
 
     protected static function fetch_public_key($iss) {
         $secret = [];
-        $jwks = json_decode(file_get_contents("{$iss}.well-known/jwks.json"));
-        foreach ($jwks->keys as $key) {
-            $pem =  '-----BEGIN CERTIFICATE-----'.PHP_EOL
-                .chunk_split($key->x5c[0], 64, PHP_EOL)
-                .'-----END CERTIFICATE-----'.PHP_EOL;
-            $secret[$key->kid] = $pem;
-        }
+
+        $c = curl_init();
+        curl_setopt_array($c, array(
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_URL => "{$iss}.well-known/jwks.json"
+        ));
+        $jwks = json_decode(curl_exec($c));
+        curl_close($c);
+
+        if (!empty($jwks))
+            foreach ($jwks->keys as $key) {
+                $pem =  '-----BEGIN CERTIFICATE-----'.PHP_EOL
+                    .chunk_split($key->x5c[0], 64, PHP_EOL)
+                    .'-----END CERTIFICATE-----'.PHP_EOL;
+                $secret[$key->kid] = $pem;
+            }
         return $secret;
     }
 


### PR DESCRIPTION
It is a little bit silly to use *file_get_contents* for authentication/authorization purposes, since it is disabled on a lot of PHP installations for security reasons.

Another note: in the management console under *APIs > Quick Start > PHP* a trailing slash is missing for the authorized iss which will let getting keys fail.