### PR TITLE
Syntax highlighitng for php code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check our docs page to get a complete guide on how to install it in an existing 
 
 ### Oauth2 authentication
 
-```
+```php
 require __DIR__ . '/vendor/autoload.php';
 
 use Auth0\SDK\API\Authentication;
@@ -58,7 +58,7 @@ var_dump($profile);
 
 ### Calling the management API
 
-```
+```php
 require __DIR__ . '/vendor/autoload.php';
 
 use Auth0\SDK\API\Management;
@@ -75,7 +75,7 @@ var_dump($usersList);
 
 ### Calling the Authentication API
 
-```
+```php
 require __DIR__ . '/vendor/autoload.php';
 
 use Auth0\SDK\API\Authentication;
@@ -130,7 +130,7 @@ This package uses composer for mantianing dependencies. However, if you cannot u
 #### 3.x
 
 - SDK api changes, now the Auth0 API client is not build of static clases anymore. Usage example:
-```
+```php
 $token = "eyJhbGciO....eyJhdWQiOiI....1ZVDisdL...";
 $domain = "account.auth0.com";
 $guzzleOptions = [ ... ];

--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -330,11 +330,11 @@ class Oauth2Client {
     }
 
     public function getUserMetadata() {
-        return $this->user["user_metadata"];
+        return isset($this->user["user_metadata"]) ? $this->user["user_metadata"] : array();
     }
 
     public function getAppMetadata() {
-        return $this->user["app_metadata"];
+        return isset($this->user["app_metadata"]) ? $this->user["app_metadata"] : array();
     }
 
     public function setUser($user) {


### PR DESCRIPTION
I only added php to the correct codeblocks to make sure github uses the correct syntax highlighting.