### PR TITLE
Fix "Undefined index: client_secret" when using RS256

### DIFF
--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -63,7 +63,9 @@ class JWTVerifier {
         $this->suported_algs = $config['suported_algs'];
         $this->valid_audiences = $config['valid_audiences'];
         $this->authorized_iss = $config['authorized_iss'];
-        $this->client_secret = $config['client_secret'];
+        if (in_array('HS256', $config['suported_algs']) {
+            $this->client_secret = $config['client_secret'];
+        }
 
         $this->JWKFetcher = new JWKFetcher($cache, $guzzleOptions);
     }


### PR DESCRIPTION
Suggested Fix for "Notice:  Undefined index: client_secret in JWTVerifier.php on line 66"