### PR TITLE
Authentication API, support for signup/ch.pwd

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -307,4 +307,41 @@ class Authentication {
       ->withBody(json_encode($data))
       ->call();
   }
+
+  public function dbconnections_signup($email, $password, $connection) {
+
+    $data = [
+      'client_id' => $this->client_id,
+      'email' => $email,
+      'password' => $password,
+      'connection' => $connection,
+    ];
+
+    return $this->apiClient->post()
+      ->dbconnections()
+      ->signup()
+      ->withHeader(new ContentType('application/json'))
+      ->withBody(json_encode($data))
+      ->call();
+  }
+
+  public function dbconnections_change_password($email, $connection, $password = null) {
+
+    $data = [
+      'client_id' => $this->client_id,
+      'email' => $email,
+      'connection' => $connection,
+    ];
+
+    if ($password !== null) {
+      $data['password'] = $password;
+    }
+
+    return $this->apiClient->post()
+      ->dbconnections()
+      ->change_password()
+      ->withHeader(new ContentType('application/json'))
+      ->withBody(json_encode($data))
+      ->call();
+  }
 }

--- a/tests/AuthApiDBConnectionsTest.php
+++ b/tests/AuthApiDBConnectionsTest.php
@@ -12,8 +12,12 @@ use Auth0\SDK\API\Authentication;
 
 class AuthApiDBConnectionsTest extends ApiTests {
 
-    protected $email = 'unit.test@auth0.com';
-    protected $connection = 'unit-test';
+    protected $email;
+    protected $connection = 'Username-Password-Authentication';
+
+    protected function setUp() {
+        $this->email = 'test-dbconnections-user' . rand() . '@test.com';
+    }
 
     public function testSignup() {
         $env = $this->getEnv();

--- a/tests/AuthApiDBConnectionsTest.php
+++ b/tests/AuthApiDBConnectionsTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: remuslazar
+ * Date: 01.12.16
+ * Time: 10:16
+ */
+
+namespace Auth0\Tests;
+
+use Auth0\SDK\API\Authentication;
+
+class AuthApiDBConnectionsTest extends ApiTests {
+
+    protected $email = 'unit.test@auth0.com';
+    protected $connection = 'unit-test';
+
+    public function testSignup() {
+        $env = $this->getEnv();
+
+        $api = new Authentication($env['DOMAIN'], $env['APP_CLIENT_ID']);
+
+        $email = $this->email;
+        $password = '123-xxx-23A-bar';
+        $connection = $this->connection;
+
+        $response = $api->dbconnections_signup($email, $password, $connection);
+
+        $this->assertArrayHasKey('_id', $response);
+        $this->assertArrayHasKey('email_verified', $response);
+        $this->assertArrayHasKey('email', $response);
+        $this->assertEquals($email, $response['email']);
+    }
+
+    public function testChangePassword() {
+        $env = $this->getEnv();
+
+        $api = new Authentication($env['DOMAIN'], $env['APP_CLIENT_ID']);
+
+        $email = $this->email;
+        $connection = $this->connection;
+
+        $response = $api->dbconnections_change_password($email, $connection);
+
+        $this->assertNotEmpty($response);
+        $this->assertContains('email', $response);
+    }
+}


### PR DESCRIPTION
This PR implements both Authentication API endpoints [dbconnections/signup](https://auth0.com/docs/api/authentication#!#post--dbconnections-signup) and [dbconnections/change_password](https://auth0.com/docs/api/authentication#!#post--dbconnections-change_password).

An additional Unit-Test is also included but this should be reworked, see my comment below.

Resolves #121 