### PR TITLE
Roll firebase/php-jwt to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "guzzlehttp/guzzle": "^6.1",
     "ext-json": "*",
     "adoy/oauth2": "^1.3",
-    "firebase/php-jwt" : "^3.0"
+    "firebase/php-jwt" : "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.*",


### PR DESCRIPTION
"microsoft/windowsazure": "v0.5.0" requires firebase/php-jwt ^4.0, which clashes with auth0-php's dependency on firebase/php-jwt ^3.0. Is there a better way to manage potentially clashing versions?