### PR TITLE
Added missing oauth2 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "php": ">=5.5",
     "guzzlehttp/guzzle": "~6.0",
     "ext-json": "*",
-    "firebase/php-jwt" : "^4.0"
+    "firebase/php-jwt" : "^4.0",
+    "adoy/oauth2": "1.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.*",


### PR DESCRIPTION
Hiya,

the library depends on the Oauth2 library by Adoy, but there is no dependency in composer.json. I have added this dependency.