### PR TITLE
Fix for Uncaught Error: Class 'Auth0\SDK\API\Auth0Api' not found in O…

### DIFF
--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -7,6 +7,7 @@ use Auth0\SDK\Exception\ApiException;
 use Auth0\SDK\Store\EmptyStore;
 use Auth0\SDK\Store\SessionStore;
 use OAuth2\Client;
+use Auth0\SDK\API\Auth0Api;
 
 /**
  * This class provides access to Auth0 Platform.


### PR DESCRIPTION
…Auth2Client.php error

Tried loading class from wrong location, had to be Auth0\SDK\Auth0Api -> included use stmt at top as fix