### PR TITLE
Lazy loading in Management API, private properties, getter methods added.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ branches:
     - /^analysis-.*$/
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -23,7 +22,7 @@ matrix:
   include:
     - php: hhvm
       dist: trusty
-    - php: 5.5
+    - php: 5.6
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^5.5 || ^7.0",
+    "php": "^5.6 || ^7.0",
     "ext-json": "*",
     "firebase/php-jwt" : "^4.0",
     "psr/http-message": "^1.0",

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -11,6 +11,7 @@ use Auth0\SDK\API\Management\DeviceCredentials;
 use Auth0\SDK\API\Management\Emails;
 use Auth0\SDK\API\Management\Jobs;
 use Auth0\SDK\API\Management\Logs;
+use Auth0\SDK\API\Management\ResourceServers;
 use Auth0\SDK\API\Management\Rules;
 use Auth0\SDK\API\Management\Stats;
 use Auth0\SDK\API\Management\Tenants;
@@ -122,6 +123,14 @@ class Management
     public function rules()
     {
         return new Rules($this->httpClient);
+    }
+
+    /**
+     * @return ResourceServers
+     */
+    public function resourceServers()
+    {
+        return new ResourceServers($this->httpClient);
     }
 
     /**

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Auth0\SDK\API;
 
 use Auth0\SDK\API\Helpers\HttpClientBuilder;
@@ -10,143 +11,156 @@ use Auth0\SDK\API\Management\DeviceCredentials;
 use Auth0\SDK\API\Management\Emails;
 use Auth0\SDK\API\Management\Jobs;
 use Auth0\SDK\API\Management\Logs;
-use Auth0\SDK\API\Management\ResourceServers;
 use Auth0\SDK\API\Management\Rules;
 use Auth0\SDK\API\Management\Stats;
 use Auth0\SDK\API\Management\Tenants;
 use Auth0\SDK\API\Management\Tickets;
 use Auth0\SDK\API\Management\UserBlocks;
 use Auth0\SDK\API\Management\Users;
-
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\HttpClient;
 
-class Management {
+class Management
+{
+    /**
+     * @var string
+     */
+    private $token;
 
     /**
      * @var string
      */
-  private $token;
-
-    /**
-     * @var string
-     */
-  private $domain;
+    private $domain;
 
     /**
      * @var HttpMethodsClient
      */
-  private $httpClient;
+    private $httpClient;
 
     /**
-     * @var array
-     */
-  private $guzzleOptions;
-
-    /**
-     * @var Blacklists
-     */
-  public $blacklists;
-
-    /**
-     * @var Clients
-     */
-  public $clients;
-
-    /**
-     * @var ClientGrants
-     */
-  public $client_grants;
-
-    /**
-     * @var Connections
-     */
-  public $connections;
-
-    /**
-     * @var DeviceCredentials
-     */
-  public $deviceCredentials;
-
-    /**
-     * @var Emails
-     */
-  public $emails;
-
-    /**
-     * @var Jobs
-     */
-  public $jobs;
-
-    /**
-     * @var Logs
-     */
-  public $logs;
-
-    /**
-     * @var Rules
-     */
-  public $rules;
-
-    /**
-     * @var ResourceServers
-     */
-  public $resource_servers;
-
-    /**
-     * @var Stats
-     */
-  public $stats;
-
-    /**
-     * @var Tenants
-     */
-  public $tenants;
-
-    /**
-     * @var Tickets
-     */
-  public $tickets;
-
-    /**
-     * @var UserBlocks
-     */
-  public $userBlocks;
-
-    /**
-     * @var Users
-     */
-  public $users;
-
-    /**
-     * Management constructor.
-     *
-     * @param string $token
-     * @param string $domain
+     * @param string          $token
+     * @param string          $domain
      * @param HttpClient|null $client
      */
-  public function __construct($token, $domain, HttpClient $client = null) {
-    $this->token = $token;
-    $this->domain = $domain;
+    public function __construct($token, $domain, HttpClient $client = null)
+    {
+        $this->token = $token;
+        $this->domain = $domain;
 
-    $httpClientBuilder = new HttpClientBuilder($domain.'/api/v2/', $client);
-    $httpClientBuilder->addHeader('Authorization', 'Bearer '.$token);
-    $this->httpClient = $httpClientBuilder->buildHttpClient();
+        $httpClientBuilder = new HttpClientBuilder($domain.'/api/v2/', $client);
+        $httpClientBuilder->addHeader('Authorization', 'Bearer '.$token);
+        $this->httpClient = $httpClientBuilder->buildHttpClient();
+    }
 
-    $this->blacklists = new Blacklists($this->httpClient);
-    $this->clients = new Clients($this->httpClient);
-    $this->client_grants = new ClientGrants($this->httpClient);
-    $this->connections = new Connections($this->httpClient);
-    $this->deviceCredentials = new DeviceCredentials($this->httpClient);
-    $this->emails = new Emails($this->httpClient);
-    $this->jobs = new Jobs($this->httpClient);
-    $this->logs = new Logs($this->httpClient);
-    $this->rules = new Rules($this->httpClient);
-    $this->resource_servers = new ResourceServers($this->httpClient);
-    $this->stats = new Stats($this->httpClient);
-    $this->tenants = new Tenants($this->httpClient);
-    $this->tickets = new Tickets($this->httpClient);
-    $this->userBlocks = new UserBlocks($this->httpClient);
-    $this->users = new Users($this->httpClient);
-  }
+    /**
+     * @return Blacklists
+     */
+    public function blacklists()
+    {
+        return new Blacklists($this->httpClient);
+    }
+
+    /**
+     * @return Clients
+     */
+    public function clients()
+    {
+        return new Clients($this->httpClient);
+    }
+
+    /**
+     * @return ClientGrants
+     */
+    public function clientGrants()
+    {
+        return new ClientGrants($this->httpClient);
+    }
+
+    /**
+     * @return Connections
+     */
+    public function connections()
+    {
+        return new Connections($this->httpClient);
+    }
+
+    /**
+     * @return DeviceCredentials
+     */
+    public function deviceCredentials()
+    {
+        return new DeviceCredentials($this->httpClient);
+    }
+
+    /**
+     * @return Emails
+     */
+    public function emails()
+    {
+        return new Emails($this->httpClient);
+    }
+
+    /**
+     * @return Jobs
+     */
+    public function jobs()
+    {
+        return new Jobs($this->httpClient);
+    }
+
+    /**
+     * @return Logs
+     */
+    public function logs()
+    {
+        return new Logs($this->httpClient);
+    }
+
+    /**
+     * @return Rules
+     */
+    public function rules()
+    {
+        return new Rules($this->httpClient);
+    }
+
+    /**
+     * @return Stats
+     */
+    public function stats()
+    {
+        return new Stats($this->httpClient);
+    }
+
+    /**
+     * @return Tenants
+     */
+    public function tenants()
+    {
+        return new Tenants($this->httpClient);
+    }
+
+    /**
+     * @return Tickets
+     */
+    public function tickets()
+    {
+        return new Tickets($this->httpClient);
+    }
+
+    /**
+     * @return UserBlocks
+     */
+    public function userBlocks()
+    {
+        return new UserBlocks($this->httpClient);
+    }
+
+    /**
+     * @return Users
+     */
+    public function Users()
+    {
+        return new users($this->httpClient);
+    }
 }

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -21,9 +21,9 @@ class BlacklistsTest extends ApiTests {
         $aud = $env["GLOBAL_CLIENT_ID"];
         $jti = 'somerandomJTI' . rand();
 
-        $api->blacklists->blacklist($aud, $jti);
+        $api->blacklists()->blacklist($aud, $jti);
 
-        $all = $api->blacklists->getAll($aud);
+        $all = $api->blacklists()->getAll($aud);
 
         $found = false;
         foreach ($all as $value) {

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -22,7 +22,7 @@ class ClientsTest extends BasicCrudTest {
 
         $api = new Management($token, $env['DOMAIN']);
 
-        return $api->clients;
+        return $api->clients();
     }
 
     protected function getCreateBody() {

--- a/tests/API/Management/ConnectionsTest.php
+++ b/tests/API/Management/ConnectionsTest.php
@@ -18,7 +18,7 @@ class ConnectionsTest extends BasicCrudTest {
 
         $api = new Management($token, $env['DOMAIN']);
 
-        return $api->connections;
+        return $api->connections();
     }
 
     protected function getCreateBody() {

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -18,7 +18,7 @@ class RulesTest extends BasicCrudTest {
 
         $api = new Management($token, $env['DOMAIN']);
 
-        return $api->rules;
+        return $api->rules();
     }
 
     protected function getCreateBody() {

--- a/tests/API/Management/UsersTest.php
+++ b/tests/API/Management/UsersTest.php
@@ -30,7 +30,7 @@ class UsersTest extends BasicCrudTest {
 
         $api = new Management($token, $this->domain);
 
-        return $api->users;
+        return $api->users();
     }
 
     protected function getAll($client, $entity)


### PR DESCRIPTION
We should avoid initiation loads of objects we do not use. 
Best practice also says that never never never use public properties. This PR solves both issues.

We move closer to https://github.com/KnpLabs/php-github-api and https://github.com/FriendsOfApi/boilerplate

# BC breaks

* Removed the following properties of `Management` and replaced them with function calls: `$blacklists`, `$clients`, `$client_grants`, `$connections`, `$deviceCredentials`, `$emails`, `$jobs`, `$logs`, `$rules`, `$resource_servers`, `$stats`, `$tenants`, `$tickets`, `$userBlocks`, `$users`, 