### PR TITLE
Code cleanup and method docs

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -267,7 +267,7 @@ final class Authentication
      *
      * @return array
      */
-    public function oauthToken($grantType, array $options)
+    private function oauthToken($grantType, array $options)
     {
         if (!isset($options['client_id'])) {
             $options['client_id'] = $this->clientId;

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -21,6 +21,11 @@ use Auth0\SDK\API\Management\Users;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\HttpClient;
 
+/**
+ * Class to communicate with Auth0 Management API
+ *
+ * @link https://auth0.com/docs/api/management/v2
+ */
 final class Management
 {
     /**

--- a/tests/API/Management/AuthApiDBConnectionsTest.php
+++ b/tests/API/Management/AuthApiDBConnectionsTest.php
@@ -25,7 +25,7 @@ class AuthApiDBConnectionsTest extends ApiTests
         $password = '123-xxx-23A-bar';
         $connection = $this->connection;
 
-        $response = $api->dbconnections_signup($email, $password, $connection);
+        $response = $api->dbconnectionsSignup($email, $password, $connection);
 
         $this->assertArrayHasKey('_id', $response);
         $this->assertArrayHasKey('email_verified', $response);
@@ -42,7 +42,7 @@ class AuthApiDBConnectionsTest extends ApiTests
         $email = $this->email;
         $connection = $this->connection;
 
-        $response = $api->dbconnections_change_password($email, $connection);
+        $response = $api->dbconnectionsChangePassword($email, $connection);
 
         $this->assertNotEmpty($response);
         $this->assertContains('email', $response);

--- a/tests/API/Management/AuthApiTest.php
+++ b/tests/API/Management/AuthApiTest.php
@@ -14,11 +14,11 @@ class AuthApiTest extends ApiTests
 
         $api = new Authentication($domain, $client_id);
 
-        $authorize_url = $api->get_authorize_link('code', 'http://lala.com');
+        $authorize_url = $api->getAuthorizeLink('code', 'http://lala.com');
 
         $this->assertEquals('https://dummy.auth0.com/authorize?response_type=code&redirect_uri=http%3A%2F%2Flala.com&client_id=123456', $authorize_url);
 
-        $authorize_url2 = $api->get_authorize_link('token', 'http://lala.com', 'facebook', 'dastate');
+        $authorize_url2 = $api->getAuthorizeLink('token', 'http://lala.com', 'facebook', 'dastate');
 
         $this->assertEquals('https://dummy.auth0.com/authorize?response_type=token&redirect_uri=http%3A%2F%2Flala.com&client_id=123456&connection=facebook&state=dastate', $authorize_url2);
     }
@@ -29,7 +29,7 @@ class AuthApiTest extends ApiTests
 
         $api = new Authentication($env['DOMAIN'], $env['NIC_ID'], $env['NIC_SECRET']);
 
-        $token = $api->client_credentials([
+        $token = $api->clientCredentials([
           'audience' => 'tests',
         ]);
 
@@ -44,7 +44,7 @@ class AuthApiTest extends ApiTests
 
         $api = new Authentication($env['DOMAIN'], $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET']);
 
-        $token = $api->client_credentials([]);
+        $token = $api->clientCredentials([]);
 
         $url = $api->impersonate($token['access_token'], 'facebook|1434903327', 'oauth2', 'auth0|56b110b8d9d327e705e1d2da', 'ycynBrUeQUnFqNacG3GAsaTyDhG4h0qT', ['response_type' => 'code']);
 
@@ -57,10 +57,10 @@ class AuthApiTest extends ApiTests
 
         $api = new Authentication($env['DOMAIN'], $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET']);
 
-        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?', $api->get_logout_link());
+        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?', $api->getLogoutLink());
 
-        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?returnTo=http%3A%2F%2Fexample.com', $api->get_logout_link('http://example.com'));
+        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?returnTo=http%3A%2F%2Fexample.com', $api->getLogoutLink('http://example.com'));
 
-        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?returnTo=http%3A%2F%2Fexample.com&client_id='.$env['GLOBAL_CLIENT_ID'], $api->get_logout_link('http://example.com', $env['GLOBAL_CLIENT_ID']));
+        $this->assertSame('https://'.$env['DOMAIN'].'/v2/logout?returnTo=http%3A%2F%2Fexample.com&client_id='.$env['GLOBAL_CLIENT_ID'], $api->getLogoutLink('http://example.com', $env['GLOBAL_CLIENT_ID']));
     }
 }


### PR DESCRIPTION
This PR cleans up the Authentication API. It adds docs and make sure the metod parameters make sense. It make sure all methods are camelCase

### Breaking changes

#### These functions has changed name: 
get_authorize_link -> getAuthorizeLink
get_samlp_link -> getSamlpLink
get_samlp_metadata_link -> getSamlpMetadataLink
get_wsfed_link -> getWsfedLink
get_wsfed_metadata_link -> getWsfedMetadataLink
get_logout_link -> getLogoutLink
authorize_with_accesstoken -> authorizeWithAccessToken
email_passwordless_start -> emailPasswordlessStart
sms_passwordless_start -> smsPasswordlessStart
userinfo -> userInfo
oauth_token -> oauthToken (now also private)
code_exchange -> codeExchange
login_with_default_directory -> loginWithDefaultDirectory
client_credentials -> clientCredentials
dbconnections_signup -> dbconnectionsSignup
dbconnections_change_password -> dbconnectionsChangePassword

#### These functions has changes signature: 
* New signature for logoauthTokenn function: `oauthToken($grantType, array $options)`
* New signature for login function: `login($username, $password, $realm, array $options = [])`
* New signature for loginWithDefaultDirectory: `loginWithDefaultDirectory($username, $password, array $options = [])`
