### PR TITLE
Promote scope, audience parameter, remove options from login 

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -309,19 +309,26 @@ final class Authentication
      * @param string $username
      * @param string $password
      * @param string $realm
-     * @param array $options {
-     *
-     *      @var string $scope    Optional
-     *      @var string $audience Optional.
-     * }
+     * @param string $scope
+     * @param string $audience
      *
      * @return array
      */
-    public function login($username, $password, $realm, array $options = [])
+    public function login($username, $password, $realm, $scope = null, $audience = null)
     {
+        $options = [];
+
         $options['username'] = $username;
         $options['password'] = $password;
         $options['realm'] = $realm;
+
+        if (!empty($scope)) {
+            $options['scope'] = $scope;
+        }
+
+        if (!empty($audience)) {
+            $options['audience'] = $audience;
+        }
 
         return $this->oauthToken('http://auth0.com/oauth/grant-type/password-realm', $options);
     }
@@ -333,18 +340,25 @@ final class Authentication
      *
      * @param string $username
      * @param string $password
-     * @param array $options {
-     *
-     *      @var string $scope    Optional.
-     *      @var string $audience Optional.
-     *}
+     * @param string $scope
+     * @param string $audience
      *
      * @return array
      */
-    public function loginWithDefaultDirectory($username, $password, array $options = [])
+    public function loginWithDefaultDirectory($username, $password, $scope = null, $audience = null)
     {
+        $options = [];
+
         $options['username'] = $username;
         $options['password'] = $password;
+
+        if (!empty($scope)) {
+            $options['scope'] = $scope;
+        }
+
+        if (!empty($audience)) {
+            $options['audience'] = $audience;
+        }
 
         return $this->oauthToken('password', $options);
     }

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -3,8 +3,15 @@
 namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Helpers\TokenGenerator;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpClient;
 use josegonzalez\Dotenv\Loader;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
 class ApiTests extends \PHPUnit_Framework_TestCase
 {
     protected function getEnv()
@@ -18,14 +25,14 @@ class ApiTests extends \PHPUnit_Framework_TestCase
         }
 
         return [
-      'GLOBAL_CLIENT_ID'     => getenv('GLOBAL_CLIENT_ID'),
-      'GLOBAL_CLIENT_SECRET' => getenv('GLOBAL_CLIENT_SECRET'),
-      'APP_CLIENT_ID'        => getenv('APP_CLIENT_ID'),
-      'APP_CLIENT_SECRET'    => getenv('APP_CLIENT_SECRET'),
-      'NIC_ID'               => getenv('NIC_ID'),
-      'NIC_SECRET'           => getenv('NIC_SECRET'),
-      'DOMAIN'               => getenv('DOMAIN'),
-    ];
+          'GLOBAL_CLIENT_ID' => getenv('GLOBAL_CLIENT_ID'),
+          'GLOBAL_CLIENT_SECRET' => getenv('GLOBAL_CLIENT_SECRET'),
+          'APP_CLIENT_ID' => getenv('APP_CLIENT_ID'),
+          'APP_CLIENT_SECRET' => getenv('APP_CLIENT_SECRET'),
+          'NIC_ID' => getenv('NIC_ID'),
+          'NIC_SECRET' => getenv('NIC_SECRET'),
+          'DOMAIN' => getenv('DOMAIN'),
+        ];
     }
 
     protected function getToken($env, $scopes)
@@ -33,5 +40,43 @@ class ApiTests extends \PHPUnit_Framework_TestCase
         $generator = new TokenGenerator(['client_id' => $env['GLOBAL_CLIENT_ID'], 'client_secret' => $env['GLOBAL_CLIENT_SECRET']]);
 
         return $generator->generate($scopes);
+    }
+
+    /**
+     * @return Response
+     */
+    protected function createResponse($body = null, $httpStatus = 200, $headers = [])
+    {
+        if (!isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return new Response($httpStatus, $headers, $body);
+    }
+
+    /**
+     * Get a mocked HTTP client where you may do tests on the request.
+     *
+     * @param string|null $body
+     * @param int         $statusCode
+     *
+     * @return HttpClient
+     */
+    protected function getMockedHttpClientCallback(callable $requestCallback)
+    {
+        $client = $this->getMockBuilder(HttpClient::class)->getMock();
+        $client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use ($requestCallback) {
+                $response = $requestCallback($request);
+                if (!$response instanceof ResponseInterface) {
+                    $response = new Response(200, [], (string) $response);
+                }
+
+                return $response;
+            });
+
+        return $client;
     }
 }

--- a/tests/API/AuthenticationTest.php
+++ b/tests/API/AuthenticationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Auth0\Tests\API;
+
+use Auth0\SDK\API\Authentication;
+use function GuzzleHttp\Psr7\parse_query;
+use Http\Client\Common\HttpMethodsClient;
+use Http\Client\HttpClient;
+use Http\Discovery\MessageFactoryDiscovery;
+use Psr\Http\Message\RequestInterface;
+
+class AuthenticationTest extends ApiTests
+{
+
+    /**
+     * @param HttpClient $httpClient
+     *
+     * @return Authentication
+     */
+    private function getAuthenticationApi(HttpClient $httpClient)
+    {
+        return new Authentication(
+            'token', 'cid', 'secret', 'audience', 'scope', new HttpMethodsClient($httpClient, MessageFactoryDiscovery::find())
+        );
+    }
+
+    public function testLogin()
+    {
+        $httpClient = $this->getMockedHttpClientCallback(function(RequestInterface $request) {
+            $body = json_decode($request->getBody()->__toString(), true);
+            $this->assertEquals('user', $body['username']);
+            $this->assertEquals('pass', $body['password']);
+            $this->assertEquals('realm', $body['realm']);
+            $this->assertEquals('scope', $body['scope']);
+            $this->assertEquals('audience', $body['audience']);
+            $this->assertEquals('cid', $body['client_id']);
+            $this->assertEquals('secret', $body['client_secret']);
+            $this->assertEquals('http://auth0.com/oauth/grant-type/password-realm', $body['grant_type']);
+
+        });
+        $api = $this->getAuthenticationApi($httpClient);
+        $api->login('user', 'pass', 'realm', 'scope', 'audience');
+    }
+
+    public function testLoginWithDefaultDirectory()
+    {
+        $httpClient = $this->getMockedHttpClientCallback(function(RequestInterface $request) {
+            $body = json_decode($request->getBody()->__toString(), true);
+            $this->assertEquals('user', $body['username']);
+            $this->assertEquals('pass', $body['password']);
+            $this->assertEquals('scope', $body['scope']);
+            $this->assertEquals('audience', $body['audience']);
+            $this->assertEquals('cid', $body['client_id']);
+            $this->assertEquals('secret', $body['client_secret']);
+            $this->assertEquals('password', $body['grant_type']);
+
+        });
+        $api = $this->getAuthenticationApi($httpClient);
+        $api->loginWithDefaultDirectory('user', 'pass', 'scope', 'audience');
+    }
+}

--- a/tests/API/Management/BaseManagementTest.php
+++ b/tests/API/Management/BaseManagementTest.php
@@ -4,7 +4,6 @@ namespace Auth0\Tests\API\Management;
 
 use Auth0\SDK\API\Management;
 use Auth0\Tests\API\ApiTests;
-use GuzzleHttp\Psr7\Response;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -19,22 +18,10 @@ abstract class BaseManagementTest extends ApiTests
      *
      * @return Management
      */
-    protected function getManagementApi($httpClient)
+    protected function getManagementApi(HttpClient $httpClient)
     {
         return new Management(
             'token', 'domain.com', new HttpMethodsClient($httpClient, MessageFactoryDiscovery::find())
         );
-    }
-
-    /**
-     * @return Response
-     */
-    protected function createResponse($body = null, $httpStatus = 200, $headers = [])
-    {
-        if (!isset($headers['Content-Type'])) {
-            $headers['Content-Type'] = 'application/json';
-        }
-
-        return new Response($httpStatus, $headers, $body);
     }
 }


### PR DESCRIPTION
As mentioned in https://github.com/auth0/auth0-PHP/pull/183#discussion_r127591260

#### BC breaking changes

* `Authentication::login` has a new method signature: `login($username, $password, $realm, $scope = null, $audience = null)`
* `Authentication::loginWithDefaultDirectory` has a new method signature: `loginWithDefaultDirectory($username, $password, $scope = null, $audience = null)`