### PR TITLE
Implement example hydrators

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -6,6 +6,8 @@ use Auth0\SDK\API\Helpers\HttpClientBuilder;
 use Auth0\SDK\API\Helpers\ResponseMediator;
 use Auth0\SDK\Exception\ApiException;
 use Auth0\SDK\Exception\InvalidArgumentException;
+use Auth0\SDK\Hydrator\ArrayHydrator;
+use Auth0\SDK\Hydrator\Hydrator;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\HttpClient;
 
@@ -49,15 +51,23 @@ final class Authentication extends BaseApi
      * @param string|null     $scope
      * @param HttpClient|null $client
      */
-    public function __construct($domain, $clientId = null, $clientSecret = null, $audience = null, $scope = null, HttpClient $client = null)
-    {
+    public function __construct(
+        $domain,
+        $clientId = null,
+        $clientSecret = null,
+        $audience = null,
+        $scope = null,
+        HttpClient $client = null,
+        Hydrator $hydrator = null
+    ) {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
         $this->domain = $domain;
         $this->audience = $audience;
         $this->scope = $scope;
+        $this->hydrator = $hydrator ?: new ArrayHydrator();
 
-        parent::__construct((new HttpClientBuilder($domain, $client))->buildHttpClient());
+        parent::__construct((new HttpClientBuilder($domain, $client))->buildHttpClient(), $hydrator);
     }
 
     /**

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -65,7 +65,7 @@ final class Authentication extends BaseApi
         $this->domain = $domain;
         $this->audience = $audience;
         $this->scope = $scope;
-        $this->hydrator = $hydrator ?: new ArrayHydrator();
+        $hydrator = $hydrator ?: new ArrayHydrator();
 
         parent::__construct((new HttpClientBuilder($domain, $client))->buildHttpClient(), $hydrator);
     }

--- a/src/API/BaseApi.php
+++ b/src/API/BaseApi.php
@@ -9,6 +9,8 @@ use Auth0\SDK\Exception\BadRequestException;
 use Auth0\SDK\Exception\TooManyRequestsException;
 use Auth0\SDK\Exception\UnauthorizedException;
 use Auth0\SDK\Exception\UnknownApiException;
+use Auth0\SDK\Hydrator\Hydrator;
+use Auth0\SDK\Hydrator\NoopHydrator;
 use Http\Client\Common\HttpMethodsClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -24,11 +26,21 @@ abstract class BaseApi
     protected $httpClient;
 
     /**
-     * @param HttpMethodsClient $apiClient
+     * @var Hydrator|null
      */
-    public function __construct(HttpMethodsClient $apiClient)
+    protected $hydrator;
+
+    /**
+     * @param HttpMethodsClient $apiClient
+     * @param Hydrator $hydrator
+     */
+    public function __construct(HttpMethodsClient $apiClient, Hydrator $hydrator)
     {
         $this->httpClient = $apiClient;
+
+        if (!$hydrator instanceof NoopHydrator) {
+            $this->hydrator = $hydrator;
+        }
     }
 
     /**

--- a/src/API/Helpers/ResponseMediator.php
+++ b/src/API/Helpers/ResponseMediator.php
@@ -6,6 +6,8 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @deprecated Will be removed prior release of 6.0.0. Use the Hydrators instead.
  */
 final class ResponseMediator
 {

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -18,6 +18,8 @@ use Auth0\SDK\API\Management\Tenants;
 use Auth0\SDK\API\Management\Tickets;
 use Auth0\SDK\API\Management\UserBlocks;
 use Auth0\SDK\API\Management\Users;
+use Auth0\SDK\Hydrator\ArrayHydrator;
+use Auth0\SDK\Hydrator\Hydrator;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\HttpClient;
 
@@ -44,11 +46,17 @@ final class Management
     private $httpClient;
 
     /**
+     * @var Hydrator
+     */
+    private $hydrator;
+
+    /**
      * @param string          $token
      * @param string          $domain
      * @param HttpClient|null $client
+     * @param Hydrator|null   $hydrator
      */
-    public function __construct($token, $domain, HttpClient $client = null)
+    public function __construct($token, $domain, HttpClient $client = null, Hydrator $hydrator = null)
     {
         $this->token = $token;
         $this->domain = $domain;
@@ -56,6 +64,7 @@ final class Management
         $httpClientBuilder = new HttpClientBuilder($domain.'/api/v2/', $client);
         $httpClientBuilder->addHeader('Authorization', 'Bearer '.$token);
         $this->httpClient = $httpClientBuilder->buildHttpClient();
+        $this->hydrator = $hydrator ?: new ArrayHydrator();
     }
 
     /**
@@ -63,7 +72,7 @@ final class Management
      */
     public function blacklists()
     {
-        return new Blacklists($this->httpClient);
+        return new Blacklists($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -71,7 +80,7 @@ final class Management
      */
     public function clients()
     {
-        return new Clients($this->httpClient);
+        return new Clients($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -79,7 +88,7 @@ final class Management
      */
     public function clientGrants()
     {
-        return new ClientGrants($this->httpClient);
+        return new ClientGrants($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -87,7 +96,7 @@ final class Management
      */
     public function connections()
     {
-        return new Connections($this->httpClient);
+        return new Connections($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -95,7 +104,7 @@ final class Management
      */
     public function deviceCredentials()
     {
-        return new DeviceCredentials($this->httpClient);
+        return new DeviceCredentials($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -103,7 +112,7 @@ final class Management
      */
     public function emails()
     {
-        return new Emails($this->httpClient);
+        return new Emails($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -111,7 +120,7 @@ final class Management
      */
     public function jobs()
     {
-        return new Jobs($this->httpClient);
+        return new Jobs($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -119,7 +128,7 @@ final class Management
      */
     public function logs()
     {
-        return new Logs($this->httpClient);
+        return new Logs($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -127,7 +136,7 @@ final class Management
      */
     public function rules()
     {
-        return new Rules($this->httpClient);
+        return new Rules($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -135,7 +144,7 @@ final class Management
      */
     public function resourceServers()
     {
-        return new ResourceServers($this->httpClient);
+        return new ResourceServers($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -143,7 +152,7 @@ final class Management
      */
     public function stats()
     {
-        return new Stats($this->httpClient);
+        return new Stats($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -151,7 +160,7 @@ final class Management
      */
     public function tenants()
     {
-        return new Tenants($this->httpClient);
+        return new Tenants($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -159,7 +168,7 @@ final class Management
      */
     public function tickets()
     {
-        return new Tickets($this->httpClient);
+        return new Tickets($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -167,7 +176,7 @@ final class Management
      */
     public function userBlocks()
     {
-        return new UserBlocks($this->httpClient);
+        return new UserBlocks($this->httpClient, $this->hydrator);
     }
 
     /**
@@ -175,6 +184,6 @@ final class Management
      */
     public function users()
     {
-        return new Users($this->httpClient);
+        return new Users($this->httpClient, $this->hydrator);
     }
 }

--- a/src/API/Management/Blacklists.php
+++ b/src/API/Management/Blacklists.php
@@ -3,8 +3,9 @@
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\API\BaseApi;
-use Auth0\SDK\API\Helpers\ResponseMediator;
 use Auth0\SDK\Exception\ApiException;
+use Auth0\SDK\Model\EmptyResponse;
+use Auth0\SDK\Model\Management\Blacklist\BlacklistIndex;
 
 final class Blacklists extends BaseApi
 {
@@ -12,7 +13,7 @@ final class Blacklists extends BaseApi
      * @link https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens
      * @param string $aud
      *
-     * @return array
+     * @return BlacklistIndex
      *
      * @throws ApiException On invalid responses
      */
@@ -20,8 +21,12 @@ final class Blacklists extends BaseApi
     {
         $response = $this->httpClient->get('/blacklists/tokens?'.http_build_query(['aud' => $aud]));
 
+        if (!$this->hydrator) {
+            return $response;
+        }
+
         if (200 === $response->getStatusCode()) {
-            return ResponseMediator::getContent($response);
+            return $this->hydrator->hydrate($response, BlacklistIndex::class);
         }
 
         $this->handleExceptions($response);
@@ -33,7 +38,7 @@ final class Blacklists extends BaseApi
      * @param string $aud
      * @param string $jti
      *
-     * @return array
+     * @return EmptyResponse
      *
      * @throws ApiException On invalid responses
      */
@@ -44,8 +49,12 @@ final class Blacklists extends BaseApi
             'jti' => $jti,
         ]));
 
+        if (!$this->hydrator) {
+            return $response;
+        }
+
         if (204 === $response->getStatusCode()) {
-            return ResponseMediator::getContent($response);
+            return $this->hydrator->hydrate($response, EmptyResponse::class);
         }
 
         $this->handleExceptions($response);

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -5,6 +5,7 @@ namespace Auth0\SDK\API\Management;
 use Auth0\SDK\API\BaseApi;
 use Auth0\SDK\API\Helpers\ResponseMediator;
 use Auth0\SDK\Exception\ApiException;
+use Auth0\SDK\Model\Management\Users\User;
 
 final class Users extends BaseApi
 {
@@ -21,8 +22,12 @@ final class Users extends BaseApi
     {
         $response = $this->httpClient->get(sprintf('/users/%s', $userId));
 
+        if (!$this->hydrator) {
+            return $response;
+        }
+
         if (200 === $response->getStatusCode()) {
-            return ResponseMediator::getContent($response);
+            return $this->hydrator->hydrate($response, User::class);
         }
 
         $this->handleExceptions($response);

--- a/src/Exception/HydrationException.php
+++ b/src/Exception/HydrationException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Auth0\SDK\Exception;
+
+use Auth0\SDK\Exception;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class HydrationException extends \RuntimeException implements Exception
+{
+}

--- a/src/Hydrator/ArrayHydrator.php
+++ b/src/Hydrator/ArrayHydrator.php
@@ -18,7 +18,7 @@ final class ArrayHydrator implements Hydrator
      *
      * @return array
      */
-    public function hydrate(ResponseInterface $response, string $class): array
+    public function hydrate(ResponseInterface $response, $class)
     {
         $body = $response->getBody()->__toString();
         if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {

--- a/src/Hydrator/ArrayHydrator.php
+++ b/src/Hydrator/ArrayHydrator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Auth0\SDK\Hydrator;
+
+use Auth0\SDK\Exception\HydrationException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Hydrate an HTTP response to array.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class ArrayHydrator implements Hydrator
+{
+    /**
+     * @param ResponseInterface $response
+     * @param string            $class
+     *
+     * @return array
+     */
+    public function hydrate(ResponseInterface $response, string $class): array
+    {
+        $body = $response->getBody()->__toString();
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
+            throw new HydrationException('The ArrayHydrator cannot hydrate response with Content-Type:'.$response->getHeaderLine('Content-Type'));
+        }
+
+        $content = json_decode($body, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new HydrationException(sprintf('Error (%d) when trying to json_decode response', json_last_error()));
+        }
+
+        return $content;
+    }
+}

--- a/src/Hydrator/Hydrator.php
+++ b/src/Hydrator/Hydrator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Auth0\SDK\Hydrator;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Hydrate a PSR-7 response to something else.
+ */
+interface Hydrator
+{
+    /**
+     * @param ResponseInterface $response
+     * @param string            $class
+     *
+     * @return mixed
+     */
+    public function hydrate(ResponseInterface $response, string $class);
+}

--- a/src/Hydrator/Hydrator.php
+++ b/src/Hydrator/Hydrator.php
@@ -15,5 +15,5 @@ interface Hydrator
      *
      * @return mixed
      */
-    public function hydrate(ResponseInterface $response, string $class);
+    public function hydrate(ResponseInterface $response, $class);
 }

--- a/src/Hydrator/ModelHydrator.php
+++ b/src/Hydrator/ModelHydrator.php
@@ -19,7 +19,7 @@ final class ModelHydrator implements Hydrator
      *
      * @return mixed
      */
-    public function hydrate(ResponseInterface $response, string $class)
+    public function hydrate(ResponseInterface $response, $class)
     {
         $body = $response->getBody()->__toString();
         if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {

--- a/src/Hydrator/ModelHydrator.php
+++ b/src/Hydrator/ModelHydrator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Auth0\SDK\Hydrator;
+
+use Auth0\SDK\Exception\HydrationException;
+use Auth0\SDK\Model\CreatableFromArray;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Hydrate an HTTP response to domain object.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class ModelHydrator implements Hydrator
+{
+    /**
+     * @param ResponseInterface $response
+     * @param string            $class
+     *
+     * @return mixed
+     */
+    public function hydrate(ResponseInterface $response, string $class)
+    {
+        $body = $response->getBody()->__toString();
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
+            throw new HydrationException('The ModelHydrator cannot hydrate response with Content-Type:'.$response->getHeaderLine('Content-Type'));
+        }
+
+        $data = json_decode($body, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new HydrationException(sprintf('Error (%d) when trying to json_decode response', json_last_error()));
+        }
+
+        if (is_subclass_of($class, CreatableFromArray::class)) {
+            $object = call_user_func($class.'::createFromArray', $data);
+        } else {
+            $object = new $class($data);
+        }
+
+        return $object;
+    }
+}

--- a/src/Hydrator/NoopHydrator.php
+++ b/src/Hydrator/NoopHydrator.php
@@ -17,7 +17,7 @@ final class NoopHydrator implements Hydrator
      *
      * @throws \LogicException
      */
-    public function hydrate(ResponseInterface $response, string $class)
+    public function hydrate(ResponseInterface $response, $class)
     {
         throw new \LogicException('The NoopHydrator should never be called');
     }

--- a/src/Hydrator/NoopHydrator.php
+++ b/src/Hydrator/NoopHydrator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Auth0\SDK\Hydrator;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Do not hydrate to any object at all.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class NoopHydrator implements Hydrator
+{
+    /**
+     * @param ResponseInterface $response
+     * @param string            $class
+     *
+     * @throws \LogicException
+     */
+    public function hydrate(ResponseInterface $response, string $class)
+    {
+        throw new \LogicException('The NoopHydrator should never be called');
+    }
+}

--- a/src/Model/CreatableFromArray.php
+++ b/src/Model/CreatableFromArray.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Auth0\SDK\Model;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface CreatableFromArray
+{
+    /**
+     * Create an API response object from the HTTP response from the API server.
+     *
+     * @param array $data
+     *
+     * @return self
+     */
+    public static function createFromArray(array $data);
+}

--- a/src/Model/EmptyResponse.php
+++ b/src/Model/EmptyResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Auth0\SDK\Model;
+
+/**
+ * This class represent a 204 HTTP response.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class EmptyResponse implements CreatableFromArray
+{
+    private function __construct()
+    {
+    }
+
+    public static function createFromArray(array $data)
+    {
+    }
+}

--- a/src/Model/Management/Blacklist/BlacklistIndex.php
+++ b/src/Model/Management/Blacklist/BlacklistIndex.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Auth0\SDK\Model\Management\Blacklist;
+
+use Auth0\SDK\Model\CreatableFromArray;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class BlacklistIndex implements CreatableFromArray
+{
+    /**
+     * @var array
+     */
+    private $blacklists;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function getBlacklists()
+    {
+        return $this->blacklists;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return BlacklistIndex
+     */
+    public static function createFromArray(array $data)
+    {
+        $model = new self();
+
+        // TODO verify the correctness
+        $model->blacklists = $data;
+
+        return $model;
+    }
+}

--- a/src/Model/Management/Users/User.php
+++ b/src/Model/Management/Users/User.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Auth0\SDK\Model\Management\Users;
+
+use Auth0\SDK\Model\CreatableFromArray;
+
+class User implements CreatableFromArray
+{
+    /**
+     * @var string
+     */
+    private $email;
+
+    /**
+     * @var bool
+     */
+    private $emailVerified;
+
+    /**
+     * @var string
+     */
+    private $username;
+
+    // ...
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmailVerified()
+    {
+        return $this->emailVerified;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    // ...
+
+    /**
+     * @param array $data
+     *
+     * @return User
+     */
+    public static function createFromArray(array $data)
+    {
+        $model = new self();
+        $model->email = $data['email'];
+        $model->emailVerified = $data['email_verified'];
+        $model->username = $data['username'];
+
+        // ...
+
+        return $model;
+    }
+}


### PR DESCRIPTION
This is a POC how hydrators should be implemented. 

Please give some feedback here. Since we [discussed who/what should handle exceptions](https://github.com/auth0/auth0-PHP/pull/193#discussion_r130418766) I've been thinking about this. *Maybe* exceptions should be handled in the hydrator? It will make sense since different hydrators will throw/not throw exceptions. 

Currently we have: 

```php
public function getAll($aud)
    {
        $response = $this->httpClient->get('/blacklists/tokens?'.http_build_query(['aud' => $aud]));

        if (!$this->hydrator) {
            return $response;
        }

        if (200 === $response->getStatusCode()) {
            return $this->hydrator->hydrate($response, BlacklistIndex::class);
        }

        // custom exceptions for this endpoint
        // (none at this endpoint)

        // Generic exceptions
        $this->handleExceptions($response);
    }
```

If hydrators handle exceptions, we do not have to [give the NoopHydrator special treatment](https://github.com/auth0/auth0-PHP/pull/203/files#diff-69658bb0b0c88adde62c5bedcaab3504R41) and we could write the same code like: 

```php
public function getAll($aud)
    {
        $response = $this->httpClient->get('/blacklists/tokens?'.http_build_query(['aud' => $aud]));

        return $this->hydrator->hydrate($response, BlacklistIndex::class);
    }
```

We cannot handle custom exceptions for an endpoint though.. 

Maybe @sagikazarmark have some ideas? We discussed this a while ago, but making this PR like this does not "feel" perfect. 
