### PR TITLE
Fixes build

### DIFF
--- a/tests/API/Management/AuthApiTest.php
+++ b/tests/API/Management/AuthApiTest.php
@@ -40,7 +40,7 @@ class AuthApiTest extends ApiTests {
         $this->assertArrayHasKey('email_verified', $userinfo);
         $this->assertArrayHasKey('user_id', $userinfo);
         $this->assertEquals('german@auth0.com', $userinfo['email']);
-        $this->assertEquals('auth0|57e293c6247600bf0ba47fc2', $userinfo['user_id']);
+        $this->assertEquals('auth0|58adc60b82b0ca0774643eef', $userinfo['user_id']);
     }
 
     public function testOauthToken() {

--- a/tests/API/Management/AuthApiTest.php
+++ b/tests/API/Management/AuthApiTest.php
@@ -39,7 +39,7 @@ class AuthApiTest extends ApiTests {
         $this->assertArrayHasKey('email', $userinfo);
         $this->assertArrayHasKey('email_verified', $userinfo);
         $this->assertArrayHasKey('user_id', $userinfo);
-        $this->assertEquals('auth@test.com', $userinfo['email']);
+        $this->assertEquals('german@auth0.com', $userinfo['email']);
         $this->assertEquals('auth0|57e293c6247600bf0ba47fc2', $userinfo['user_id']);
     }
 


### PR DESCRIPTION
Something change on the backend? Tests are failing due to different email address:

```
1) Auth0\Tests\API\Management\AuthApiTest::testAuthorizeWithRO
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'auth@test.com'
+'german@auth0.com'
```