### PR TITLE
Removes PHP 5.5 from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
     - /^analysis-.*$/
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1


### PR DESCRIPTION
PHP 5.5 is end of life and no longer supported. I don't see any need to continue testing on out of data PHP version. 

http://php.net/supported-versions.php