### PR TITLE
Fix missed method rename changes

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -229,7 +229,7 @@ final class Auth0
 
         $params['response_mode'] = $this->responseMode;
 
-        $url = $this->authentication->get_authorize_link($this->responseType, $this->redirectUri, $connection, $state, $params);
+        $url = $this->authentication->getAuthorizeLink($this->responseType, $this->redirectUri, $connection, $state, $params);
 
         header("Location: $url");
         exit;
@@ -292,7 +292,7 @@ final class Auth0
             throw new CoreException('Can\'t initialize a new session while there is one active session already');
         }
 
-        $response = $this->authentication->code_exchange($code, $this->redirectUri);
+        $response = $this->authentication->codeExchange($code, $this->redirectUri);
 
         $accessToken = (isset($response['access_token'])) ? $response['access_token'] : false;
         $refreshToken = (isset($response['refresh_token'])) ? $response['refresh_token'] : false;


### PR DESCRIPTION
Fixes method renamings missed by #183 

Ideally, I should be sending this in with with a couple of tests for the methods on this class that make these calls (`login` and `exchange`).
In order to write these tests, a few minor changes might be required on the class itself to be able to mock some of the calls these methods make, so sending these fixes standalone first to fix the typos and leave the class in a usable state.