### PR TITLE
Fixed error messages

### DIFF
--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -33,6 +33,9 @@ abstract class ApiException extends \RuntimeException implements Exception
     {
         $e = new static();
         $e->response = $response;
+        if (is_array($message)) {
+            $message = json_encode($message);
+        }
         $e->message = $message;
 
         return $e;


### PR DESCRIPTION
Currently, we may be passing in arrays as Exception messages. This isn't great, the `$message` property on `Exception` is supposed to be a string (see http://php.net/manual/en/class.exception.php). 

I totally get that it may be desirable to do something more fancy than just JSON-encoding the array, but at least this prevents type errors. Let me know if you want me to do anything fancier with it.