### PR TITLE
Add additional params to login

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -238,8 +238,8 @@ class Auth0 {
     $this->refresh_token = $this->store->get("refresh_token");
   }
 
-  public function login($state = null, $connection = null) {
-    $params = [];
+  public function login($state = null, $connection = null, $additional_params = []) {
+    $params = $additional_params;
     if ($this->audience) {
       $params['audience'] = $this->audience;
     }


### PR DESCRIPTION
Make it possible to pass additional parameters to the login method, e.g. `['prompt' => 'none']`.