### PR TITLE
Adding tests for state handler; correcting storage method used

### DIFF
--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -39,7 +39,7 @@ class SessionStateHandler implements StateHandler
      */
     public function issue() {
         $state = uniqid('', true);
-        $this->store->set(self::STATE_NAME, $state);
+        $this->store($state);
         return $state;
     }
 

--- a/tests/API/Helpers/State/StateHandlerTest.php
+++ b/tests/API/Helpers/State/StateHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Auth0\Tests\Api\Helpers\State;
+
+use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+use Auth0\SDK\Store\SessionStore;
+
+class StateHandlerTest extends \PHPUnit_Framework_TestCase {
+    
+    public function testStateStoredCorrectly() {
+        // Suppress header sent error
+        @$test_store = new SessionStore();
+        $test_state = new SessionStateHandler( $test_store );
+        $uniqid = uniqid();
+        $test_state->store( $uniqid );
+        
+        $this->assertEquals( $uniqid, $test_store->get( SessionStateHandler::STATE_NAME ) );
+    }
+    
+    public function testStateIssuedCorrectly() {
+        // Suppress header sent error
+        @$test_store = new SessionStore();
+        $test_state = new SessionStateHandler( $test_store );
+        $uniqid_returned = $test_state->issue();
+        
+        $this->assertEquals( $uniqid_returned, $test_store->get( SessionStateHandler::STATE_NAME ) );
+    }
+    
+    public function testStateValidatesCorrectly() {
+        // Suppress header sent error
+        @$test_store = new SessionStore();
+        $test_state = new SessionStateHandler( $test_store );
+        $uniqid_returned_1 = $test_state->issue();
+        
+        $this->assertTrue( $test_state->validate( $uniqid_returned_1 ) );
+        $this->assertNull( $test_store->get( SessionStateHandler::STATE_NAME ) );
+    
+        $uniqid_returned_2 = $test_state->issue();
+        $this->assertFalse( $test_state->validate( $uniqid_returned_2 . 'false' ) );
+    }
+}


### PR DESCRIPTION
Tests are self-explanatory. 

@cocojoe - It looks like you created a `store` method and then didn't use it so I made that change. 