### PR TITLE
Auth0 class documentation fixed for store and state handler

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -158,7 +158,8 @@ class Auth0 {
    *     - persist_id_token       (Boolean) Optional. Indicates if you want to persist the id token, default false
    *     - store                  (Mixed)   Optional. Indicates how we store the persisting methods, default is session
    *                                                  store, you can pass false to avoid storing it or a class that
-   *                                                  implements a store (get, set, delete). TODO: add a proper interface
+   *                                                  implements the StorageInterface
+   *     - state_handler            (Mixed) Optional  Indicates how to handle the state, default is SessionStateHandler using a newly opened session, you can pass false to avoid handling the state or a class that implements the StateHandler interface
    *     - debug                  (Boolean) Optional. Default false
    *     - guzzle_options          (Object) Optional. Options forwarded to Guzzle
    *

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -159,7 +159,9 @@ class Auth0 {
    *     - store                  (Mixed)   Optional. Indicates how we store the persisting methods, default is session
    *                                                  store, you can pass false to avoid storing it or a class that
    *                                                  implements the StorageInterface
-   *     - state_handler            (Mixed) Optional  Indicates how to handle the state, default is SessionStateHandler using a newly opened session, you can pass false to avoid handling the state or a class that implements the StateHandler interface
+   *     - state_handler            (Mixed) Optional  Indicates how to handle the state, default is SessionStateHandler 
+   *                                                  using a newly opened session, you can pass false to avoid handling 
+   *                                                  the state or a class that implements the StateHandler interface
    *     - debug                  (Boolean) Optional. Default false
    *     - guzzle_options          (Object) Optional. Options forwarded to Guzzle
    *


### PR DESCRIPTION
Auth0` documentation for `store` and `state_handler` properties lacks behind the implementation.