### PR TITLE
Create instance of custom state handler

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -242,7 +242,7 @@ class Auth0 {
       if ($config['state_handler'] === false) {
         $this->stateHandler = new DummyStateHandler();
       } else {
-        $this->stateHandler = $config['state_handler'];
+        $this->stateHandler = new $config['state_handler'];
       }
     } else {
       $this->stateHandler = new SessionStateHandler(new SessionStore());


### PR DESCRIPTION
If state_handler is defined in $config, create an instance of it instead of using the string.