### PR TITLE
Add email template endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit",
+    "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit  --colors=always --verbose ",
     "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
   },
   "license": "MIT"

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -9,6 +9,7 @@
 namespace Auth0\SDK\API\Helpers;
 
 use Auth0\SDK\API\Header\Header;
+use Auth0\SDK\API\Header\ContentType;
 
 class ApiClient {
 
@@ -64,6 +65,31 @@ class ApiClient {
         ));
 
         return $builder->withHeaders($this->headers);
+    }
+
+    /**
+     * Create a new RequestBuilder.
+     * Similar to the above but does not use a magic method.
+     *
+     * @param string $method - HTTP method to use (GET, POST, PATCH, etc).
+     *
+     * @return RequestBuilder
+     */
+    public function method($method) {
+        $method = strtolower( $method );
+        $builder = new RequestBuilder( [
+            'domain' => $this->domain,
+            'basePath' => $this->basePath,
+            'method' => $method,
+            'guzzleOptions' => $this->guzzleOptions
+        ] );
+        $builder->withHeaders($this->headers);
+
+        if ( in_array( $method, [ 'patch', 'post', 'put' ] ) ) {
+            $builder->withHeader( new ContentType('application/json') );
+        }
+
+        return $builder;
     }
 
 }

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -7,6 +7,7 @@ use Auth0\SDK\API\Management\ClientGrants;
 use Auth0\SDK\API\Management\Connections;
 use Auth0\SDK\API\Management\DeviceCredentials;
 use Auth0\SDK\API\Management\Emails;
+use Auth0\SDK\API\Management\EmailTemplates;
 use Auth0\SDK\API\Management\Jobs;
 use Auth0\SDK\API\Management\Logs;
 use Auth0\SDK\API\Management\ResourceServers;
@@ -143,6 +144,7 @@ class Management {
     $this->connections = new Connections($this->apiClient);
     $this->deviceCredentials = new DeviceCredentials($this->apiClient);
     $this->emails = new Emails($this->apiClient);
+    $this->emailTemplates = new EmailTemplates($this->apiClient);
     $this->jobs = new Jobs($this->apiClient);
     $this->logs = new Logs($this->apiClient);
     $this->rules = new Rules($this->apiClient);

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -75,6 +75,11 @@ class Management {
   public $emails;
 
     /**
+     * @var EmailTemplates
+     */
+  public $emailTemplates;
+
+    /**
      * @var Jobs
      */
   public $jobs;

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -1,46 +1,76 @@
 <?php
-
+/**
+ * @package Auth0\SDK\API\Management
+ */
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
+/**
+ * Class EmailTemplates.
+ * Handles requests to the Email Templates endpoint of the v2 Management API.
+ *
+ * @package Auth0\SDK\API\Management\EmailTemplates
+ */
 class EmailTemplates extends GenericResource
 {
     /**
-     * Get an email template
+     * Get an email template by name.
+     * The email template needs to already exist or the response will be a 404.
+     * An invalid template name will respond with a 400.
+     * See docs @link below for valid names and fields.
      *
-     * @param string $templateName - the email template name to get
+     * @param string $templateName - the email template name to get.
      *
-     * @return mixed
+     * @return array
+     *
+     * @throws \Exception - if a 200 response was not returned from the API.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
      */
     public function get($templateName)
     {
-        return $this->apiClient->get()->addPath('email-templates', $templateName)->call();
+        return $this->apiClient->method('get')
+            ->addPath('email-templates', $templateName)
+            ->call();
     }
 
     /**
-     * @param array $data
-     * @return mixed
+     * Patch an email template by name.
+     * This will update only the email template data fields provided (see HTTP PATCH).
+     * See docs @link below for valid names and fields.
+     *
+     * @param string $templateName - the email template name to patch.
+     * @param array $data - an array of data to update.
+     *
+     * @return array - updated data for the template name provided.
+     *
+     * @throws \Exception - if a 200 response was not returned from the API.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
      */
-    public function create($data) 
+    public function patch($templateName, $data)
     {
-        return $this->apiClient->post()
-            ->clients()
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('patch')
+            ->addPath('email-templates', $templateName)
             ->withBody(json_encode($data))
             ->call();
     }
 
     /**
-     * @param string $id
-     * @param array $data
-     * @return mixed
+     * Create an email template by name.
+     * See docs @link below for valid names and fields.
+     *
+     * @param array $data - an array of data to use for the new email, including a valid template name.
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception - if a 200 response was not returned from the API.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates
      */
-    public function patch($id, $data)
+    public function create($data)
     {
-        return $this->apiClient->patch()
-            ->clients($id)
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+            ->addPath('email-templates')
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -4,6 +4,8 @@
  */
 namespace Auth0\SDK\API\Management;
 
+use \Auth0\SDK\Exception\CoreException;
+
 /**
  * Class EmailTemplates.
  * Handles requests to the Email Templates endpoint of the v2 Management API.
@@ -13,11 +15,56 @@ namespace Auth0\SDK\API\Management;
 class EmailTemplates extends GenericResource
 {
     /**
+     * @var string
+     */
+    const TEMPLATE_VERIFY_EMAIL = 'verify_email';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_RESET_EMAIL = 'reset_email';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_WELCOME_EMAIL = 'welcome_email';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_BLOCKED_ACCOUNT = 'blocked_account';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_STOLEN_CREDENTIALS = 'stolen_credentials';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_ENROLLMENT_EMAIL = 'enrollment_email';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_CHANGE_PASSWORD = 'change_password';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_PASSWORD_RESET = 'password_reset';
+
+    /**
+     * @var string
+     */
+    const TEMPLATE_MFA_OOB_CODE = 'mfa_oob_code';
+
+    /**
      * Get an email template by name.
      * See docs @link below for valid names and fields.
      * Requires scope: read:email_templates.
      *
-     * @param string $templateName - the email template name to get.
+     * @param string $templateName - the email template name to get (see constants defined for this class).
      *
      * @return array
      *
@@ -38,7 +85,7 @@ class EmailTemplates extends GenericResource
      * See docs @link below for valid names, fields, and possible responses.
      * Requires scope: update:email_templates.
      *
-     * @param string $templateName - the email template name to patch.
+     * @param string $templateName - the email template name to patch (see constants defined for this class).
      * @param array $data - an array of data to update.
      *
      * @return array - updated data for the template name provided.
@@ -60,9 +107,14 @@ class EmailTemplates extends GenericResource
      * See docs @link below for valid names and fields.
      * Requires scope: create:email_templates.
      *
-     * @param array $data
-     *      An array of data to use for the new email, including a valid `template`.
-     *      See docs link below for required fields.
+     * @param string $template - the template name to create (see constants defined for this class).
+     * @param boolean $enabled - is the email template enabled?
+     * @param string $from - the email address the email should come from.
+     * @param string $subject - the email subject.
+     * @param string $body - the email body in the syntax indicated below.
+     * @param string $syntax - the email body syntax to use.
+     * @param string $resultUrl - URL where a click-through should land.
+     * @param int $urlLifetime - URL lifetime, in seconds.
      *
      * @return mixed|string
      *
@@ -70,8 +122,31 @@ class EmailTemplates extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates
      */
-    public function create($data)
-    {
+    public function create(
+        $template,
+        $enabled,
+        $from,
+        $subject,
+        $body,
+        $syntax = 'liquid',
+        $resultUrl = '',
+        $urlLifetime = 0
+    ) {
+        // Required fields
+        $data = [
+            'template' => (string) $template,
+            'enabled' => (bool) $enabled,
+            'from' => (string) $from,
+            'subject' => (string) $subject,
+            'body' => (string) $body,
+            'syntax' => (string) $syntax,
+            'urlLifetimeInSeconds' => abs( intval( $urlLifetime ) )
+        ];
+
+        if (! empty($resultUrl)) {
+            $data['resultUrl'] = filter_var($resultUrl, FILTER_SANITIZE_URL);
+        }
+
         return $this->apiClient->method('post')
             ->addPath('email-templates')
             ->withBody(json_encode($data))

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Auth0\SDK\API\Management;
+
+use Auth0\SDK\API\Header\ContentType;
+
+class EmailTemplates extends GenericResource
+{
+    /**
+     * Get an email template
+     *
+     * @param string $templateName - the email template name to get
+     *
+     * @return mixed
+     */
+    public function get($templateName)
+    {
+        return $this->apiClient->get()->addPath('email-templates', $templateName)->call();
+    }
+
+    /**
+     * @param array $data
+     * @return mixed
+     */
+    public function create($data) 
+    {
+        return $this->apiClient->post()
+            ->clients()
+            ->withHeader(new ContentType('application/json'))
+            ->withBody(json_encode($data))
+            ->call();
+    }
+
+    /**
+     * @param string $id
+     * @param array $data
+     * @return mixed
+     */
+    public function patch($id, $data)
+    {
+        return $this->apiClient->patch()
+            ->clients($id)
+            ->withHeader(new ContentType('application/json'))
+            ->withBody(json_encode($data))
+            ->call();
+    }
+}

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -14,9 +14,8 @@ class EmailTemplates extends GenericResource
 {
     /**
      * Get an email template by name.
-     * The email template needs to already exist or the response will be a 404.
-     * An invalid template name will respond with a 400.
      * See docs @link below for valid names and fields.
+     * Requires scope: read:email_templates.
      *
      * @param string $templateName - the email template name to get.
      *
@@ -36,7 +35,8 @@ class EmailTemplates extends GenericResource
     /**
      * Patch an email template by name.
      * This will update only the email template data fields provided (see HTTP PATCH).
-     * See docs @link below for valid names and fields.
+     * See docs @link below for valid names, fields, and possible responses.
+     * Requires scope: update:email_templates.
      *
      * @param string $templateName - the email template name to patch.
      * @param array $data - an array of data to update.
@@ -58,8 +58,11 @@ class EmailTemplates extends GenericResource
     /**
      * Create an email template by name.
      * See docs @link below for valid names and fields.
+     * Requires scope: create:email_templates.
      *
-     * @param array $data - an array of data to use for the new email, including a valid template name.
+     * @param array $data
+     *      An array of data to use for the new email, including a valid `template`.
+     *      See docs link below for required fields.
      *
      * @return mixed|string
      *

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -11,9 +11,11 @@ class ApiTests extends \PHPUnit_Framework_TestCase {
   }
 
   protected static function getEnvStatic() {
-      $loader = new Loader('.env');
-      $loader->parse()
-             ->putenv(true);
+    $env_path = '.env';
+    if (file_exists($env_path)) {
+      $loader = new Loader($env_path);
+      $loader->parse()->putenv(true);
+    }
 
     return [
       "GLOBAL_CLIENT_ID" => getenv('GLOBAL_CLIENT_ID'),

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -5,15 +5,15 @@ use Auth0\SDK\API\Helpers\TokenGenerator;
 use josegonzalez\Dotenv\Loader;
 
 class ApiTests extends \PHPUnit_Framework_TestCase {
+
   protected function getEnv() {
-    try {
+    return self::getEnvStatic();
+  }
+
+  protected static function getEnvStatic() {
       $loader = new Loader('.env');
       $loader->parse()
              ->putenv(true);
-    }
-    catch (\InvalidArgumentException $e) {
-      //ignore
-    }
 
     return [
       "GLOBAL_CLIENT_ID" => getenv('GLOBAL_CLIENT_ID'),
@@ -27,7 +27,14 @@ class ApiTests extends \PHPUnit_Framework_TestCase {
   }
 
   protected function getToken($env, $scopes) {
-    $generator = new TokenGenerator([ 'client_id' => $env['GLOBAL_CLIENT_ID'], 'client_secret' => $env['GLOBAL_CLIENT_SECRET' ] ]);
+    return self::getTokenStatic($env, $scopes);
+  }
+
+  protected static function getTokenStatic($env, $scopes) {
+    $generator = new TokenGenerator([
+        'client_id' => $env['GLOBAL_CLIENT_ID'],
+        'client_secret' => $env['GLOBAL_CLIENT_SECRET']
+    ]);
     return $generator->generate($scopes);
   }
 }

--- a/tests/API/Management/EmailTemplatesTest.php
+++ b/tests/API/Management/EmailTemplatesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Auth0\Tests\API\Management;
+
+use Auth0\SDK\API\Management;
+use Auth0\Tests\API\ApiTests;
+use GuzzleHttp\Exception\ClientException;
+
+/**
+ * Class EmailTemplateTest
+ *
+ * @package Auth0\Tests\API\Management
+ */
+class EmailTemplateTest extends ApiTests
+{
+
+    const EMAIL_TEMPLATE_NAME = 'enrollment_email';
+
+    /**
+     * Management API token with scopes read:email_templates, create:email_templates, update:email_templates
+     *
+     * @var string
+     */
+    protected static $token;
+
+    /**
+     * Valid tenant domain
+     *
+     * @var string
+     */
+    protected static $domain;
+
+    /**
+     * Auth0 v2 Management API accessor
+     *
+     * @var Management
+     */
+    protected static $api;
+
+    /**
+     * Email template retrieved during class setup, tested later
+     *
+     * @var array
+     */
+    protected static $gotEmail;
+
+    /**
+     * Can this email template be created?
+     *
+     * @var bool
+     */
+    protected static $mustCreate = false;
+
+    /**
+     * Test fixture for class
+     *
+     * @throws \Exception
+     */
+    public static function setUpBeforeClass()
+    {
+        $env = self::getEnvStatic();
+
+        self::$domain = $env['DOMAIN'];
+        self::$token = self::getTokenStatic($env, [
+            'email_templates' => [
+                'actions' => ['create', 'read', 'update']
+            ]
+        ]);
+
+        self::$api = new Management(self::$token, self::$domain);
+
+        try {
+            self::$gotEmail = self::$api->emailTemplates->get(self::EMAIL_TEMPLATE_NAME);
+        } catch (ClientException $e) {
+            if (404 === $e->getCode()) {
+                self::$mustCreate = true;
+            }
+        }
+    }
+
+    /**
+     * Test fixture for each method
+     */
+    protected function assertPreConditions()
+    {
+        $this->assertNotEmpty(self::$token);
+        $this->assertInstanceOf(Management::class, self::$api);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testGotAnEmail()
+    {
+        if (self::$mustCreate) {
+            self::$gotEmail = self::$api->emailTemplates->create([
+                'template' => self::EMAIL_TEMPLATE_NAME,
+                'body' => '<!doctype html><html><body><h1>Hi!</h1></body></html>',
+                'from' => 'test@' . self::$domain,
+                'subject' => 'Test email',
+                'syntax' => 'liquid',
+                'urlLifetimeInSeconds' => 0,
+                'enabled' => false,
+            ]);
+        }
+
+        $this->assertEquals(self::EMAIL_TEMPLATE_NAME, self::$gotEmail['template']);
+    }
+
+    /**
+     * Test updating the email template
+     *
+     * @throws \Exception
+     */
+    public function testPatch()
+    {
+        $new_subject = 'Email subject ' . time();
+        self::$gotEmail = self::$api->emailTemplates->patch(self::EMAIL_TEMPLATE_NAME, [
+            'subject' => $new_subject,
+        ]);
+
+        $this->assertEquals($new_subject, self::$gotEmail['subject']);
+    }
+}


### PR DESCRIPTION
- Adding `GET`, `PATCH`, and `POST` for [email templates API](https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName)
- Adding tests for these new methods
- Added a more IDE-friendly method to create an ApiClient
- Added static methods to the ApiTest class to allow for fixture setup