### PR TITLE
Clients endpoint pagination and improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
   },
   "scripts": {
     "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit  --colors=always --verbose ",
-    "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml",
+    "php-compat" : "SHELL_INTERACTIVE=1 phpcs --standard=PHPCompatibility --runtime-set testVersion 5.5",
+    "phpcs"      : "SHELL_INTERACTIVE=1 phpcs --standard=PSR2 --extensions=php --ignore=./examples/*,./vendor/*",
+    "phpcbf"     : "SHELL_INTERACTIVE=1 phpcbf --standard=PSR2 --extensions=php --ignore=./examples/*,./vendor/*"
   },
   "license": "MIT"
 }

--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -287,6 +287,17 @@ class RequestBuilder {
     }
 
     /**
+     * @param array $params
+     * @return RequestBuilder
+     */
+    public function withParamsDict($params) {
+        foreach($params as $key => $value) {
+            $this->withParam($key, $value);
+        }
+        return $this;
+    }
+
+    /**
      * @return array
      */
     private function buildMultiPart() {

--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -287,10 +287,13 @@ class RequestBuilder {
     }
 
     /**
-     * @param array $params
+     * Add URL parameters using $key => $value array.
+     *
+     * @param array $params - URL parameters to add.
+     * 
      * @return RequestBuilder
      */
-    public function withParamsDict($params) {
+    public function withDictParams($params) {
         foreach($params as $key => $value) {
             $this->withParam($key, $value);
         }

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -1,33 +1,95 @@
 <?php
-
+/**
+ * Clients endpoints for the Management API.
+ *
+ * @package Auth0\SDK\API\Management
+ */
 namespace Auth0\SDK\API\Management;
 
-
-use Auth0\SDK\API\Header\ContentType;
-
-class Clients extends GenericResource 
+/**
+ * Class Clients.
+ * Handles requests to the Clients endpoint of the v2 Management API.
+ *
+ * @package Auth0\SDK\API\Management
+ */
+class Clients extends GenericResource
 {
     /**
-     * @param null|string|array $fields
-     * @param null|string|array $include_fields
-     * @return mixed
+     * Allowed app types for self::getAll().
      */
-    public function getAll($fields = null, $include_fields = null) 
-    {
-        $request = $this->apiClient->get()
-            ->clients();
+    const APP_TYPE_NATIVE = 'native';
+    const APP_TYPE_NON_INTERACTIVE = 'non_interactive';
+    const APP_TYPE_REGULAR_WEB = 'regular_web';
+    const APP_TYPE_SPA = 'spa';
 
-        if ($fields !== null) 
-        {
-            if (is_array($fields)) 
-            {
+    /**
+     * Get all Clients by page.
+     *
+     * @param null|string|array $fields         - Fields to include or exclude from the result.
+     * @param null|boolean      $include_fields - True to include $fields, false to exclude $fields.
+     * @param null|string       $app_type       - Application type to get, see class constants above.
+     * @param integer           $page           - Page number to get, zero-based.
+     * @param null|integer      $per_page       - Number of results to get, null to return the default number.
+     *
+     * @return mixed
+     *
+     * @throws \Exception
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Clients/get_clients
+     */
+    public function getAll($fields = null, $include_fields = null, $app_type = null, $page = 0, $per_page = null)
+    {
+        $request = $this->apiClient->method('get')->addPath('clients');
+
+        if (!empty($fields)) {
+            if (is_array($fields)) {
                 $fields = implode(',', $fields);
             }
             $request->withParam('fields', $fields);
         }
 
-        if ($include_fields !== null) 
-        {
+        if (null !== $include_fields) {
+            $request->withParam('include_fields', $include_fields);
+        }
+
+        if (null !== $app_type) {
+            $request->withParam('app_type', $app_type);
+        }
+
+        $request->withParam('page', abs(intval($page)));
+
+        if (null !== $per_page) {
+            $request->withParam('per_page', $per_page);
+        }
+
+        return $request->call();
+    }
+
+    /**
+     * Get a single Client by ID.
+     *
+     * @param string            $id             - Client ID to get.
+     * @param null|string|array $fields         - Fields to include or exclude, based on $include_fields parameter.
+     * @param null|string|array $include_fields - Should the field(s) above be included or excluded?
+     *
+     * @return mixed
+     *
+     * @throws \Exception
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
+     */
+    public function get($id, $fields = null, $include_fields = null)
+    {
+        $request = $this->apiClient->method('get')->addPath('clients', $id);
+
+        if (!empty($fields)) {
+            if (is_array($fields)) {
+                $fields = implode(',', $fields);
+            }
+            $request->withParam('fields', $fields);
+        }
+
+        if (null !== $include_fields) {
             $request->withParam('include_fields', $include_fields);
         }
 
@@ -35,66 +97,62 @@ class Clients extends GenericResource
     }
 
     /**
-     * @param string $id
-     * @param null|string|array $fields
-     * @param null|string|array $include_fields
-     * @return mixed
+     * Delete a client.
+     *
+     * @param string $id - Client ID to delete.
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Clients/delete_clients_by_id
      */
-    public function get($id, $fields = null, $include_fields = null) 
+    public function delete($id)
     {
-        $request = $this->apiClient->get()
-            ->clients($id);
-
-        if ($fields !== null) 
-        {
-            if (is_array($fields)) 
-            {
-                $fields = implode(',', $fields);
-            }
-            $request->withParam('fields', $fields);
-        }
-        if ($include_fields !== null) 
-        {
-            $request->withParam('include_fields', $include_fields);
-        }
-
-        return $request->call();
-    }
-
-    /**
-     * @param string $id
-     * @return mixed
-     */
-    public function delete($id) 
-    {
-        return $this->apiClient->delete()
-            ->clients($id)
+        return $this->apiClient->method('delete')
+            ->addPath('clients', $id)
             ->call();
     }
 
     /**
-     * @param array $data
-     * @return mixed
+     * Create a new Client.
+     *
+     * @param array $data - Client create data.
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Clients/post_clients
      */
-    public function create($data) 
+    public function create($data)
     {
-        return $this->apiClient->post()
-            ->clients()
-            ->withHeader(new ContentType('application/json'))
+        if (empty($data['name'])) {
+            throw new \Exception('Missing required "name" field.');
+        }
+
+        return $this->apiClient->method('post')
+            ->addPath('clients')
             ->withBody(json_encode($data))
             ->call();
     }
 
     /**
-     * @param string $id
-     * @param array $data
-     * @return mixed
+     * Update a Client.
+     *
+     * @param string $id - Client ID to update
+     * @param array $data - Client data to update.
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Clients/patch_clients_by_id
      */
-    public function update($id, $data) 
+    public function update($id, $data)
     {
-        return $this->apiClient->patch()
-            ->clients($id)
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('patch')
+            ->addPath('clients', $id)
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -51,7 +51,7 @@ class Clients extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('clients')
-            ->withParamsDict($params)
+            ->withDictParams($params)
             ->call();
     }
 
@@ -82,7 +82,7 @@ class Clients extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('clients', $client_id)
-            ->withParamsDict($params)
+            ->withDictParams($params)
             ->call();
     }
 

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -14,22 +14,15 @@ namespace Auth0\SDK\API\Management;
  */
 class Clients extends GenericResource
 {
-    /**
-     * Allowed app types for self::getAll().
-     */
-    const APP_TYPE_NATIVE = 'native';
-    const APP_TYPE_NON_INTERACTIVE = 'non_interactive';
-    const APP_TYPE_REGULAR_WEB = 'regular_web';
-    const APP_TYPE_SPA = 'spa';
 
     /**
      * Get all Clients by page.
      *
      * @param null|string|array $fields         - Fields to include or exclude from the result.
      * @param null|boolean      $include_fields - True to include $fields, false to exclude $fields.
-     * @param null|string       $app_type       - Application type to get, see class constants above.
      * @param integer           $page           - Page number to get, zero-based.
      * @param null|integer      $per_page       - Number of results to get, null to return the default number.
+     * @param array             $add_params     - Additional API parameters; see docs link below for supported.
      *
      * @return mixed
      *
@@ -37,38 +30,35 @@ class Clients extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/get_clients
      */
-    public function getAll($fields = null, $include_fields = null, $app_type = null, $page = 0, $per_page = null)
+    public function getAll($fields = null, $include_fields = null, $page = 0, $per_page = null, $add_params = [])
     {
-        $request = $this->apiClient->method('get')->addPath('clients');
+        // Set additional parameters first so they are over-written by function parameters.
+        $params = $add_params;
 
+        // Results fields.
         if (!empty($fields)) {
-            if (is_array($fields)) {
-                $fields = implode(',', $fields);
+            $params['fields'] = is_array($fields) ? implode(',', $fields) : $fields;
+            if (null !== $include_fields) {
+                $params['include_fields'] = $include_fields;
             }
-            $request->withParam('fields', $fields);
         }
 
-        if (null !== $include_fields) {
-            $request->withParam('include_fields', $include_fields);
-        }
-
-        if (null !== $app_type) {
-            $request->withParam('app_type', $app_type);
-        }
-
-        $request->withParam('page', abs(intval($page)));
-
+        // Pagination.
+        $params['page'] = abs(intval($page));
         if (null !== $per_page) {
-            $request->withParam('per_page', $per_page);
+            $params['per_page'] = $per_page;
         }
 
-        return $request->call();
+        return $this->apiClient->method('get')
+            ->addPath('clients')
+            ->withParamsDict($params)
+            ->call();
     }
 
     /**
      * Get a single Client by ID.
      *
-     * @param string            $id             - Client ID to get.
+     * @param string            $client_id      - Client ID to get.
      * @param null|string|array $fields         - Fields to include or exclude, based on $include_fields parameter.
      * @param null|string|array $include_fields - Should the field(s) above be included or excluded?
      *
@@ -78,28 +68,28 @@ class Clients extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
      */
-    public function get($id, $fields = null, $include_fields = null)
+    public function get($client_id, $fields = null, $include_fields = null)
     {
-        $request = $this->apiClient->method('get')->addPath('clients', $id);
+        $params = [];
 
+        // Results fields.
         if (!empty($fields)) {
-            if (is_array($fields)) {
-                $fields = implode(',', $fields);
+            $params['fields'] = is_array($fields) ? implode(',', $fields) : $fields;
+            if (null !== $include_fields) {
+                $params['include_fields'] = $include_fields;
             }
-            $request->withParam('fields', $fields);
         }
 
-        if (null !== $include_fields) {
-            $request->withParam('include_fields', $include_fields);
-        }
-
-        return $request->call();
+        return $this->apiClient->method('get')
+            ->addPath('clients', $client_id)
+            ->withParamsDict($params)
+            ->call();
     }
 
     /**
      * Delete a client.
      *
-     * @param string $id - Client ID to delete.
+     * @param string $client_id - Client ID to delete.
      *
      * @return mixed|string
      *
@@ -107,10 +97,10 @@ class Clients extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/delete_clients_by_id
      */
-    public function delete($id)
+    public function delete($client_id)
     {
         return $this->apiClient->method('delete')
-            ->addPath('clients', $id)
+            ->addPath('clients', $client_id)
             ->call();
     }
 
@@ -140,7 +130,7 @@ class Clients extends GenericResource
     /**
      * Update a Client.
      *
-     * @param string $id - Client ID to update
+     * @param string $client_id - Client ID to update.
      * @param array $data - Client data to update.
      *
      * @return mixed|string
@@ -149,10 +139,10 @@ class Clients extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/patch_clients_by_id
      */
-    public function update($id, $data)
+    public function update($client_id, $data)
     {
         return $this->apiClient->method('patch')
-            ->addPath('clients', $id)
+            ->addPath('clients', $client_id)
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -22,7 +22,7 @@ class Clients extends GenericResource
      * @param null|boolean      $include_fields - True to include $fields, false to exclude $fields.
      * @param integer           $page           - Page number to get, zero-based.
      * @param null|integer      $per_page       - Number of results to get, null to return the default number.
-     * @param array             $add_params     - Additional API parameters; see docs link below for supported.
+     * @param array             $add_params     - Additional API parameters, over-written by function params.
      *
      * @return mixed
      *
@@ -33,7 +33,7 @@ class Clients extends GenericResource
     public function getAll($fields = null, $include_fields = null, $page = 0, $per_page = null, $add_params = [])
     {
         // Set additional parameters first so they are over-written by function parameters.
-        $params = $add_params;
+        $params = is_array( $add_params ) ? $add_params : [];
 
         // Results fields.
         if (!empty($fields)) {

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -2,58 +2,148 @@
 
 namespace Auth0\Tests\API;
 
-abstract class BasicCrudTest extends ApiTests {
-
+abstract class BasicCrudTest extends ApiTests
+{
+    /**
+     * Tenant domain for the test account.
+     *
+     * @var string
+     */
     protected $domain;
 
+    /**
+     * Environment variables, generated in self::__construct().
+     *
+     * @var array
+     */
+    protected $env;
+
+    /**
+     * Should all results be searched for the created entity?
+     *
+     * @var bool
+     */
     protected $findCreatedItem = true;
 
-    protected abstract function getApiClient();
-    protected abstract function getCreateBody();
-    protected abstract function getUpdateBody();
-    protected abstract function afterCreate($entity);
-    protected abstract function afterUpdate($entity);
+    /**
+     * CRUD API client to test.
+     *
+     * @return mixed
+     */
+    abstract protected function getApiClient();
 
-    protected function getAll($client, $entity) {
-        return $client->getAll();
+    /**
+     * Data to use to create the test entity.
+     *
+     * @return array
+     */
+    abstract protected function getCreateBody();
+
+    /**
+     * Data to use to update the test entity.
+     *
+     * @return array
+     */
+    abstract protected function getUpdateBody();
+
+    /**
+     * Assertions for the created entity.
+     *
+     * @param array $created_entity - Created entity.
+     *
+     * @return mixed
+     */
+    abstract protected function afterCreate($created_entity);
+
+    /**
+     * Assertions for the updated entity.
+     *
+     * @param array $updated_entity - Updated entity.
+     *
+     * @return mixed
+     */
+    abstract protected function afterUpdate($updated_entity);
+
+    /**
+     * BasicCrudTest constructor.
+     * Sets up environment and domain value.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->env = $this->getEnv();
+        $this->domain = $this->env['DOMAIN'];
     }
 
-    protected function getId($entity) {
+    /**
+     * Stub "get all entities" method.
+     * Can be overridden by child classes for specific test cases.
+     *
+     * @param mixed $crud_api - API client from the child class
+     * @param array $created_entity - Created entity.
+     *
+     * @return mixed
+     */
+    protected function getAll($crud_api, $created_entity)
+    {
+        return $crud_api->getAll();
+    }
+
+    /**
+     * Get the unique identifier for the entity.
+     *
+     * @param array $entity - Entity array.
+     *
+     * @return mixed
+     */
+    protected function getId($entity)
+    {
         return $entity['id'];
     }
 
-    public function testAll() {
+    /**
+     * All basic CRUD test assertions.
+     */
+    public function testAll()
+    {
 
-        $client = $this->getApiClient();
+        // Get the API client from the child class.
+        $crud_api = $this->getApiClient();
 
-        $options = $client->getApiClient()->get()->getGuzzleOptions();
-
+        // Get and check that our options have been set correctly.
+        $options = $crud_api->getApiClient()->get()->getGuzzleOptions();
         $this->assertArrayHasKey('base_uri', $options);
         $this->assertEquals("https://$this->domain/api/v2/", $options['base_uri']);
 
-        $created = $client->create($this->getCreateBody());
+        // Test a generic "create entity" method for this API client.
+        $created_entity = $crud_api->create($this->getCreateBody());
+        $created_entity_id = $this->getId($created_entity);
+        $this->afterCreate($created_entity);
 
-        $all = $this->getAll($client, $created);
+        // Test a generic "get entity" method.
+        $got_entity = $crud_api->get($created_entity_id);
+        $this->afterCreate($got_entity);
 
-        $found = false;
-        foreach ($all as $value) {
-            if ($this->getId($value) === $this->getId($created)) {
-                $found = true;
-                break;
+        // Test a generic "get all entities" method for this API client.
+        $all_entities = $this->getAll($crud_api, $created_entity);
+
+        // Look through our returned results for the created item, if indicated.
+        if ($this->findCreatedItem && !empty($all_entities)) {
+            $found = false;
+            foreach ($all_entities as $value) {
+                if ($this->getId($value) === $created_entity_id) {
+                    $found = true;
+                    break;
+                }
             }
+            $this->assertTrue($found, 'Created item not found');
         }
 
-        if ($this->findCreatedItem) {
-          $this->assertTrue($found, 'Created item not found');
-        }
+        // Test a generic "update entity" method for this API client.
+        $updated_entity = $crud_api->update($created_entity_id, $this->getUpdateBody());
+        $this->afterUpdate($updated_entity);
 
-        $this->afterCreate($created);
-
-        $client->update($this->getId($created), $this->getUpdateBody());
-
-        $get = $client->get($this->getId($created));
-        $this->afterUpdate($get);
-
-        $client->delete($this->getId($created));
+        // Test a generic "delete entity" method for this API client.
+        $crud_api->delete($created_entity_id);
     }
 }

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -19,6 +19,20 @@ abstract class BasicCrudTest extends ApiTests
     protected $env;
 
     /**
+     * API client to test.
+     *
+     * @var mixed
+     */
+    protected $api;
+
+    /**
+     * Name of the entity's ID.
+     *
+     * @var mixed
+     */
+    protected $id_name = 'id';
+
+    /**
      * Should all results be searched for the created entity?
      *
      * @var bool
@@ -73,20 +87,20 @@ abstract class BasicCrudTest extends ApiTests
         parent::__construct();
         $this->env = $this->getEnv();
         $this->domain = $this->env['DOMAIN'];
+        $this->api = $this->getApiClient();
     }
 
     /**
      * Stub "get all entities" method.
      * Can be overridden by child classes for specific test cases.
      *
-     * @param mixed $crud_api - API client from the child class
      * @param array $created_entity - Created entity.
      *
      * @return mixed
      */
-    protected function getAll($crud_api, $created_entity)
+    protected function getAllEntities($created_entity)
     {
-        return $crud_api->getAll();
+        return $this->api->getAll();
     }
 
     /**
@@ -98,7 +112,7 @@ abstract class BasicCrudTest extends ApiTests
      */
     protected function getId($entity)
     {
-        return $entity['id'];
+        return $entity[$this->id_name];
     }
 
     /**
@@ -106,26 +120,22 @@ abstract class BasicCrudTest extends ApiTests
      */
     public function testAll()
     {
-
-        // Get the API client from the child class.
-        $crud_api = $this->getApiClient();
-
         // Get and check that our options have been set correctly.
-        $options = $crud_api->getApiClient()->get()->getGuzzleOptions();
+        $options = $this->api->getApiClient()->get()->getGuzzleOptions();
         $this->assertArrayHasKey('base_uri', $options);
         $this->assertEquals("https://$this->domain/api/v2/", $options['base_uri']);
 
         // Test a generic "create entity" method for this API client.
-        $created_entity = $crud_api->create($this->getCreateBody());
+        $created_entity = $this->api->create($this->getCreateBody());
         $created_entity_id = $this->getId($created_entity);
         $this->afterCreate($created_entity);
 
         // Test a generic "get entity" method.
-        $got_entity = $crud_api->get($created_entity_id);
+        $got_entity = $this->api->get($created_entity_id);
         $this->afterCreate($got_entity);
 
         // Test a generic "get all entities" method for this API client.
-        $all_entities = $this->getAll($crud_api, $created_entity);
+        $all_entities = $this->getAllEntities($created_entity);
 
         // Look through our returned results for the created item, if indicated.
         if ($this->findCreatedItem && !empty($all_entities)) {
@@ -140,10 +150,10 @@ abstract class BasicCrudTest extends ApiTests
         }
 
         // Test a generic "update entity" method for this API client.
-        $updated_entity = $crud_api->update($created_entity_id, $this->getUpdateBody());
+        $updated_entity = $this->api->update($created_entity_id, $this->getUpdateBody());
         $this->afterUpdate($updated_entity);
 
         // Test a generic "delete entity" method for this API client.
-        $crud_api->delete($created_entity_id);
+        $this->api->delete($created_entity_id);
     }
 }

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -116,15 +116,20 @@ abstract class BasicCrudTest extends ApiTests
     }
 
     /**
+     * Check that HTTP options have been set correctly.
+     */
+    public function testHttpOptions()
+    {
+        $options = $this->api->getApiClient()->get()->getGuzzleOptions();
+        $this->assertArrayHasKey('base_uri', $options);
+        $this->assertEquals("https://$this->domain/api/v2/", $options['base_uri']);
+    }
+
+    /**
      * All basic CRUD test assertions.
      */
     public function testAll()
     {
-        // Get and check that our options have been set correctly.
-        $options = $this->api->getApiClient()->get()->getGuzzleOptions();
-        $this->assertArrayHasKey('base_uri', $options);
-        $this->assertEquals("https://$this->domain/api/v2/", $options['base_uri']);
-
         // Test a generic "create entity" method for this API client.
         $created_entity = $this->api->create($this->getCreateBody());
         $created_entity_id = $this->getId($created_entity);
@@ -132,6 +137,8 @@ abstract class BasicCrudTest extends ApiTests
 
         // Test a generic "get entity" method.
         $got_entity = $this->api->get($created_entity_id);
+
+        // Make sure what we got matches what we created.
         $this->afterCreate($got_entity);
 
         // Test a generic "get all entities" method for this API client.

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -132,8 +132,8 @@ abstract class BasicCrudTest extends ApiTests
     {
         // Test a generic "create entity" method for this API client.
         $created_entity = $this->api->create($this->getCreateBody());
-        $created_entity_id = $this->getId($created_entity);
         $this->afterCreate($created_entity);
+        $created_entity_id = $this->getId($created_entity);
 
         // Test a generic "get entity" method.
         $got_entity = $this->api->get($created_entity_id);

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -2,42 +2,197 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\SDK\API\Management;
+use Auth0\SDK\API\Management\Clients;
 use Auth0\Tests\API\BasicCrudTest;
 
-class ClientsTest extends BasicCrudTest {
-    
-    protected function getId($entity) {
-        return $entity['client_id'];
+/**
+ * Class ClientsTest
+ *
+ * @package Auth0\Tests\API\Management
+ */
+class ClientsTest extends BasicCrudTest
+{
+    /**
+     * Unique identifier name for Clients.
+     *
+     * @var string
+     */
+    protected $id_name = 'client_id';
+
+    /**
+     * Name of the created Client.
+     * Appended with a random string in self::__construct().
+     *
+     * @var string
+     */
+    protected $create_client_name = 'TEST-CREATE-CLIENT-';
+
+    /**
+     * Application type of the created Client.
+     *
+     * @var string
+     */
+    protected $create_app_type = Clients::APP_TYPE_REGULAR_WEB;
+
+    /**
+     * SSO setting of the created Client.
+     *
+     * @var bool
+     */
+    protected $create_sso = false;
+
+    /**
+     * Description of the created Client.
+     *
+     * @var string
+     */
+    protected $create_desc = '__Auth0_PHP_initial_app_description__';
+
+    /**
+     * Name of the updated Client.
+     * Appended with a random string in self::__construct().
+     *
+     * @var string
+     */
+    protected $update_client_name = 'TEST-UPDATE-CLIENT-';
+
+    /**
+     * Application type of the updated Client.
+     *
+     * @var string
+     */
+    protected $update_app_type = Clients::APP_TYPE_NON_INTERACTIVE;
+
+    /**
+     * SSO setting of the updated Client.
+     *
+     * @var bool
+     */
+    protected $update_sso = true;
+
+    /**
+     * Description of the updated Client.
+     *
+     * @var string
+     */
+    protected $update_desc = '__Auth0_PHP_updated_app_description__';
+
+    /**
+     * ClientsTest constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->create_client_name .= rand();
+        $this->update_client_name .= rand();
     }
 
-    protected function getApiClient() {
-        $env = $this->getEnv();
-        $token = $this->getToken($env, [
-            'clients' => [
-                'actions' => ['create', 'read', 'delete', 'update']
-            ]
-        ]);
+    /**
+     * Return the ID for the entity created.
+     *
+     * @param array $entity - Client created during test.
+     *
+     * @return string|integer
+     */
+    protected function getId($entity)
+    {
+        return $entity[$this->id_name];
+    }
 
-        $this->domain = $env['DOMAIN'];
-
-        $api = new Management($token, $env['DOMAIN']);
-
+    /**
+     * Return the Clients API to test.
+     *
+     * @return Management\Clients
+     */
+    protected function getApiClient()
+    {
+        $token = $this->getToken($this->env, [ 'clients' => [ 'actions' => ['create', 'read', 'delete', 'update' ] ] ]);
+        $api = new Management($token, $this->domain);
         return $api->clients;
     }
 
-    protected function getCreateBody() {
-        $client_name = 'test-create-client' . rand();
-        echo "\n-- Using client name $client_name \n";
+    /**
+     * Get the Client create data to send with the test create call.
+     *
+     * @return array
+     */
+    protected function getCreateBody()
+    {
+        return [
+            'name' => $this->create_client_name,
+            'app_type' => $this->create_app_type,
+            'sso' => $this->create_sso,
+            'description' => $this->create_desc,
+        ];
+    }
 
-        return ['name' => $client_name, 'sso' => false];
+    /**
+     * Tests the \Auth0\SDK\API\Management\Clients::getAll() method.
+     *
+     * @param Management\Clients $client - API client to use.
+     * @param array $created_entity - Entity created during create() test.
+     *
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    protected function getAll($client, $created_entity)
+    {
+        $fields = array_keys($this->getCreateBody());
+        $fields[] = $this->id_name;
+
+        // Check that pagination works.
+        $all_results = $client->getAll($fields, true, $this->create_app_type, 1, 1);
+        $this->assertEquals(1, count($all_results));
+        $this->assertEquals(count($fields), count($all_results[0]));
+
+        // If we want to check for the created result, we need all Clients.
+        if ($this->findCreatedItem) {
+            $all_results = $client->getAll($fields, true, $this->create_app_type, 0, 100);
+        }
+
+        return $all_results;
     }
-    protected function getUpdateBody() {
-        return ['sso' => true];
+
+    /**
+     * Check that the Client created matches the initial values sent.
+     *
+     * @param array $entity - The created Client to check against initial values.
+     */
+    protected function afterCreate($entity)
+    {
+        $this->assertNotEmpty($entity[$this->id_name]);
+        $this->assertEquals($this->create_client_name, $entity['name']);
+        $this->assertEquals($this->create_app_type, $entity['app_type']);
+        $this->assertEquals($this->create_sso, $entity['sso']);
+        $this->assertEquals($this->create_desc, $entity['description']);
     }
-    protected function afterCreate($entity) {
-        $this->assertNotTrue($entity['sso']);
+
+    /**
+     * Get the Client values that should be updated.
+     *
+     * @return array
+     */
+    protected function getUpdateBody()
+    {
+        return [
+            'name' => $this->update_client_name,
+            'app_type' => $this->update_app_type,
+            'sso' => $this->update_sso,
+            'description' => $this->update_desc,
+        ];
     }
-    protected function afterUpdate($entity) {
-        $this->assertTrue($entity['sso']);
+
+    /**
+     * Update entity returned values check.
+     *
+     * @param array $entity - Client that was updated.
+     */
+    protected function afterUpdate($entity)
+    {
+        $this->assertEquals($this->update_client_name, $entity['name']);
+        $this->assertEquals($this->update_app_type, $entity['app_type']);
+        $this->assertEquals($this->update_sso, $entity['sso']);
+        $this->assertEquals($this->update_desc, $entity['description']);
     }
 }

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -74,18 +74,28 @@ class ClientsTest extends BasicCrudTest
     {
         $fields = array_keys($this->getCreateBody());
         $fields[] = $this->id_name;
+        $page_num = 1;
 
-        // Check that pagination works.
-        $all_results = $this->api->getAll($fields, true, 1, 1);
-        $this->assertEquals(1, count($all_results));
-        $this->assertEquals(count($fields), count($all_results[0]));
+        // Get the second page of Clients with 1 per page (second result).
+        $paged_results = $this->api->getAll($fields, true, $page_num, 1);
 
-        // If we want to check for the created result, we need all Clients.
-        if ($this->findCreatedItem) {
-            $all_results = $this->api->getAll($fields, true, 0, 100);
-        }
+        // Make sure we only have one result, as requested.
+        $this->assertEquals(1, count($paged_results));
 
-        return $all_results;
+        // Make sure we only have the 4 fields we requested.
+        $this->assertEquals(count($fields), count($paged_results[0]));
+
+        // Get many results (needs to include the created result if self::findCreatedItem === true).
+        $many_results_per_page = 50;
+        $many_results = $this->api->getAll($fields, true, 0, $many_results_per_page);
+
+        // Make sure we have at least as many results as we requested.
+        $this->assertLessThan($many_results_per_page, count($many_results));
+
+        // Make sure our paged result above appears in the right place.
+        $this->assertEquals($paged_results[0][$this->id_name], $many_results[$page_num][$this->id_name]);
+
+        return $many_results;
     }
 
     /**
@@ -95,12 +105,12 @@ class ClientsTest extends BasicCrudTest
      */
     protected function afterCreate($entity)
     {
-        $expect_client = $this->getCreateBody();
-        $this->assertNotEmpty($entity[$this->id_name]);
-        $this->assertEquals($expect_client['name'], $entity['name']);
-        $this->assertEquals($expect_client['app_type'], $entity['app_type']);
-        $this->assertEquals($expect_client['sso'], $entity['sso']);
-        $this->assertEquals($expect_client['description'], $entity['description']);
+        $expected = $this->getCreateBody();
+        $this->assertNotEmpty($this->getId($entity));
+        $this->assertEquals($expected['name'], $entity['name']);
+        $this->assertEquals($expected['app_type'], $entity['app_type']);
+        $this->assertEquals($expected['sso'], $entity['sso']);
+        $this->assertEquals($expected['description'], $entity['description']);
     }
 
     /**
@@ -125,10 +135,10 @@ class ClientsTest extends BasicCrudTest
      */
     protected function afterUpdate($entity)
     {
-        $expect_client = $this->getUpdateBody();
-        $this->assertEquals($expect_client['name'], $entity['name']);
-        $this->assertEquals($expect_client['app_type'], $entity['app_type']);
-        $this->assertEquals($expect_client['sso'], $entity['sso']);
-        $this->assertEquals($expect_client['description'], $entity['description']);
+        $expected = $this->getUpdateBody();
+        $this->assertEquals($expected['name'], $entity['name']);
+        $this->assertEquals($expected['app_type'], $entity['app_type']);
+        $this->assertEquals($expected['sso'], $entity['sso']);
+        $this->assertEquals($expected['description'], $entity['description']);
     }
 }

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -93,6 +93,7 @@ class ClientsTest extends BasicCrudTest
         $this->assertLessThan($many_results_per_page, count($many_results));
 
         // Make sure our paged result above appears in the right place.
+        // $page_num here represents the expected location for the single entity retrieved above. 
         $this->assertEquals($paged_results[0][$this->id_name], $many_results[$page_num][$this->id_name]);
 
         return $many_results;

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -2,7 +2,6 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\SDK\API\Management;
-use Auth0\SDK\API\Management\Clients;
 use Auth0\Tests\API\BasicCrudTest;
 
 /**
@@ -20,62 +19,11 @@ class ClientsTest extends BasicCrudTest
     protected $id_name = 'client_id';
 
     /**
-     * Name of the created Client.
-     * Appended with a random string in self::__construct().
+     * Random number used for unique testing names.
      *
-     * @var string
+     * @var integer
      */
-    protected $create_client_name = 'TEST-CREATE-CLIENT-';
-
-    /**
-     * Application type of the created Client.
-     *
-     * @var string
-     */
-    protected $create_app_type = Clients::APP_TYPE_REGULAR_WEB;
-
-    /**
-     * SSO setting of the created Client.
-     *
-     * @var bool
-     */
-    protected $create_sso = false;
-
-    /**
-     * Description of the created Client.
-     *
-     * @var string
-     */
-    protected $create_desc = '__Auth0_PHP_initial_app_description__';
-
-    /**
-     * Name of the updated Client.
-     * Appended with a random string in self::__construct().
-     *
-     * @var string
-     */
-    protected $update_client_name = 'TEST-UPDATE-CLIENT-';
-
-    /**
-     * Application type of the updated Client.
-     *
-     * @var string
-     */
-    protected $update_app_type = Clients::APP_TYPE_NON_INTERACTIVE;
-
-    /**
-     * SSO setting of the updated Client.
-     *
-     * @var bool
-     */
-    protected $update_sso = true;
-
-    /**
-     * Description of the updated Client.
-     *
-     * @var string
-     */
-    protected $update_desc = '__Auth0_PHP_updated_app_description__';
+    protected $rand;
 
     /**
      * ClientsTest constructor.
@@ -83,20 +31,7 @@ class ClientsTest extends BasicCrudTest
     public function __construct()
     {
         parent::__construct();
-        $this->create_client_name .= rand();
-        $this->update_client_name .= rand();
-    }
-
-    /**
-     * Return the ID for the entity created.
-     *
-     * @param array $entity - Client created during test.
-     *
-     * @return string|integer
-     */
-    protected function getId($entity)
-    {
-        return $entity[$this->id_name];
+        $this->rand = rand();
     }
 
     /**
@@ -119,36 +54,35 @@ class ClientsTest extends BasicCrudTest
     protected function getCreateBody()
     {
         return [
-            'name' => $this->create_client_name,
-            'app_type' => $this->create_app_type,
-            'sso' => $this->create_sso,
-            'description' => $this->create_desc,
+            'name' => 'TEST-CREATE-CLIENT-' . $this->rand,
+            'app_type' => 'regular_web',
+            'sso' => false,
+            'description' => '__Auth0_PHP_initial_app_description__',
         ];
     }
 
     /**
      * Tests the \Auth0\SDK\API\Management\Clients::getAll() method.
      *
-     * @param Management\Clients $client - API client to use.
      * @param array $created_entity - Entity created during create() test.
      *
      * @return mixed
      *
      * @throws \Exception
      */
-    protected function getAll($client, $created_entity)
+    protected function getAllEntities($created_entity)
     {
         $fields = array_keys($this->getCreateBody());
         $fields[] = $this->id_name;
 
         // Check that pagination works.
-        $all_results = $client->getAll($fields, true, $this->create_app_type, 1, 1);
+        $all_results = $this->api->getAll($fields, true, 1, 1);
         $this->assertEquals(1, count($all_results));
         $this->assertEquals(count($fields), count($all_results[0]));
 
         // If we want to check for the created result, we need all Clients.
         if ($this->findCreatedItem) {
-            $all_results = $client->getAll($fields, true, $this->create_app_type, 0, 100);
+            $all_results = $this->api->getAll($fields, true, 0, 100);
         }
 
         return $all_results;
@@ -161,11 +95,12 @@ class ClientsTest extends BasicCrudTest
      */
     protected function afterCreate($entity)
     {
+        $expect_client = $this->getCreateBody();
         $this->assertNotEmpty($entity[$this->id_name]);
-        $this->assertEquals($this->create_client_name, $entity['name']);
-        $this->assertEquals($this->create_app_type, $entity['app_type']);
-        $this->assertEquals($this->create_sso, $entity['sso']);
-        $this->assertEquals($this->create_desc, $entity['description']);
+        $this->assertEquals($expect_client['name'], $entity['name']);
+        $this->assertEquals($expect_client['app_type'], $entity['app_type']);
+        $this->assertEquals($expect_client['sso'], $entity['sso']);
+        $this->assertEquals($expect_client['description'], $entity['description']);
     }
 
     /**
@@ -176,10 +111,10 @@ class ClientsTest extends BasicCrudTest
     protected function getUpdateBody()
     {
         return [
-            'name' => $this->update_client_name,
-            'app_type' => $this->update_app_type,
-            'sso' => $this->update_sso,
-            'description' => $this->update_desc,
+            'name' => 'TEST-UPDATE-CLIENT-',
+            'app_type' => 'native',
+            'sso' => true,
+            'description' => '__Auth0_PHP_updated_app_description__',
         ];
     }
 
@@ -190,9 +125,10 @@ class ClientsTest extends BasicCrudTest
      */
     protected function afterUpdate($entity)
     {
-        $this->assertEquals($this->update_client_name, $entity['name']);
-        $this->assertEquals($this->update_app_type, $entity['app_type']);
-        $this->assertEquals($this->update_sso, $entity['sso']);
-        $this->assertEquals($this->update_desc, $entity['description']);
+        $expect_client = $this->getUpdateBody();
+        $this->assertEquals($expect_client['name'], $entity['name']);
+        $this->assertEquals($expect_client['app_type'], $entity['app_type']);
+        $this->assertEquals($expect_client['sso'], $entity['sso']);
+        $this->assertEquals($expect_client['description'], $entity['description']);
     }
 }

--- a/tests/API/Management/UsersTest.php
+++ b/tests/API/Management/UsersTest.php
@@ -33,8 +33,8 @@ class UsersTest extends BasicCrudTest {
         return $api->users;
     }
 
-    protected function getAll($client, $entity) { echo "user_id:'{$entity['user_id']}'";
-        return $client->getAll([
+    protected function getAllEntities($entity) { echo "user_id:'{$entity['user_id']}'";
+        return $this->api->getAll([
             "q" => "user_id:'{$entity['user_id']}'",
             "search_engine"=>"v2"
         ]);


### PR DESCRIPTION
- Add pagination to getAll method via page and per_page parameters.
- Add application type to getAll method via app_type parameter and app_type constants.
- Change apiClient fluent methods to explicit.
- Add validation for required 'name' parameter in create method.
- Add docblocks throughout Clients.
- Add additional testing for Clients and BasicCrudTest.