### PR TITLE
Adding API scopes to docblocks for Clients, Connections, and Email Tpls

### DIFF
--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -16,6 +16,9 @@ class Clients extends GenericResource
 {
     /**
      * Get all Clients by page.
+     * Required scopes:
+     *      - "read:clients" - For any call to this endpoint.
+     *      - "read:client_keys" - To retrieve "client_secret" and "encryption_key" attributes.
      *
      * @param null|string|array $fields         - Fields to include or exclude from the result.
      * @param null|boolean      $include_fields - True to include $fields, false to exclude $fields.
@@ -58,6 +61,9 @@ class Clients extends GenericResource
 
     /**
      * Get a single Client by ID.
+     * Required scopes:
+     *      - "read:clients" - For any call to this endpoint.
+     *      - "read:client_keys" - To retrieve "client_secret" and "encryption_key" attributes.
      *
      * @param string            $client_id      - Client ID to get.
      * @param null|string|array $fields         - Fields to include or exclude, based on $include_fields parameter.
@@ -89,6 +95,7 @@ class Clients extends GenericResource
 
     /**
      * Delete a Client by ID.
+     * Required scope: "delete:clients"
      *
      * @param string $client_id - Client ID to delete.
      *
@@ -107,6 +114,7 @@ class Clients extends GenericResource
 
     /**
      * Create a new Client.
+     * Required scope: "create:clients"
      *
      * @param array $data - Client create data; "name" field is required.
      *
@@ -130,6 +138,9 @@ class Clients extends GenericResource
 
     /**
      * Update a Client.
+     * Required scopes:
+     *      - "update:clients" - For any call to this endpoint.
+     *      - "update:client_keys" - To update "client_secret" and "encryption_key" attributes.
      *
      * @param string $client_id - Client ID to update.
      * @param array $data - Client data to update.

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -16,6 +16,7 @@ class Connections extends GenericResource
 {
     /**
      * Get all Connections by page.
+     * Required scope: "read:connections"
      *
      * @param null|string $strategy        - Connection strategy to retrieve.
      * @param null|string|array $fields    - Fields to include or exclude from the result, empty to retrieve all fields.
@@ -70,6 +71,7 @@ class Connections extends GenericResource
 
     /**
      * Get a single Connection by ID.
+     * Required scope: "read:connections"
      *
      * @param string $id - Connection ID to get.
      * @param null|string|array $fields - Fields to include or exclude from the result, empty to retrieve all fields.
@@ -101,6 +103,7 @@ class Connections extends GenericResource
 
     /**
      * Delete a Connection by ID.
+     * Required scope: "delete:connections"
      *
      * @param string $id - Connection ID to delete.
      *
@@ -119,6 +122,7 @@ class Connections extends GenericResource
 
     /**
      * Delete a specific User for a Connection.
+     * Required scope: "delete:users"
      *
      * @param string $id - Auth0 database Connection ID (user_id with strategy of "auth0").
      * @param string $email - Email of the user to delete.
@@ -140,6 +144,7 @@ class Connections extends GenericResource
 
     /**
      * Create a new Connection.
+     * Required scope: "create:connections"
      *
      * @param array $data - Connection create data; "name" and "strategy" fields are required.
      *
@@ -167,6 +172,7 @@ class Connections extends GenericResource
 
     /**
      * Update a Connection.
+     * Required scope: "update:connections"
      *
      * @param string $id - Connection ID to update.
      * @param array $data - Connection data to update.

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -62,7 +62,7 @@ class EmailTemplates extends GenericResource
     /**
      * Get an email template by name.
      * See docs @link below for valid names and fields.
-     * Requires scope: read:email_templates.
+     * Required scope: "read:email_templates"
      *
      * @param string $templateName - the email template name to get (see constants defined for this class).
      *
@@ -83,7 +83,7 @@ class EmailTemplates extends GenericResource
      * Patch an email template by name.
      * This will update only the email template data fields provided (see HTTP PATCH).
      * See docs @link below for valid names, fields, and possible responses.
-     * Requires scope: update:email_templates.
+     * Required scope: "update:email_templates"
      *
      * @param string $templateName - the email template name to patch (see constants defined for this class).
      * @param array $data - an array of data to update.
@@ -105,7 +105,7 @@ class EmailTemplates extends GenericResource
     /**
      * Create an email template by name.
      * See docs @link below for valid names and fields.
-     * Requires scope: create:email_templates.
+     * Required scope: "create:email_templates"
      *
      * @param string $template - the template name to create (see constants defined for this class).
      * @param boolean $enabled - is the email template enabled?


### PR DESCRIPTION
Follows the example of the Users endpoint, Docs only. 