### PR TITLE
Deprecate Auth0\SDK\API\Oauth2Client class

### DIFF
--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -10,6 +10,8 @@ use OAuth2\Client;
 
 /**
  * This class provides access to Auth0 Platform.
+ *
+ * @deprecated - Deprecated in 5.2.1; use \Auth0\SDK\Auth0 instead.
  */
 class Oauth2Client
 {
@@ -126,6 +128,8 @@ class Oauth2Client
 
     /**
      * BaseAuth0 Constructor.
+     *
+     * @deprecated - Deprecated in 5.2.1; use \Auth0\SDK\Auth0 instead.
      *
      * Configuration:
      *     - domain (String) - Required. Should match your Auth0 domain


### PR DESCRIPTION
This class was replaced with `Auth0\SDK\Auth0` a while back so it's not being used anywhere in the library. Also, `OAuth2\Client` it relied on is not included in the Composer requires so it's not even able to initialize. 