### PR TITLE
Adding pagination, tests, + docs to Client Grants; minor test suite refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   "scripts": {
     "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit  --colors=always --verbose ",
     "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml",
-    "phpcs": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s",
+    "phpcs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s .",
+    "phpcs-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s",
     "phpcbf": "./vendor/bin/phpcbf --standard=phpcs-ruleset.xml .",
     "phpcbf-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcbf --standard=phpcs-ruleset.xml",
     "sniffs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -e"

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -61,10 +61,12 @@
         <exclude name="Squiz.Commenting.FileComment"/>
         <exclude name="Squiz.Commenting.LongConditionClosingComment"/>
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
     </rule>
     <rule ref="Squiz.ControlStructures"/>
     <rule ref="Squiz.Functions">
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>
+        <exclude name="Squiz.ControlStructures.InlineIfDeclaration.NoBrackets"/>
     </rule>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
         <properties>
@@ -75,7 +77,10 @@
         <exclude name="Squiz.Operators.ComparisonOperatorUsage.NotAllowed"/>
         <exclude name="Squiz.Operators.ComparisonOperatorUsage.ImplicitTrue"/>
     </rule>
-    <rule ref="Squiz.PHP"/>
+    <rule ref="Squiz.PHP">
+        <exclude name="Squiz.PHP.DisallowComparisonAssignment.AssignedComparison"/>
+        <exclude name="Squiz.PHP.DisallowInlineIf.Found"/>
+    </rule>
     <rule ref="Squiz.Scope"/>
     <rule ref="Squiz.Strings"/>
     <rule ref="Squiz.WhiteSpace">

--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -2,75 +2,193 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
+use Auth0\SDK\Exception\CoreException;
 
+/**
+ * Class ClientGrants.
+ * Handles requests to the Client Grants endpoint of the v2 Management API.
+ *
+ * @package Auth0\SDK\API\Management
+ */
 class ClientGrants extends GenericResource
 {
+
     /**
+     * Get all Client Grants, by page if desired.
+     * Required scope: "read:client_grants"
      *
-     * @param  string      $id
-     * @param  null|string $audience
+     * @param array        $params   Additional URL parameters to send:
+     *      - "audience" to filter be a specific API audience identifier.
+     *      - "client_id" to return an object.
+     *      - "include_totals" to return an object.
+     * @param null|integer $page     The page number, zero based.
+     * @param null|integer $per_page The amount of entries per page.
+     *
      * @return mixed
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
+     */
+    public function getAll(array $params = [], $page = null, $per_page = null)
+    {
+        if (null !== $page) {
+            $params['page'] = abs(intval($page));
+        }
+
+        if (null !== $per_page) {
+            $params['per_page'] = abs(intval($per_page));
+        }
+
+        return $this->apiClient->method('get')
+            ->addPath('client-grants')
+            ->withDictParams($params)
+            ->call();
+    }
+
+    /**
+     * Get Client Grants by audience.
+     * Required scope: "read:client_grants"
+     *
+     * @param string       $audience API Audience to filter by.
+     * @param null|integer $page     The page number, zero based.
+     * @param null|integer $per_page The amount of entries per page.
+     *
+     * @return mixed
+     *
+     * @throws CoreException Thrown when $audience is empty or not a string.
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
+     */
+    public function getByAudience($audience, $page = null, $per_page = null)
+    {
+        if (empty($audience) || ! is_string($audience)) {
+            throw new CoreException('Empty or invalid "audience" parameter.');
+        }
+
+        return $this->getAll(['audience' => $audience], $page, $per_page);
+    }
+
+    /**
+     * Get Client Grants by Client ID.
+     * Required scope: "read:client_grants"
+     *
+     * @param string       $client_id Client ID to filter by.
+     * @param null|integer $page      The page number, zero based.
+     * @param null|integer $per_page  The amount of entries per page.
+     *
+     * @return mixed
+     *
+     * @throws CoreException Thrown when $client_id is empty or not a string.
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
+     */
+    public function getByClientId($client_id, $page = null, $per_page = null)
+    {
+        if (empty($client_id) || ! is_string($client_id)) {
+            throw new CoreException('Empty or invalid "client_id" parameter.');
+        }
+
+        return $this->getAll(['client_id' => $client_id], $page, $per_page);
+    }
+
+    /**
+     * Create a new Client Grant.
+     * Required scope: "create:client_grants"
+     *
+     * @param string $client_id Client ID to receive the grant.
+     * @param string $audience  Audience identifier for the API being granted.
+     * @param array  $scope     Array of scopes for the grant.
+     *
+     * @return mixed
+     *
+     * @throws CoreException Thrown when $client_id or $audience are empty or not a string.
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants
+     */
+    public function create($client_id, $audience, array $scope = [])
+    {
+        if (empty($client_id) || ! is_string($client_id)) {
+            throw new CoreException('Empty or invalid "client_id" parameter.');
+        }
+
+        if (empty($audience) || ! is_string($audience)) {
+            throw new CoreException('Empty or invalid "audience" parameter.');
+        }
+
+        return $this->apiClient->method('post')
+            ->addPath('client-grants')
+            ->withBody(json_encode([
+                'client_id' => $client_id,
+                'audience' => $audience,
+                'scope' => $scope,
+            ]))
+            ->call();
+    }
+
+    /**
+     * Delete a Client Grant by ID.
+     * Required scope: "delete:client_grants"
+     *
+     * @param string $id Client Grant ID to delete.
+     *
+     * @return mixed
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/delete_client_grants_by_id
+     */
+    public function delete($id)
+    {
+        return $this->apiClient->method('delete')
+            ->addPath('client-grants', $id)
+            ->call();
+    }
+
+    /**
+     * Update an existing Client Grant.
+     * Required scope: "update:client_grants"
+     *
+     * @param string $id    Client Grant ID to update.
+     * @param array  $scope Array of scopes to update; will replace existing scopes, not merge.
+     *
+     * @return mixed
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/patch_client_grants_by_id
+     */
+    public function update($id, array $scope)
+    {
+        return $this->apiClient->method('patch')
+            ->addPath('client-grants', $id)
+            ->withBody(json_encode(['scope' => $scope,]))
+            ->call();
+    }
+
+    /**
+     * Get a Client Grant.
+     * TODO: Deprecate, cannot get a Client Grant by ID.
+     *
+     * @param string      $id       Client Grant ID.
+     * @param null|string $audience Client Grant audience to filter by.
+     *
+     * @return mixed
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
      */
     public function get($id, $audience = null)
     {
         $request = $this->apiClient->get()
-        ->addPath('client-grants');
+            ->addPath('client-grants');
 
         if ($audience !== null) {
             $request = $request->withParam('audience', $audience);
         }
 
         return $request->call();
-    }
-
-    /**
-     *
-     * @param  string $client_id
-     * @param  string $audience
-     * @param  string $scope
-     * @return mixed
-     */
-    public function create($client_id, $audience, $scope)
-    {
-        return $this->apiClient->post()
-        ->addPath('client-grants')
-        ->withHeader(new ContentType('application/json'))
-        ->withBody(json_encode([
-            'client_id' => $client_id,
-            'audience' => $audience,
-            'scope' => $scope,
-        ]))
-        ->call();
-    }
-
-    /**
-     *
-     * @param  string      $id
-     * @param  null|string $audience
-     * @return mixed
-     */
-    public function delete($id, $audience = null)
-    {
-        return $this->apiClient->delete()
-        ->addPath('client-grants', $id)
-        ->call();
-    }
-
-    /**
-     *
-     * @param  string $id
-     * @param  string $scope
-     * @return mixed
-     */
-    public function update($id, $scope)
-    {
-        return $this->apiClient->patch()
-        ->addPath('client-grants', $id)
-        ->withHeader(new ContentType('application/json'))
-        ->withBody(json_encode([
-            'scope' => $scope,
-        ]))
-        ->call();
     }
 }

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -2,10 +2,17 @@
 namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Helpers\TokenGenerator;
+use Auth0\SDK\API\Management;
 use josegonzalez\Dotenv\Loader;
 
 class ApiTests extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     *
+     * @var array
+     */
+    protected static $env = [];
 
     protected function getEnv()
     {
@@ -45,5 +52,34 @@ class ApiTests extends \PHPUnit_Framework_TestCase
             ]
         );
         return $generator->generate($scopes);
+    }
+
+    /**
+     * Return an API client used during self::setUpBeforeClass().
+     *
+     * @param string $endpoint Endpoint name used for token generation.
+     * @param array  $actions  Actions required for token generation.
+     *
+     * @return mixed
+     */
+    protected static function getApiStatic($endpoint, array $actions)
+    {
+        self::$env  = self::getEnvStatic();
+        $token      = self::getTokenStatic(self::$env, [$endpoint => ['actions' => $actions]]);
+        $api_client = new Management($token, self::$env['DOMAIN']);
+        return $api_client->$endpoint;
+    }
+
+    /**
+     * Does an error message contain a specific string?
+     *
+     * @param \Exception $e   - Error object.
+     * @param string     $str - String to find in the error message.
+     *
+     * @return boolean
+     */
+    protected function errorHasString(\Exception $e, $str)
+    {
+        return ! (false === strpos($e->getMessage(), $str));
     }
 }

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -13,13 +13,6 @@ abstract class BasicCrudTest extends ApiTests
     protected $domain;
 
     /**
-     * Environment variables, generated in self::__construct().
-     *
-     * @var array
-     */
-    protected $env;
-
-    /**
      * API client to test.
      *
      * @var mixed
@@ -93,8 +86,8 @@ abstract class BasicCrudTest extends ApiTests
     public function __construct()
     {
         parent::__construct();
-        $this->env    = $this->getEnv();
-        $this->domain = $this->env['DOMAIN'];
+        self::$env    = $this->getEnv();
+        $this->domain = self::$env['DOMAIN'];
         $this->api    = $this->getApiClient();
         $this->rand   = rand();
     }
@@ -120,19 +113,6 @@ abstract class BasicCrudTest extends ApiTests
     protected function getId($entity)
     {
         return $entity[$this->id_name];
-    }
-
-    /**
-     * Does an error message contain a specific string?
-     *
-     * @param \Exception $e   - Error object.
-     * @param string     $str - String to find in the error message.
-     *
-     * @return boolean
-     */
-    protected function errorHasString(\Exception $e, $str)
-    {
-        return ! (false === strpos($e->getMessage(), $str));
     }
 
     /**

--- a/tests/API/Management/AuthApiTest.php
+++ b/tests/API/Management/AuthApiTest.php
@@ -59,7 +59,7 @@ class AuthApiTest extends ApiTests
 
         $token = $api->client_credentials(
             [
-                'audience' => 'tests'
+                'audience' => 'https://'.$env['DOMAIN'].'/api/v2/'
             ]
         );
 

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Auth0\Tests\API;
+
+use Auth0\SDK\API\Management;
+use Auth0\SDK\Exception\CoreException;
+
+/**
+ * Class ClientGrantsTest.
+ * Tests the Auth0\SDK\API\Management\ClientGrants class.
+ *
+ * @package Auth0\Tests\API
+ */
+class ClientGrantsTest extends ApiTests
+{
+
+    /**
+     * Existing test API audience identifier.
+     */
+    const TESTS_API_AUDIENCE = 'tests';
+
+    /**
+     * Client Grants API client.
+     *
+     * @var Management\ClientGrants
+     */
+    protected static $api;
+
+    /**
+     * Valid test scopes for the "tests" API.
+     * Used for testing create and update.
+     *
+     * @var array
+     */
+    protected static $scopes = ['test:scope1', 'test:scope2'];
+
+    /**
+     * Sets up API client for the testing class.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$api = self::getApiStatic( 'client_grants', ['read', 'create', 'delete', 'update'] );
+    }
+
+    /**
+     * Test that get methods work as expected.
+     *
+     * @return void
+     *
+     * @throws CoreException Thrown when there is a problem with parameters passed to the method.
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     */
+    public function testGet()
+    {
+        $all_results = self::$api->getAll();
+        $this->assertNotEmpty($all_results);
+
+        $expected_client_id = $all_results[0]['client_id'] ?: null;
+        $this->assertNotNull($expected_client_id);
+
+        $expected_audience = $all_results[0]['audience'] ?: null;
+        $this->assertNotNull($expected_audience);
+
+        $audience_results = self::$api->getByAudience($expected_audience);
+        $this->assertNotEmpty($audience_results);
+        $this->assertEquals($expected_audience, $audience_results[0]['audience']);
+
+        $client_id_results = self::$api->getByClientId($expected_client_id);
+        $this->assertNotEmpty($client_id_results);
+        $this->assertEquals($expected_client_id, $client_id_results[0]['client_id']);
+    }
+
+    /**
+     * Test that pagination parameters are passed to the endpoint.
+     *
+     * @return void
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     */
+    public function testGetWithPagination()
+    {
+        $expected_count = 2;
+
+        $results_1 = self::$api->getAll([], 0, $expected_count);
+        $this->assertCount($expected_count, $results_1);
+
+        $expected_page = 1;
+        $results_2     = self::$api->getAll([], $expected_page, 1);
+        $this->assertCount(1, $results_2);
+        $this->assertEquals($results_1[$expected_page]['client_id'], $results_2[0]['client_id']);
+        $this->assertEquals($results_1[$expected_page]['audience'], $results_2[0]['audience']);
+    }
+
+    /**
+     * Test that the "include_totals" parameter works.
+     *
+     * @return void
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     */
+    public function testGetAllIncludeTotals()
+    {
+        $expected_page  = 1;
+        $expected_count = 2;
+
+        $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);
+        $this->assertArrayHasKey('total', $results);
+        $this->assertEquals($expected_page * $expected_count, $results['start']);
+        $this->assertEquals($expected_count, $results['limit']);
+        $this->assertNotEmpty($results['client_grants']);
+    }
+
+    /**
+     * Test that we can create, update, and delete a Client Grant.
+     *
+     * @return void
+     *
+     * @throws CoreException Thrown when there is a problem with parameters passed to the method.
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     */
+    public function testCreateUpdateDeleteGrant()
+    {
+        $client_id = self::$env['APP_CLIENT_ID'];
+        $audience  = self::TESTS_API_AUDIENCE;
+
+        // Create a Client Grant with just one of the testing scopes.
+        $create_result = self::$api->create($client_id, $audience, [self::$scopes[0]]);
+        $this->assertArrayHasKey('id', $create_result);
+        $this->assertEquals($client_id, $create_result['client_id']);
+        $this->assertEquals($audience, $create_result['audience']);
+        $this->assertEquals([self::$scopes[0]], $create_result['scope']);
+
+        $grant_id = $create_result['id'];
+
+        // Test patching the created Client Grant.
+        $update_result = self::$api->update($grant_id, self::$scopes);
+        $this->assertEquals(self::$scopes, $update_result['scope']);
+
+        // Test deleting the created Client Grant.
+        $delete_result = self::$api->delete($grant_id);
+        $this->assertNull($delete_result);
+    }
+
+    /**
+     * Test that create method throws errors correctly.
+     *
+     * @return void
+     *
+     * @throws \Exception Thrown by the Guzzle HTTP client when there is a problem with the API call.
+     */
+    public function testCreateGrantExceptions()
+    {
+        $throws_missing_client_id_exception = false;
+        try {
+            self::$api->create('', self::TESTS_API_AUDIENCE, []);
+        } catch (CoreException $e) {
+            $throws_missing_client_id_exception = $this->errorHasString($e, 'Empty or invalid "client_id" parameter');
+        }
+
+        $this->assertTrue($throws_missing_client_id_exception);
+
+        $throws_missing_audience_exception = false;
+        try {
+            self::$api->create(self::$env['APP_CLIENT_ID'], '', []);
+        } catch (CoreException $e) {
+            $throws_missing_audience_exception = $this->errorHasString($e, 'Empty or invalid "audience" parameter');
+        }
+
+        $this->assertTrue($throws_missing_audience_exception);
+    }
+}

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -26,7 +26,7 @@ class ClientsTest extends BasicCrudTest
      */
     protected function getApiClient()
     {
-        $token = $this->getToken($this->env, [ 'clients' => [ 'actions' => ['create', 'read', 'delete', 'update' ] ] ]);
+        $token = $this->getToken(self::$env, [ 'clients' => [ 'actions' => ['create', 'read', 'delete', 'update' ] ] ]);
         $api   = new Management($token, $this->domain);
         return $api->clients;
     }

--- a/tests/API/Management/ConnectionsTest.php
+++ b/tests/API/Management/ConnectionsTest.php
@@ -27,7 +27,7 @@ class ConnectionsTest extends BasicCrudTest
     protected function getApiClient()
     {
         $token = $this->getToken(
-            $this->env, [
+            self::$env, [
                 'connections' => ['actions' => ['create', 'read', 'delete', 'update']],
                 'users' => ['actions' => ['delete']],
             ]

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -65,7 +65,7 @@ class LogsTest extends ApiTests
     public function testLogSearchPagination()
     {
         $expected_count = 5;
-        $search_results= self::$api->search([
+        $search_results = self::$api->search([
             // Fields here to speed up API call.
             'fields' => '_id,log_id',
             'include_fields' => true,

--- a/tests/API/Management/UsersTest.php
+++ b/tests/API/Management/UsersTest.php
@@ -40,7 +40,7 @@ class UsersTest extends BasicCrudTest
      */
     protected function getApiClient()
     {
-        $token = $this->getToken($this->env, ['users' => ['actions' => ['create', 'read', 'delete', 'update']]]);
+        $token = $this->getToken(self::$env, ['users' => ['actions' => ['create', 'read', 'delete', 'update']]]);
         $api   = new Management($token, $this->domain);
         return $api->users;
     }


### PR DESCRIPTION
- Add public `getAll` method with pagination parameters
- Add public `getByAudience` method to filter by audience
- Add public `getByClientId` method to filter by client ID
- Add `CoreException` throws to `create` if required params are empty or invalid
- Add comment to deprecate `get` method (cannot get a Client Grant by ID so the method is useless)
- Add test coverage
- Minor changes to code quality scanning
- Add test helper `getApiStatic` (will propagate throughout testing code base in different PR)