### PR TITLE
Add pagination, docs, and better tests for Rules

### DIFF
--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -78,7 +78,7 @@ class Rules extends GenericResource
     public function get($id, $fields = null, $include_fields = null)
     {
         if (empty($id) || ! is_string($id)) {
-            throw new CoreException('Empty or invalid "id" parameter.');
+            throw new CoreException('Invalid "id" parameter.');
         }
 
         $params = [];
@@ -113,7 +113,7 @@ class Rules extends GenericResource
     public function delete($id)
     {
         if (empty($id) || ! is_string($id)) {
-            throw new CoreException('Empty or invalid "id" parameter.');
+            throw new CoreException('Invalid "id" parameter.');
         }
 
         return $this->apiClient->method('delete')
@@ -166,11 +166,7 @@ class Rules extends GenericResource
     public function update($id, array $data)
     {
         if (empty($id) || ! is_string($id)) {
-            throw new CoreException('Empty or invalid "id" parameter.');
-        }
-
-        if (empty($data)) {
-            throw new CoreException('Empty "data" parameter; nothing to do.');
+            throw new CoreException('Invalid "id" parameter.');
         }
 
         return $this->apiClient->method('patch')

--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -2,107 +2,179 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
+use Auth0\SDK\Exception\CoreException;
 
+/**
+ * Class Rules.
+ * Handles requests to the Rules endpoint of the v2 Management API.
+ *
+ * @package Auth0\SDK\API\Management
+ */
 class Rules extends GenericResource
 {
     /**
+     * Get all Rules, by page if desired.
+     * Required scope: "read:rules"
      *
-     * @param  null|string       $enabled
-     * @param  null|string|array $fields
-     * @param  null|string|array $include_fields
+     * @param null|boolean      $enabled        Retrieves rules that match the value, otherwise all rules are retrieved.
+     * @param null|string|array $fields         Fields to include or exclude from the result.
+     * @param null|boolean      $include_fields True to include $fields, false to exclude $fields.
+     * @param null|integer      $page           Page number to get, zero-based.
+     * @param null|integer      $per_page       Number of results to get, null to return the default number.
+     *
      * @return mixed
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Rules/get_rules
      */
-    public function getAll($enabled = null, $fields = null, $include_fields = null)
+    public function getAll($enabled = null, $fields = null, $include_fields = null, $page = null, $per_page = null)
     {
-        $request = $this->apiClient->get()
-            ->rules();
+        $params = [];
 
+        // Only return enabled Rules.
         if ($enabled !== null) {
-            $request->withParam('enabled', $enabled);
+            $params['enabled'] = (bool) $enabled;
         }
 
-        if ($fields !== null) {
-            if (is_array($fields)) {
-                $fields = implode(',', $fields);
+        // Fields to include or exclude from results.
+        if (! empty($fields)) {
+            $params['fields'] = is_array($fields) ? implode(',', $fields) : $fields;
+            if (null !== $include_fields) {
+                $params['include_fields'] = $include_fields;
             }
-
-            $request->withParam('fields', $fields);
         }
 
-        if ($include_fields !== null) {
-            $request->withParam('include_fields', $include_fields);
+        // Pagination parameters.
+        if (null !== $page) {
+            $params['page'] = abs(intval($page));
         }
 
-        return $request->call();
-    }
-
-    /**
-     *
-     * @param  string            $id
-     * @param  null|string|array $fields
-     * @param  null|string|array $include_fields
-     * @return mixed
-     */
-    public function get($id, $fields = null, $include_fields = null)
-    {
-        $request = $this->apiClient->get()
-            ->rules($id);
-
-        if ($fields !== null) {
-            if (is_array($fields)) {
-                $fields = implode(',', $fields);
-            }
-
-            $request->withParam('fields', $fields);
+        if (null !== $per_page) {
+            $params['per_page'] = abs(intval($per_page));
         }
 
-        if ($include_fields !== null) {
-            $request->withParam('include_fields', $include_fields);
-        }
-
-        $info = $request->call();
-
-        return $info;
-    }
-
-    /**
-     *
-     * @param  string $id
-     * @return mixed
-     */
-    public function delete($id)
-    {
-        return $this->apiClient->delete()
-            ->rules($id)
+        return $this->apiClient->method('get')
+            ->addPath('rules')
+            ->withDictParams($params)
             ->call();
     }
 
     /**
+     * Get a single rule by ID.
+     * Required scope: "read:rules"
      *
-     * @param  array $data
+     * @param string            $id             Rule ID to get.
+     * @param null|string|array $fields         Fields to include or exclude from the result.
+     * @param null|boolean      $include_fields True to include $fields, false to exclude $fields.
+     *
      * @return mixed
+     *
+     * @throws CoreException Thrown when $id is empty or not a string.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Rules/get_rules_by_id
      */
-    public function create($data)
+    public function get($id, $fields = null, $include_fields = null)
     {
-        return $this->apiClient->post()
-            ->rules()
-            ->withHeader(new ContentType('application/json'))
+        if (empty($id) || ! is_string($id)) {
+            throw new CoreException('Empty or invalid "id" parameter.');
+        }
+
+        $params = [];
+
+        // Fields to include or exclude from results.
+        if (! empty($fields)) {
+            $params['fields'] = is_array($fields) ? implode(',', $fields) : $fields;
+            if (null !== $include_fields) {
+                $params['include_fields'] = $include_fields;
+            }
+        }
+
+        return $this->apiClient->method('get')
+            ->addPath('rules', $id)
+            ->withDictParams($params)
+            ->call();
+    }
+
+    /**
+     * Delete a rule by ID.
+     * Required scope: "delete:rules"
+     *
+     * @param string $id Rule ID to delete.
+     *
+     * @return mixed
+     *
+     * @throws CoreException Thrown when $id is empty or not a string.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Rules/delete_rules_by_id
+     */
+    public function delete($id)
+    {
+        if (empty($id) || ! is_string($id)) {
+            throw new CoreException('Empty or invalid "id" parameter.');
+        }
+
+        return $this->apiClient->method('delete')
+            ->addPath('rules', $id)
+            ->call();
+    }
+
+    /**
+     * Create a new Rule.
+     * Required scope: "create:rules"
+     *
+     * @param array $data Dictionary array of keys and values to create a Rule.
+     *
+     * @return mixed
+     *
+     * @throws CoreException Thrown when required "script" or "name" fields are missing or empty.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Rules/post_rules
+     * @link https://auth0.com/docs/rules/current#create-rules-with-the-management-api
+     */
+    public function create(array $data)
+    {
+        if (empty($data['name'])) {
+            throw new CoreException('Missing required "name" field.');
+        }
+
+        if (empty($data['script'])) {
+            throw new CoreException('Missing required "script" field.');
+        }
+
+        return $this->apiClient->method('post')
+            ->addPath('rules')
             ->withBody(json_encode($data))
             ->call();
     }
 
     /**
+     * Update a Rule by ID.
+     * Required scope: "update:rules"
      *
-     * @param  string $id
-     * @param  array  $data
+     * @param string $id   Rule ID to delete.
+     * @param array  $data Rule data to update.
+     *
      * @return mixed
+     *
+     * @throws CoreException Thrown when $id is empty or not a string or if $data is empty.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      */
-    public function update($id, $data)
+    public function update($id, array $data)
     {
-        return $this->apiClient->patch()
-            ->rules($id)
-            ->withHeader(new ContentType('application/json'))
+        if (empty($id) || ! is_string($id)) {
+            throw new CoreException('Empty or invalid "id" parameter.');
+        }
+
+        if (empty($data)) {
+            throw new CoreException('Empty "data" parameter; nothing to do.');
+        }
+
+        return $this->apiClient->method('patch')
+            ->addPath('rules', $id)
             ->withBody(json_encode($data))
             ->call();
     }

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -102,7 +102,7 @@ class ClientGrantsTest extends ApiTests
      */
     public function testGetAllIncludeTotals()
     {
-        $expected_page  = 1;
+        $expected_page  = 0;
         $expected_count = 2;
 
         $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -168,9 +168,8 @@ class RulesTest extends ApiTests
         try {
             self::$api->get(null);
         } catch (CoreException $e) {
-            $caught_get_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+            $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
-
         $this->assertTrue($caught_get_no_id_exception);
 
         // Test that the delete method throws an exception if the $id parameter is empty.
@@ -178,9 +177,8 @@ class RulesTest extends ApiTests
         try {
             self::$api->delete(null);
         } catch (CoreException $e) {
-            $caught_delete_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+            $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
-
         $this->assertTrue($caught_delete_no_id_exception);
 
         // Test that the create method throws an exception if no "name" field is passed.
@@ -190,7 +188,6 @@ class RulesTest extends ApiTests
         } catch (CoreException $e) {
             $caught_create_no_name_exception = $this->errorHasString($e, 'Missing required "name" field');
         }
-
         $this->assertTrue($caught_create_no_name_exception);
 
         // Test that the create method throws an exception if no "script" field is passed.
@@ -200,7 +197,6 @@ class RulesTest extends ApiTests
         } catch (CoreException $e) {
             $caught_create_no_script_exception = $this->errorHasString($e, 'Missing required "script" field');
         }
-
         $this->assertTrue($caught_create_no_script_exception);
 
         // Test that the update method throws an exception if the $id parameter is empty.
@@ -208,19 +204,8 @@ class RulesTest extends ApiTests
         try {
             self::$api->update(null, []);
         } catch (CoreException $e) {
-            $caught_update_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+            $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
-
         $this->assertTrue($caught_update_no_id_exception);
-
-        // Test that the update method throws an exception if the $id parameter is empty.
-        $caught_update_no_data_exception = false;
-        try {
-            self::$api->update('rule_id', []);
-        } catch (CoreException $e) {
-            $caught_update_no_data_exception = $this->errorHasString($e, 'Empty "data" parameter; nothing to do');
-        }
-
-        $this->assertTrue($caught_update_no_data_exception);
     }
 }

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -1,53 +1,226 @@
 <?php
-namespace Auth0\Tests\API\Management;
+namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Management;
-use Auth0\Tests\API\BasicCrudTest;
+use Auth0\SDK\Exception\CoreException;
 
-class RulesTest extends BasicCrudTest
+/**
+ * Class RulesTest.
+ *
+ * @package Auth0\Tests\API\Management
+ */
+class RulesTest extends ApiTests
 {
 
-    protected function getApiClient()
+    /**
+     * Rules API client.
+     *
+     * @var Management\Rules
+     */
+    protected static $api;
+
+    /**
+     * Sets up API client for the testing class.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
     {
-        $env   = $this->getEnv();
-        $token = $this->getToken(
-            $env, [
-                'rules' => [
-                    'actions' => ['create', 'read', 'delete', 'update']
-                ]
-            ]
-        );
-
-        $this->domain = $env['DOMAIN'];
-
-        $api = new Management($token, $env['DOMAIN']);
-
-        return $api->rules;
+        self::$api = self::getApiStatic( 'rules', ['read', 'create', 'delete', 'update'] );
     }
 
-    protected function getCreateBody()
+    /**
+     * Test that get methods work as expected.
+     *
+     * @return void
+     *
+     * @throws CoreException Thrown when there is a problem with parameters passed to the method.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     */
+    public function testGet()
     {
-        $name = 'test-create-rule'.rand();
-        echo "\n-- Using rule name $name \n";
+        $results = self::$api->getAll();
+        $this->assertNotEmpty($results);
 
-        return [
-            'name' => $name,
-            'script' => "function (user, context, callback) {\n  callback(null, user, context);\n}",
+        // Check getting a single rule by a known ID.
+        $get_rule_id = $results[0]['id'];
+        $result      = self::$api->get($get_rule_id);
+        $this->assertNotEmpty($result);
+        $this->assertEquals($results[0]['id'], $get_rule_id);
+
+        // Iterate through the results to see if we have enabled and disabled Rules.
+        $has_enabled  = false;
+        $has_disabled = false;
+        foreach ($results as $result) {
+            if ($result['enabled']) {
+                $has_enabled = true;
+            } else {
+                $has_disabled = true;
+            }
+        }
+
+        // Check enabled rules.
+        $enabled_results = self::$api->getAll(true);
+        if ($has_enabled) {
+            $this->assertNotEmpty($enabled_results);
+        } else {
+            $this->assertEmpty($enabled_results);
+        }
+
+        // Check disabled rules.
+        $disabled_results = self::$api->getAll(false);
+        if ($has_disabled) {
+            $this->assertNotEmpty($disabled_results);
+        } else {
+            $this->assertEmpty($disabled_results);
+        }
+    }
+
+    /**
+     * Test that get methods respect fields.
+     *
+     * @return void
+     *
+     * @throws CoreException Thrown when there is a problem with parameters passed to the method.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     */
+    public function testGetWithFields()
+    {
+        $fields = ['id', 'name'];
+
+        $fields_results = self::$api->getAll(null, $fields, true);
+        $this->assertNotEmpty($fields_results);
+        $this->assertCount(count($fields), $fields_results[0]);
+
+        $get_rule_id   = $fields_results[0]['id'];
+        $fields_result = self::$api->get($get_rule_id, $fields, true);
+        $this->assertNotEmpty($fields_result);
+        $this->assertCount(count($fields), $fields_result);
+    }
+
+    /**
+     * Test that getAll method respects pagination.
+     *
+     * @return void
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     */
+    public function testGetAllPagination()
+    {
+        $paged_results = self::$api->getAll(null, null, null, 0, 2);
+        $this->assertCount(2, $paged_results);
+
+        // Second page of 1 result.
+        $paged_results_2 = self::$api->getAll(null, null, null, 1, 1);
+        $this->assertCount(1, $paged_results_2);
+        $this->assertEquals($paged_results[1]['id'], $paged_results_2[0]['id']);
+    }
+
+    /**
+     * Test that create, update, and delete methods work as expected.
+     *
+     * @return void
+     *
+     * @throws CoreException Thrown when there is a problem with parameters passed to the method.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     */
+    public function testCreateUpdateDelete()
+    {
+        $create_data = [
+            'name' => 'test-create-rule-'.rand(),
+            'script' => 'function (user, context, callback) { callback(null, user, context); }',
             'enabled' => true,
         ];
-    }
-    protected function getUpdateBody()
-    {
-        return [
+
+        $create_result = self::$api->create($create_data);
+        $this->assertNotEmpty($create_result['id']);
+        $this->assertEquals($create_data['enabled'], $create_result['enabled']);
+        $this->assertEquals($create_data['name'], $create_result['name']);
+        $this->assertEquals($create_data['script'], $create_result['script']);
+
+        $test_rule_id = $create_result['id'];
+        $update_data  = [
+            'name' => 'test-create-rule-'.rand(),
+            'script' => 'function (user, context, cb) { cb(null, user, context); }',
             'enabled' => false,
         ];
+
+        $update_result = self::$api->update($test_rule_id, $update_data);
+        $this->assertEquals($update_data['enabled'], $update_result['enabled']);
+        $this->assertEquals($update_data['name'], $update_result['name']);
+        $this->assertEquals($update_data['script'], $update_result['script']);
+
+        $delete_result = self::$api->delete($test_rule_id);
+        $this->assertNull($delete_result);
     }
-    protected function afterCreate($entity)
+
+    /**
+     * Test that exceptions are thrown for specific methods in specific cases.
+     *
+     * @return void
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     */
+    public function testExceptions()
     {
-        $this->assertTrue($entity['enabled']);
-    }
-    protected function afterUpdate($entity)
-    {
-        $this->assertNotTrue($entity['enabled']);
+        // Test that the get method throws an exception if the $id parameter is empty.
+        $caught_get_no_id_exception = false;
+        try {
+            self::$api->get(null);
+        } catch (CoreException $e) {
+            $caught_get_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+        }
+
+        $this->assertTrue($caught_get_no_id_exception);
+
+        // Test that the delete method throws an exception if the $id parameter is empty.
+        $caught_delete_no_id_exception = false;
+        try {
+            self::$api->delete(null);
+        } catch (CoreException $e) {
+            $caught_delete_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+        }
+
+        $this->assertTrue($caught_delete_no_id_exception);
+
+        // Test that the create method throws an exception if no "name" field is passed.
+        $caught_create_no_name_exception = false;
+        try {
+            self::$api->create(['script' => 'function(){}']);
+        } catch (CoreException $e) {
+            $caught_create_no_name_exception = $this->errorHasString($e, 'Missing required "name" field');
+        }
+
+        $this->assertTrue($caught_create_no_name_exception);
+
+        // Test that the create method throws an exception if no "script" field is passed.
+        $caught_create_no_script_exception = false;
+        try {
+            self::$api->create(['name' => 'test-create-rule-'.rand()]);
+        } catch (CoreException $e) {
+            $caught_create_no_script_exception = $this->errorHasString($e, 'Missing required "script" field');
+        }
+
+        $this->assertTrue($caught_create_no_script_exception);
+
+        // Test that the update method throws an exception if the $id parameter is empty.
+        $caught_update_no_id_exception = false;
+        try {
+            self::$api->update(null, []);
+        } catch (CoreException $e) {
+            $caught_update_no_id_exception = $this->errorHasString($e, 'Empty or invalid "id" parameter');
+        }
+
+        $this->assertTrue($caught_update_no_id_exception);
+
+        // Test that the update method throws an exception if the $id parameter is empty.
+        $caught_update_no_data_exception = false;
+        try {
+            self::$api->update('rule_id', []);
+        } catch (CoreException $e) {
+            $caught_update_no_data_exception = $this->errorHasString($e, 'Empty "data" parameter; nothing to do');
+        }
+
+        $this->assertTrue($caught_update_no_data_exception);
     }
 }


### PR DESCRIPTION
- Add pagination to `getAll` method in Rules
- Throw `CoreException` for missing or empty required params in `get`, `create`, `update`, and `delete`
- Rewrite tests for more isolation and better coverage