### PR TITLE
Add config keys for session base name and cookie expires

### DIFF
--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -63,8 +63,6 @@ class SessionStateHandler implements StateHandler
      * @param string $state
      *
      * @return boolean
-     *
-     * @throws \Exception
      */
     public function validate($state)
     {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -272,6 +272,9 @@ class Auth0
             $this->dontPersist('id_token');
         }
 
+        $session_base_name      = ! empty( $config['session_base_name'] ) ? $config['session_base_name'] : null;
+        $session_cookie_expires = isset( $config['session_cookie_expires'] ) ? $config['session_cookie_expires'] : null;
+
         if (isset($config['store'])) {
             if ($config['store'] === false) {
                 $emptyStore = new EmptyStore();
@@ -280,7 +283,7 @@ class Auth0
                 $this->setStore($config['store']);
             }
         } else {
-            $sessionStore = new SessionStore();
+            $sessionStore = new SessionStore($session_base_name, $session_cookie_expires);
             $this->setStore($sessionStore);
         }
 
@@ -291,7 +294,7 @@ class Auth0
                 $this->stateHandler = $config['state_handler'];
             }
         } else {
-            $stateStore         = new SessionStore();
+            $stateStore         = new SessionStore($session_base_name, $session_cookie_expires);
             $this->stateHandler = new SessionStateHandler($stateStore);
         }
 

--- a/tests/API/Helpers/State/SessionStateHandlerTest.php
+++ b/tests/API/Helpers/State/SessionStateHandlerTest.php
@@ -28,28 +28,36 @@ class SessionStateHandlerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * SessionStateHandlerTest constructor.
+     *
+     * @return void
      */
     public function __construct()
     {
         parent::__construct();
 
-        // Suppress header sent error
-        @$this->sessionStore = new SessionStore();
-        $this->stateHandler  = new SessionStateHandler($this->sessionStore);
+        $this->sessionStore = new SessionStore();
+        $this->stateHandler = new SessionStateHandler($this->sessionStore);
     }
 
     /**
      * Test that state is stored and retrieved properly.
+     *
+     * @return void
      */
     public function testStateStoredCorrectly()
     {
         $uniqid = uniqid();
-        $this->stateHandler->store($uniqid);
+
+        // Suppressing "headers already sent" warning related to cookies.
+        // phpcs:ignore
+        @$this->stateHandler->store($uniqid);
         $this->assertEquals($uniqid, $this->sessionStore->get(SessionStateHandler::STATE_NAME));
     }
 
     /**
      * Test that the state is being issued correctly.
+     *
+     * @return void
      */
     public function testStateIssuedCorrectly()
     {
@@ -60,7 +68,7 @@ class SessionStateHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * Test that state validated properly.
      *
-     * @throws \Exception
+     * @return void
      */
     public function testStateValidatesCorrectly()
     {
@@ -73,7 +81,7 @@ class SessionStateHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * Test that state validation fails with an incorrect value.
      *
-     * @throws \Exception
+     * @return void
      */
     public function testStateFailsWithIncorrectValue()
     {

--- a/tests/API/Management/AuthApiDBConnectionsTest.php
+++ b/tests/API/Management/AuthApiDBConnectionsTest.php
@@ -25,7 +25,7 @@ class AuthApiDBConnectionsTest extends ApiTests
         $api = new Authentication($env['DOMAIN'], $env['APP_CLIENT_ID']);
 
         $email      = $this->email;
-        $password   = '123-xxx-23A-bar';
+        $password   = 'Bqn8LEsu68p38TmFvsWW';
         $connection = $this->connection;
 
         $response = $api->dbconnections_signup($email, $password, $connection);


### PR DESCRIPTION
This PR adds the ability to change the base name for the session key as well as the session cookie expires:

- Add a `session_base_name` key to the config array passed when instantiating `Auth0` to change the session key base name used. 
- Add a `session_cookie_expires` key to the config array passed when instantiating `Auth0` to change the session cookie expires time. Cannot remove that from the default or else session cookies would be shorter than expected for anyone using the default. 
- Moved the `SessionStore::initSession()` call out of the `SessionStore` constructor so it happens later in the execution, allowing for apps that start their own sessions to do that more easily. 

Closes #215
Closes #273
