### PR TITLE
Add ID token validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,7 @@
     "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit --colors=always --coverage-text",
     "test-ci": "vendor/bin/phpunit --colors=always --coverage-clover=build/coverage.xml",
     "phpcs": "\"vendor/bin/phpcs\"",
-    "phpcs-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs",
     "phpcbf": "\"vendor/bin/phpcbf\"",
-    "phpcbf-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcbf",
     "sniffs": "\"vendor/bin/phpcs\" -e",
     "config-phpcs": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
   }

--- a/src/API/Helpers/TokenGenerator.php
+++ b/src/API/Helpers/TokenGenerator.php
@@ -1,4 +1,5 @@
-<?php namespace Auth0\SDK\API\Helpers;
+<?php
+namespace Auth0\SDK\API\Helpers;
 
 use Firebase\JWT\JWT;
 
@@ -16,36 +17,36 @@ class TokenGenerator
     const DEFAULT_LIFETIME = 3600;
 
     /**
-     * Client ID for the token.
+     * Audience for the ID token.
      *
      * @var string
      */
-    protected $client_id;
+    protected $audience;
 
     /**
-     * Client Secret for the token.
+     * Secret used to encode the token.
      *
      * @var string
      */
-    protected $client_secret;
+    protected $secret;
 
     /**
      * TokenGenerator constructor.
      *
-     * @param string $client_id     Client ID to use.
-     * @param string $client_secret Client Secret to use.
+     * @param string $audience ID token audience to set.
+     * @param string $secret   Token encryption secret to encode the token.
      */
-    public function __construct($client_id, $client_secret)
+    public function __construct($audience, $secret)
     {
-        $this->client_id     = $client_id;
-        $this->client_secret = $client_secret;
+        $this->audience = $audience;
+        $this->secret   = $secret;
     }
 
     /**
      * Create the ID token.
      *
      * @param array   $scopes         Array of scopes to include.
-     * @param integer $lifetime       Lifetime of the token.
+     * @param integer $lifetime       Lifetime of the token, in seconds.
      * @param boolean $secret_encoded True to base64 decode the client secret.
      *
      * @return string
@@ -57,11 +58,11 @@ class TokenGenerator
             'iat' => $time,
             'scopes' => $scopes,
             'exp' => $time + $lifetime,
-            'aud' => $this->client_id,
+            'aud' => $this->audience,
         ];
         $payload['jti'] = md5(json_encode($payload));
 
-        $secret = $secret_encoded ? base64_decode(strtr($this->client_secret, '-_', '+/')) : $this->client_secret;
+        $secret = $secret_encoded ? base64_decode(strtr($this->secret, '-_', '+/')) : $this->secret;
 
         return JWT::encode($payload, $secret);
     }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -73,7 +73,8 @@ class Auth0
     protected $clientSecret;
 
     /**
-     * Is the Auth0 Client Secret encoded?
+     * True if the client secret is base64 encoded, false if not.
+     * This information can be found in your Auth0 Application settings below the Client Secret field.
      *
      * @var boolean
      */
@@ -182,7 +183,8 @@ class Auth0
     protected $guzzleOptions;
 
     /**
-     * Algorithm to use for ID token validation.
+     * Algorithm used for ID token validation.
+     * Can be "HS256" or "RS256" only.
      *
      * @var string
      */
@@ -609,7 +611,7 @@ class Auth0
     }
 
     /**
-     * Sets and persists the ID token.
+     * Sets, validates, and persists the ID token.
      *
      * @param string $idToken - ID token returned from the code exchange.
      *

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -23,7 +23,7 @@ class JWTVerifier
      *
      * @var JWKFetcher|null
      */
-    protected $jwks_fetcher = null;
+    protected $JWKFetcher = null;
 
     /**
      * Algorithms supported.
@@ -87,8 +87,8 @@ class JWTVerifier
         $guzzleOptions = [];
 
         // Allow for dependency injection of a JWKFetcher object.
-        $this->jwks_fetcher = $jwkFetcher;
-        if (! $this->jwks_fetcher instanceof JWKFetcher) {
+        $this->JWKFetcher = $jwkFetcher;
+        if (! $this->JWKFetcher instanceof JWKFetcher) {
             // CacheHandler implementation to be used in JWKFetcher.
             if (isset($config['cache']) && $config['cache'] instanceof CacheHandler) {
                 $cache = $config['cache'];
@@ -99,7 +99,7 @@ class JWTVerifier
                 $guzzleOptions = $config['guzzle_options'];
             }
 
-            $this->jwks_fetcher = new JWKFetcher($cache, $guzzleOptions);
+            $this->JWKFetcher = new JWKFetcher($cache, $guzzleOptions);
         }
 
         // JWKS path to use; see variable declaration above for default.
@@ -217,7 +217,7 @@ class JWTVerifier
             }
 
             $jwks_url                   = $body_decoded->iss.$this->jwks_path;
-            $secret[$head_decoded->kid] = $this->jwks_fetcher->requestJwkX5c($jwks_url, $head_decoded->kid);
+            $secret[$head_decoded->kid] = $this->JWKFetcher->requestJwkX5c($jwks_url, $head_decoded->kid);
         }
 
         try {

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -1,12 +1,14 @@
 <?php
 namespace Auth0\Tests\API;
 
+use Auth0\Tests\Traits\ErrorHelpers;
 use Auth0\SDK\API\Helpers\TokenGenerator;
 use Auth0\SDK\API\Management;
 use josegonzalez\Dotenv\Loader;
 
 class ApiTests extends \PHPUnit_Framework_TestCase
 {
+    use ErrorHelpers;
 
     /**
      *
@@ -45,12 +47,7 @@ class ApiTests extends \PHPUnit_Framework_TestCase
 
     protected static function getTokenStatic($env, $scopes)
     {
-        $generator = new TokenGenerator(
-            [
-                'client_id' => $env['GLOBAL_CLIENT_ID'],
-                'client_secret' => $env['GLOBAL_CLIENT_SECRET']
-            ]
-        );
+        $generator = new TokenGenerator( $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET'] );
         return $generator->generate($scopes);
     }
 
@@ -68,18 +65,5 @@ class ApiTests extends \PHPUnit_Framework_TestCase
         $token      = self::getTokenStatic(self::$env, [$endpoint => ['actions' => $actions]]);
         $api_client = new Management($token, self::$env['DOMAIN']);
         return $api_client->$endpoint;
-    }
-
-    /**
-     * Does an error message contain a specific string?
-     *
-     * @param \Exception $e   - Error object.
-     * @param string     $str - String to find in the error message.
-     *
-     * @return boolean
-     */
-    protected function errorHasString(\Exception $e, $str)
-    {
-        return ! (false === strpos($e->getMessage(), $str));
     }
 }

--- a/tests/API/Helpers/TokenTest.php
+++ b/tests/API/Helpers/TokenTest.php
@@ -4,100 +4,434 @@ namespace Auth0\Tests\Api\Helpers;
 use Auth0\SDK\API\Helpers\TokenGenerator;
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Auth0JWT;
+use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Exception\InvalidTokenException;
+use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\SDK\Helpers\JWKFetcher;
+use Firebase\JWT\JWT;
 
+/**
+ * Class TokenTest
+ *
+ * @package Auth0\Tests\Api\Helpers
+ */
 class TokenTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testTokenGenerationDecode()
+    use ErrorHelpers;
+
+    /**
+     * Default Client ID.
+     */
+    const CLIENT_ID = '__test_client_id__';
+
+    /**
+     * Default Client Secret.
+     */
+    const CLIENT_SECRET = '__test_client_secret__';
+
+    /**
+     * Test legacy misspelling.
+     *
+     * @return void
+     */
+    public function testThatSuportedAlgsThrowsException()
     {
-        $client_id     = 'client_id_1';
-        $client_secret = 'client_secret_1';
+        $caught_exception = false;
+        try {
+            new JWTVerifier( [ 'suported_algs' => uniqid() ] );
+        } catch (CoreException $e) {
+            $caught_exception = $this->errorHasString( $e, '`suported_algs` was properly renamed to `supported_algs`' );
+        }
 
-        $generator = new TokenGenerator([ 'client_id' => $client_id, 'client_secret' => $client_secret]);
+        $this->assertTrue($caught_exception);
+    }
 
-        $jwt = $generator->generate(
-            [
-                'users' => [
-                    'actions' => ['read']
-                ]
-            ]
-        );
+    /**
+     * Test for audience config param.
+     *
+     * @return void
+     */
+    public function testThatMissingAudThrowsException()
+    {
+        $caught_exception = false;
+        try {
+            new JWTVerifier([]);
+        } catch (CoreException $e) {
+            $caught_exception = $this->errorHasString( $e, 'The audience is mandatory' );
+        }
 
-        $verifier = new JWTVerifier(
-            [
-                'valid_audiences' => [$client_id],
-                'client_secret' => $client_secret
-            ]
-        );
+        $this->assertTrue($caught_exception);
+    }
 
-        $decoded = $verifier->verifyAndDecode($jwt);
+    /**
+     * Test unsupported algorithms in the config param.
+     *
+     * @return void
+     */
+    public function testThatOtherAlgsThrowsException()
+    {
+        $caught_exception = false;
+        try {
+            new JWTVerifier( [
+                'valid_audiences' => [ uniqid() ],
+                'supported_algs' => [ 'RS256', 'RS512' ],
+            ] );
+        } catch (CoreException $e) {
+            $caught_exception = $this->errorHasString( $e, 'Cannot support the following algorithm(s): RS512' );
+        }
+
+        $this->assertTrue($caught_exception);
+    }
+
+    /**
+     * Test for missing issuer for RS256 tokens.
+     *
+     * @return void
+     */
+    public function testThatMissingIssThrowsException()
+    {
+        $caught_exception = false;
+        try {
+            new JWTVerifier( [
+                'valid_audiences' => [ uniqid() ],
+                'supported_algs' => [ 'RS256' ],
+            ] );
+        } catch (CoreException $e) {
+            $caught_exception = $this->errorHasString( $e, 'The iss is required' );
+        }
+
+        $this->assertTrue($caught_exception);
+    }
+
+    /**
+     * Test that a secret is required for an HS256 token.
+     *
+     * @return void
+     */
+    public function testThatMissingSecretThrowsException()
+    {
+        $caught_exception = false;
+        try {
+            new JWTVerifier( [
+                'valid_audiences' => [ uniqid() ],
+                'supported_algs' => [ 'HS256' ],
+            ] );
+        } catch (CoreException $e) {
+            $caught_exception = $this->errorHasString($e, 'The client_secret is required');
+        }
+
+        $this->assertTrue($caught_exception);
+    }
+
+    /**
+     * Test that a malformed token is rejected.
+     *
+     * @return void
+     *
+     * @throws CoreException See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     */
+    public function testThatTokenWithIncorrectSegmentsThrowsException()
+    {
+        $verifier = new JWTVerifier( [
+            'valid_audiences' => [ uniqid() ],
+            'supported_algs' => [ 'HS256' ],
+            'client_secret' => self::CLIENT_SECRET,
+        ] );
+
+        $caught_exception = false;
+        try {
+            $verifier->verifyAndDecode( uniqid() );
+        } catch (InvalidTokenException $e) {
+            $caught_exception = $this->errorHasString($e, 'Wrong number of segments');
+        }
+
+        $this->assertTrue($caught_exception);
+
+        $caught_exception = false;
+        try {
+            $verifier->verifyAndDecode( uniqid().'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $caught_exception = $this->errorHasString($e, 'Wrong number of segments');
+        }
+
+        $this->assertTrue($caught_exception);
+    }
+
+    /**
+     * Test that a malformed token or missing algorithm fails.
+     *
+     * @return void
+     *
+     * @throws CoreException See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     */
+    public function testThatTokenWithBadAlgThrowsException()
+    {
+        $dummy_segment = JWT::urlsafeB64Encode('{"dummy":"yes"}');
+        $verifier      = new JWTVerifier( [
+            'valid_audiences' => [ uniqid() ],
+            'supported_algs' => [ 'HS256' ],
+            'client_secret' => self::CLIENT_SECRET,
+        ] );
+
+        // 1. A token with a head that cannot be JSON decoded should throw an exception.
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( uniqid().'.'.uniqid().'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Malformed token');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 2. A token with a payload that cannot be JSON decoded should throw an exception.
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $dummy_segment.'.'.uniqid().'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Malformed token');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 3. A token without an alg property should throw an exception.
+        $head_obj = (object) [ 'typ' => 'JWT' ];
+        $jwt_head = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$dummy_segment.'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Token algorithm not found');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 4. A token with an alg not in supported_algs should throw an exception.
+        $head_obj->alg = 'RS256';
+        $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$dummy_segment.'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Token algorithm not supported');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+    }
+
+    /**
+     * Test that an invalid audience is rejected.
+     *
+     * @return void
+     *
+     * @throws CoreException See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     */
+    public function testThatTokenWithInvalidAudThrowsException()
+    {
+        $verifier = new JWTVerifier( [
+            'valid_audiences' => [ '__valid_aud__' ],
+            'supported_algs' => [ 'RS256' ],
+            'authorized_iss' => [ '__valid_iss__' ],
+        ] );
+
+        // 1. A token with an invalid audience should throw an exception.
+        $head_obj      = new \stdClass();
+        $head_obj->typ = 'JWT';
+        $head_obj->alg = 'RS256';
+        $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
+
+        $payload_obj      = new \stdClass();
+        $payload_obj->aud = '__invalid_aud__';
+        $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'This token is not intended for us');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 2. A token without a key ID should throw an exception.
+        $payload_obj->aud = '__valid_aud__';
+        $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
+        } catch (CoreException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Token key ID is missing for RS256 token');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 3. A token with an invalid issuer should throw an exception.
+        $head_obj->kid = uniqid();
+        $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
+
+        $payload_obj->iss = '__invalid_iss__';
+        $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
+        } catch (CoreException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'We cannot trust on a token issued by');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+
+        // 4. A token with an invalid signature should throw an exception.
+        $verifier = new JWTVerifier( [
+            'valid_audiences' => [ '__valid_aud__' ],
+            'client_secret' => self::CLIENT_SECRET,
+        ] );
+
+        $head_obj->alg = 'HS256';
+        $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
+
+        $payload_obj->iss = '__valid_iss__';
+        $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
+
+        $caught_exception = false;
+        $error_msg        = 'No exception caught';
+        try {
+            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
+        } catch (CoreException $e) {
+            $error_msg        = $e->getMessage();
+            $caught_exception = $this->errorHasString($e, 'Signature verification failed');
+        }
+
+        $this->assertTrue($caught_exception, $error_msg);
+    }
+
+    /**
+     * Test a successful HS256 token decoding.
+     *
+     * @return void
+     *
+     * @throws CoreException See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     * @throws InvalidTokenException See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     */
+    public function testSuccessfulHs256TokenDecoding()
+    {
+        $token_generator = new TokenGenerator( self::CLIENT_ID, self::CLIENT_SECRET );
+
+        // 1. Test that an encoded client secret can be used.
+        $verifier = new JWTVerifier( [
+            'valid_audiences' => [ self::CLIENT_ID ],
+            'client_secret' => self::CLIENT_SECRET,
+        ] );
+        $jwt      = $token_generator->generate( ['users' => ['actions' => ['read']]] );
+        $decoded  = $verifier->verifyAndDecode($jwt);
 
         $this->assertObjectHasAttribute('aud', $decoded);
-        $this->assertEquals($client_id, $decoded->aud);
+        $this->assertEquals(self::CLIENT_ID, $decoded->aud);
+        $this->assertObjectHasAttribute('scopes', $decoded);
+        $this->assertObjectHasAttribute('users', $decoded->scopes);
+        $this->assertObjectHasAttribute('actions', $decoded->scopes->users);
+        $this->assertArraySubset(['read'], $decoded->scopes->users->actions);
+
+        // 2. Test that a non-encoded client secret can be used.
+        $verifier = new JWTVerifier( [
+            'valid_audiences' => [ self::CLIENT_ID ],
+            'client_secret' => self::CLIENT_SECRET,
+            'secret_base64_encoded' => false,
+        ] );
+        $jwt      = $token_generator->generate(
+            ['users' => ['actions' => ['read']]],
+            TokenGenerator::DEFAULT_LIFETIME,
+            false
+        );
+        $decoded  = $verifier->verifyAndDecode($jwt);
+
+        $this->assertObjectHasAttribute('aud', $decoded);
+        $this->assertEquals(self::CLIENT_ID, $decoded->aud);
         $this->assertObjectHasAttribute('scopes', $decoded);
         $this->assertObjectHasAttribute('users', $decoded->scopes);
         $this->assertObjectHasAttribute('actions', $decoded->scopes->users);
         $this->assertArraySubset(['read'], $decoded->scopes->users->actions);
     }
 
-    public function testTokenWithNotEncodedSecret()
+    /**
+     * Test a successful RS256 token decoding.
+     *
+     * @return void
+     *
+     * @throws \Exception See Auth0\SDK\JWTVerifier::verifyAndDecode().
+     */
+    public function testSuccessfulRs256TokenDecoding()
     {
-        $client_id     = 'client_id_1';
-        $client_secret = 'client_secret_1';
+        // Mock the JWKFetcher object.
+        $mocked_jwks = $this
+            ->getMockBuilder( JWKFetcher::class )
+            ->setMethods( [ 'requestJwkX5c' ] )
+            ->getMock();
+        $mocked_jwks->method( 'requestJwkX5c' )->willReturn( uniqid() );
 
-        $generator = new TokenGenerator(
-            [
-                'client_id' => $client_id,
-                'client_secret' => $client_secret,
-                'secret_base64_encoded' => false
-            ]
-        );
+        // Mock the JWT object.
+        $expected_sub  = uniqid();
+        $verifier_args = [
+            'valid_audiences' => [ self::CLIENT_ID ],
+            'client_secret' => self::CLIENT_SECRET,
+            'supported_algs' => [ 'RS256' ],
+            'authorized_iss' => [ '__valid_iss__' ],
+            'jwks_path' => 'path/to/custom/jwks.json',
+        ];
+        $mocked_jwt    = $this
+            ->getMockBuilder( JWTVerifier::class )
+            ->setConstructorArgs( [ $verifier_args, $mocked_jwks ] )
+            ->setMethods( [ 'decodeToken' ] )
+            ->getMock();
+        $mocked_jwt->method( 'decodeToken' )->willReturn( (object) ['sub' => $expected_sub] );
 
-        $jwt = $generator->generate(
-            [
-                'users' => [
-                    'actions' => ['read']
-                ]
-            ]
-        );
+        $head_obj      = new \stdClass();
+        $head_obj->typ = 'JWT';
+        $head_obj->alg = 'RS256';
+        $head_obj->kid = uniqid();
+        $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
 
-        $verifier = new JWTVerifier(
-            [
-                'valid_audiences' => [$client_id],
-                'client_secret' => $client_secret,
-                'secret_base64_encoded' => false
-            ]
-        );
+        $payload_obj      = new \stdClass();
+        $payload_obj->aud = self::CLIENT_ID;
+        $payload_obj->iss = '__valid_iss__';
+        $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
 
-        $decoded = $verifier->verifyAndDecode($jwt);
+        $jwt     = $jwt_head.'.'.$jwt_payload.'.'.uniqid();
+        $decoded = $mocked_jwt->verifyAndDecode($jwt);
 
-        $this->assertObjectHasAttribute('aud', $decoded);
-        $this->assertEquals($client_id, $decoded->aud);
-        $this->assertObjectHasAttribute('scopes', $decoded);
-        $this->assertObjectHasAttribute('users', $decoded->scopes);
-        $this->assertObjectHasAttribute('actions', $decoded->scopes->users);
-        $this->assertArraySubset(['read'], $decoded->scopes->users->actions);
+        $this->assertObjectHasAttribute('sub', $decoded);
+        $this->assertEquals($expected_sub, $decoded->sub);
     }
 
+    /**
+     * Test the deprecated Auth0JWT::decode() method.
+     *
+     * @return void
+     */
     public function testDeprecatedTestTokenGenerationDecode()
     {
-        $client_id     = 'client_id_1';
-        $client_secret = 'client_secret_1';
-
-        $generator = new TokenGenerator([ 'client_id' => $client_id, 'client_secret' => $client_secret]);
-
-        $jwt = $generator->generate(
-            [
-                'users' => [
-                    'actions' => ['read']
-                ]
-            ]
-        );
-
-        $decoded = Auth0JWT::decode($jwt, $client_id, $client_secret);
-
+        $token_generator = new TokenGenerator( self::CLIENT_ID, self::CLIENT_SECRET );
+        $jwt             = $token_generator->generate(['users' => ['actions' => ['read']]]);
+        $decoded         = Auth0JWT::decode($jwt, self::CLIENT_ID, self::CLIENT_SECRET);
         $this->assertObjectHasAttribute('aud', $decoded);
-        $this->assertEquals($client_id, $decoded->aud);
+        $this->assertEquals(self::CLIENT_ID, $decoded->aud);
         $this->assertObjectHasAttribute('scopes', $decoded);
         $this->assertObjectHasAttribute('users', $decoded->scopes);
         $this->assertObjectHasAttribute('actions', $decoded->scopes->users);

--- a/tests/API/Helpers/TokenTest.php
+++ b/tests/API/Helpers/TokenTest.php
@@ -313,7 +313,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $caught_exception = false;
         $error_msg        = 'No exception caught';
         try {
-            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
+            $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.JWT::urlsafeB64Encode(uniqid()) );
         } catch (CoreException $e) {
             $error_msg        = $e->getMessage();
             $caught_exception = $this->errorHasString($e, 'Signature verification failed');

--- a/tests/API/Helpers/TokenTest.php
+++ b/tests/API/Helpers/TokenTest.php
@@ -98,7 +98,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
                 'supported_algs' => [ 'RS256' ],
             ] );
         } catch (CoreException $e) {
-            $caught_exception = $this->errorHasString( $e, 'The iss is required' );
+            $caught_exception = $this->errorHasString( $e, 'The token iss property is required' );
         }
 
         $this->assertTrue($caught_exception);
@@ -260,7 +260,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
         } catch (InvalidTokenException $e) {
             $error_msg        = $e->getMessage();
-            $caught_exception = $this->errorHasString($e, 'This token is not intended for us');
+            $caught_exception = $this->errorHasString($e, 'Invalid audience __invalid_aud__; expected __valid_aud__');
         }
 
         $this->assertTrue($caught_exception, $error_msg);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,3 +6,5 @@ require_once $tests_dir.'../vendor/autoload.php';
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );
 }
+
+require_once $tests_dir.'traits/ErrorHelpers.php';

--- a/tests/traits/ErrorHelpers.php
+++ b/tests/traits/ErrorHelpers.php
@@ -1,0 +1,19 @@
+<?php
+namespace Auth0\Tests\Traits;
+
+trait ErrorHelpers
+{
+
+    /**
+     * Does an error message contain a specific string?
+     *
+     * @param \Exception $e   - Error object.
+     * @param string     $str - String to find in the error message.
+     *
+     * @return boolean
+     */
+    protected function errorHasString(\Exception $e, $str)
+    {
+        return ! (false === strpos($e->getMessage(), $str));
+    }
+}


### PR DESCRIPTION
This SDK already had a `JWTVerifier` class to verify ID tokens but that class was not being used in the default login route. This PR adds this validation to `Auth0\SDK\Auth0::setIdToken()` before the incoming ID token is stored. Underlying validation library is [Firebase JWT](https://github.com/firebase/php-jwt).

### What is validated

- Issuer
- Audience
- Signature
- NBF
- IAT
- Expiration

### Potential issues

#### NBF and IAT validation

Both of these values check a timecode in the token payload against the time set on the server doing the validation. If your server time is different from the issuing server, this could cause the validation to fail. If you're getting an error message stating `Cannot handle token prior to ...`, then you can try setting a leeway in the Firebase JWT library, like this:

```php
// Set this before the Auth0 class is initialized.
// Value is in seconds and should be no greater than a few minutes.

\Firebase\JWT\JWT::$leeway = 30;

// ... 
$auth0 = new Auth0( [ 
    // ...
] );
```

#### Client Secret encoding

Most tenants will not have a base64-encoded Client Secret but older tenants might. It will display on your Application settings page whether this is the case or not:

![screenshot 2018-09-05 16 49 55](https://user-images.githubusercontent.com/855223/45127133-c0bb2380-b12b-11e8-882f-b45a988a91d4.png)

By default, the JWT verifier uses the Client Secret as-is with no decoding. If your Client Secret is encoded, add a new value to your `Auth0` initialization array like this:

```php
$auth0 = new Auth0( [ 
    // ...
    'secret_base64_encoded' => true,
    // ...
] );
```