### PR TITLE
Add custom JWKS path and kid check to JWKFetcher + tests

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -95,6 +95,7 @@
     <rule ref="Squiz.PHP">
         <exclude name="Squiz.PHP.DisallowComparisonAssignment.AssignedComparison"/>
         <exclude name="Squiz.PHP.DisallowInlineIf.Found"/>
+        <exclude name="Squiz.PHP.DisallowBooleanStatement.Found"/>
     </rule>
     <rule ref="Squiz.Scope"/>
     <rule ref="Squiz.Strings"/>

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     }
   },
   "scripts": {
-    "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit  --colors=always --verbose ",
-    "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml",
+    "test": "SHELL_INTERACTIVE=1 vendor/bin/phpunit --colors=always --coverage-text",
+    "test-ci": "vendor/bin/phpunit --colors=always --coverage-clover=build/coverage.xml",
     "phpcs": "\"vendor/bin/phpcs\"",
     "phpcs-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs",
     "phpcbf": "\"vendor/bin/phpcbf\"",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,8 @@
 <phpunit
-     colors="true"
-     bootstrap="./vendor/autoload.php"
->
+     coverage-text="true"
+     bootstrap="./tests/bootstrap.php">
   <testsuites>
-    <testsuite name="Auth0 Test Suite">
+    <testsuite name="Auth0 PHP SDK Test Suite">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -6,16 +6,23 @@ use Auth0\SDK\API\Helpers\RequestBuilder;
 use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\Helpers\Cache\NoCacheHandler;
 
+/**
+ * Class JWKFetcher.
+ *
+ * @package Auth0\SDK\Helpers
+ */
 class JWKFetcher
 {
 
     /**
+     * Cache handler or null for no caching.
      *
-     * @var CacheHandler|NoCacheHandler
+     * @var CacheHandler|NoCacheHandler|null
      */
     private $cache = null;
 
     /**
+     * Options for the Guzzle HTTP client.
      *
      * @var array
      */
@@ -24,10 +31,10 @@ class JWKFetcher
     /**
      * JWKFetcher constructor.
      *
-     * @param CacheHandler|null $cache
-     * @param array             $guzzleOptions
+     * @param CacheHandler|null $cache         Cache handler or null for no caching.
+     * @param array             $guzzleOptions Options for the Guzzle HTTP client.
      */
-    public function __construct(CacheHandler $cache = null, $guzzleOptions = [])
+    public function __construct(CacheHandler $cache = null, array $guzzleOptions = [])
     {
         if ($cache === null) {
             $cache = new NoCacheHandler();
@@ -38,45 +45,115 @@ class JWKFetcher
     }
 
     /**
+     * Convert a certificate to PEM format.
      *
-     * @param  string $cert
+     * @param string $cert X509 certificate to convert to PEM format.
+     *
      * @return string
      */
     protected function convertCertToPem($cert)
     {
-        return '-----BEGIN CERTIFICATE-----'.PHP_EOL.chunk_split($cert, 64, PHP_EOL).'-----END CERTIFICATE-----'.PHP_EOL;
+        $output  = '-----BEGIN CERTIFICATE-----'.PHP_EOL;
+        $output .= chunk_split($cert, 64, PHP_EOL);
+        $output .= '-----END CERTIFICATE-----'.PHP_EOL;
+        return $output;
     }
 
     /**
+     * Fetch x509 cert for RS256 token decoding.
      *
-     * @param string $iss
+     * @param string      $domain Base domain for the JWKS, including scheme.
+     * @param string|null $kid    Kid to use.
+     * @param string      $path   Path to the JWKS from the $domain.
      *
-     * @return array|mixed|null
+     * @return mixed
      *
-     * @throws \Exception
+     * @throws \Exception If the Guzzle HTTP client cannot complete the request.
      */
-    public function fetchKeys($iss)
+    public function fetchKeys($domain, $kid = null, $path = '.well-known/jwks.json')
     {
-        $url = "{$iss}.well-known/jwks.json";
+        $jwks_url = $domain.$path;
 
-        if (($secret = $this->cache->get($url)) === null) {
-            $secret = [];
+        // Check for a cached JWKS value.
+        $secret = $this->cache->get($jwks_url);
+        if (! is_null($secret)) {
+            return $secret;
+        }
 
-            $request = new RequestBuilder([
-                'domain' => $iss,
-                'basePath' => '.well-known/jwks.json',
-                'method' => 'GET',
-                'guzzleOptions' => $this->guzzleOptions
-            ]);
-            $jwks    = $request->call();
+        $secret = [];
 
-            foreach ($jwks['keys'] as $key) {
-                $secret[$key['kid']] = $this->convertCertToPem($key['x5c'][0]);
-            }
+        $jwks = $this->getJwks( $domain, $path );
 
-            $this->cache->set($url, $secret);
+        if (! is_array( $jwks['keys'] ) || empty( $jwks['keys'] )) {
+            return $secret;
+        }
+
+        // No kid passed so get the kid of the first JWK.
+        if (is_null($kid)) {
+            $kid = $this->getProp( $jwks, 'kid' );
+        }
+
+        $x5c = $this->getProp( $jwks, 'x5c', $kid );
+
+        // Need the kid and x5c for a well-formed return value. 
+        if (! is_null($kid) && ! is_null($x5c)) {
+            $secret[$kid] = $this->convertCertToPem($x5c);
+            $this->cache->set($jwks_url, $secret);
         }
 
         return $secret;
+    }
+
+    /**
+     * Get a specific property from a JWKS using a key, if provided.
+     *
+     * @param array       $jwks JWKS to parse.
+     * @param string      $prop Property to retrieve.
+     * @param null|string $kid  Kid to check.
+     *
+     * @return null|string
+     */
+    public function getProp(array $jwks, $prop, $kid = null)
+    {
+        $r_key = null;
+        if (! $kid) {
+            // No kid indicated, get the first entry.
+            $r_key = $jwks['keys'][0];
+        } else {
+            // Iterate through the JWKS for the correct kid.
+            foreach ($jwks['keys'] as $key) {
+                if (isset($key['kid']) && $key['kid'] === $kid) {
+                    $r_key = $key;
+                    break;
+                }
+            }
+        }
+
+        // If a key was not found or the property does not exist, return.
+        if (is_null($r_key) || ! isset($r_key[$prop])) {
+            return null;
+        }
+
+        // If the value is an array, get the first element.
+        return is_array( $r_key[$prop] ) ? $r_key[$prop][0] : $r_key[$prop];
+    }
+
+    /**
+     * Get a JWKS given a domain and path to call.
+     *
+     * @param string $domain Base domain for the JWKS, including scheme.
+     * @param string $path   Path to the JWKS from the $domain.
+     *
+     * @return mixed|string
+     */
+    protected function getJwks($domain, $path)
+    {
+        $request = new RequestBuilder([
+            'domain' => $domain,
+            'basePath' => $path,
+            'method' => 'GET',
+            'guzzleOptions' => $this->guzzleOptions
+        ]);
+        return $request->call();
     }
 }

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -23,6 +23,8 @@ class JWTVerifier
 
     protected $secret_base64_encoded = null;
 
+    protected $jwks_path = '.well-known/jwks.json';
+
     /**
      * JWTVerifier Constructor.
      *
@@ -87,6 +89,10 @@ class JWTVerifier
             $this->client_secret = $config['client_secret'];
         }
 
+        if (isset($config['jwks_path'])) {
+            $this->jwks_path = (string) $config['jwks_path'];
+        }
+
         $this->JWKFetcher = new JWKFetcher($cache, $guzzleOptions);
     }
 
@@ -125,7 +131,8 @@ class JWTVerifier
                 throw new CoreException("We can't trust on a token issued by: `{$body->iss}`.");
             }
 
-            $secret = $this->JWKFetcher->fetchKeys($body->iss);
+            $jwks_url = $body->iss.$this->jwks_path;
+            $secret   = $this->JWKFetcher->fetchKeys($jwks_url);
         } else if ($head->alg === 'HS256') {
             if ($this->secret_base64_encoded) {
                 $secret = JWT::urlsafeB64Decode($this->client_secret);

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -122,9 +122,10 @@ class SessionStore implements StoreInterface
     public function getSessionKeyName($key)
     {
         $key_name = $key;
-        if ( ! empty( $this->session_base_name ) ) {
+        if (! empty( $this->session_base_name )) {
             $key_name = $this->session_base_name.'_'.$key_name;
         }
+
         return $key_name;
     }
 }

--- a/tests/Helpers/JWKFetcherTest.php
+++ b/tests/Helpers/JWKFetcherTest.php
@@ -1,0 +1,196 @@
+<?php
+namespace Auth0\Tests\Helpers\Cache;
+
+use \Auth0\SDK\Helpers\JWKFetcher;
+
+/**
+ * Class JWKFetcherTest.
+ *
+ * @package Auth0\Tests\Helpers\Cache
+ */
+class JWKFetcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that a standard JWKS path returns the first x5c.
+     *
+     * @return void
+     */
+    public function testFetchKeysWithoutKid()
+    {
+        $jwksFetcher = $this->getStub();
+
+        $keys = $jwksFetcher->fetchKeys( 'https://localhost/' );
+
+        $this->assertCount(1, $keys);
+
+        $pem_parts = $this->getPemParts( $keys );
+
+        $this->assertEquals( 4, count($pem_parts) );
+        $this->assertEquals( '-----BEGIN CERTIFICATE-----', $pem_parts[0] );
+        $this->assertEquals( '-----END CERTIFICATE-----', $pem_parts[2] );
+        $this->assertEquals( '__test_x5c_1__', $pem_parts[1] );
+    }
+
+    /**
+     * Test that a standard JWKS path returns the correct x5c when given a kid.
+     *
+     * @return void
+     */
+    public function testFetchKeysWithKid()
+    {
+        $jwksFetcher = $this->getStub();
+
+        $keys = $jwksFetcher->fetchKeys( 'https://localhost/', '__test_kid_2__' );
+
+        $this->assertCount(1, $keys);
+
+        $pem_parts = $this->getPemParts( $keys );
+
+        $this->assertEquals( 4, count($pem_parts) );
+        $this->assertEquals( '-----BEGIN CERTIFICATE-----', $pem_parts[0] );
+        $this->assertEquals( '-----END CERTIFICATE-----', $pem_parts[2] );
+        $this->assertEquals( '__test_x5c_2__', $pem_parts[1] );
+    }
+
+    /**
+     * Test that a custom JWKS path returns the correct JSON.
+     *
+     * @return void
+     */
+    public function testFetchKeysWithPath()
+    {
+        $jwksFetcher = $this->getStub();
+
+        $keys = $jwksFetcher->fetchKeys( 'https://localhost/', '__test_custom_kid__', '.custom/jwks.json' );
+
+        $this->assertCount(1, $keys);
+
+        $pem_parts = $this->getPemParts( $keys );
+
+        $this->assertEquals( 4, count( $pem_parts ) );
+        $this->assertEquals( '-----BEGIN CERTIFICATE-----', $pem_parts[0] );
+        $this->assertEquals( '-----END CERTIFICATE-----', $pem_parts[2] );
+        $this->assertEquals( '__test_custom_x5c__', $pem_parts[1] );
+    }
+
+    /**
+     * Test that a JWK with no x509 cert returns a blank array.
+     *
+     * @return void
+     */
+    public function testFetchKeysNoX5c()
+    {
+        $jwksFetcher = $this->getStub();
+
+        $keys = $jwksFetcher->fetchKeys( 'https://localhost/', '__no_x5c_test_kid_2__' );
+
+        $this->assertEmpty($keys);
+    }
+
+    /**
+     * Test that the protected getProp method returns correctly.
+     *
+     * @return void
+     */
+    public function testConvertCertToPem()
+    {
+        $class  = new \ReflectionClass(JWKFetcher::class);
+        $method = $class->getMethod('convertCertToPem');
+        $method->setAccessible(true);
+
+        $test_string_1 = '';
+        for ($i = 1; $i <= 64; $i++) {
+            $test_string_1 .= 'a';
+        }
+
+        $test_string_2 = '';
+        for ($i = 1; $i <= 64; $i++) {
+            $test_string_2 .= 'b';
+        }
+
+        $returned_pem = $method->invoke(new JWKFetcher(), $test_string_1.$test_string_2);
+        $pem_parts    = explode( PHP_EOL, $returned_pem );
+        $this->assertEquals( 5, count($pem_parts) );
+        $this->assertEquals( '-----BEGIN CERTIFICATE-----', $pem_parts[0] );
+        $this->assertEquals( $test_string_1, $pem_parts[1] );
+        $this->assertEquals( $test_string_2, $pem_parts[2] );
+        $this->assertEquals( '-----END CERTIFICATE-----', $pem_parts[3] );
+    }
+
+    /**
+     * Test that the protected getProp method returns correctly.
+     *
+     * @return void
+     */
+    public function testGetProp()
+    {
+        $jwks = $this->getLocalJwks( 'test', '-jwks' );
+
+        $jwksFetcher = new JWKFetcher();
+
+        $this->assertEquals( '__string_value_1__', $jwksFetcher->getProp( $jwks, 'string' ) );
+        $this->assertEquals( '__array_value_1__', $jwksFetcher->getProp( $jwks, 'array' ) );
+        $this->assertNull( $jwksFetcher->getProp( $jwks, 'invalid' ) );
+
+        $test_kid = '__kid_value__';
+
+        $this->assertEquals( '__string_value_2__', $jwksFetcher->getProp( $jwks, 'string', $test_kid ) );
+        $this->assertEquals( '__array_value_3__', $jwksFetcher->getProp( $jwks, 'array', $test_kid ) );
+        $this->assertNull( $jwksFetcher->getProp( $jwks, 'invalid', $test_kid ) );
+    }
+
+    /**
+     * Get a test JSON fixture instead of a remote one.
+     *
+     * @param string $domain Domain name of the JWKS.
+     * @param string $path   Path to the JWKS.
+     *
+     * @return array
+     */
+    public function getLocalJwks($domain = '', $path = '')
+    {
+        // Normalize the domain to a file name.
+        $domain = str_replace( 'https://', '', $domain );
+        $domain = str_replace( 'http://', '', $domain );
+
+        // Replace everything that isn't a letter, digit, or dash.
+        $pattern     = '/[^a-zA-Z1-9^-]/i';
+        $file_append = preg_replace($pattern, '-', $domain).preg_replace($pattern, '-', $path);
+
+        // Get the test JSON file.
+        $json_contents = file_get_contents( AUTH0_PHP_TEST_JSON_DIR.$file_append.'.json' );
+        return json_decode( $json_contents, true );
+    }
+
+    /**
+     * Stub the JWKFetcher class.
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getStub()
+    {
+        $stub = $this->getMockBuilder(JWKFetcher::class)
+            ->setMethods(['getJwks'])
+            ->getMock();
+
+        $stub->method('getJwks')
+            ->will($this->returnCallback([$this, 'getLocalJwks']));
+
+        return $stub;
+    }
+
+    /**
+     * Get array of PEM parts.
+     *
+     * @param array $keys JWKS keys.
+     *
+     * @return array
+     */
+    private function getPemParts(array $keys)
+    {
+        $keys_keys = array_keys($keys);
+        $kid       = $keys_keys[0];
+        $pem       = $keys[$kid];
+        return explode( PHP_EOL, $pem );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,8 @@
 <?php
-$tests_dir = dirname(__FILE__) . '/';
+$tests_dir = dirname(__FILE__).'/';
 
-require_once $tests_dir . '../vendor/autoload.php';
+require_once $tests_dir.'../vendor/autoload.php';
 
-if ( ! defined( 'AUTH0_PHP_TEST_JSON_DIR' ) ) {
+if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+$tests_dir = dirname(__FILE__) . '/';
+
+require_once $tests_dir . '../vendor/autoload.php';
+
+if ( ! defined( 'AUTH0_PHP_TEST_JSON_DIR' ) ) {
+    define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );
+}

--- a/tests/json/localhost--custom-jwks-json.json
+++ b/tests/json/localhost--custom-jwks-json.json
@@ -1,0 +1,6 @@
+{"keys": [
+  {
+    "x5c": [ "__test_custom_x5c__" ],
+    "kid": "__test_custom_kid__"
+  }
+] }

--- a/tests/json/localhost--well-known-jwks-json.json
+++ b/tests/json/localhost--well-known-jwks-json.json
@@ -1,0 +1,13 @@
+{"keys": [
+  {
+    "x5c": [ "__test_x5c_1__" ],
+    "kid": "__test_kid_1__"
+  },
+  {
+    "x5c": [ "__test_x5c_2__" ],
+    "kid": "__test_kid_2__"
+  },
+  {
+    "kid": "__no_x5c_test_kid_2__"
+  }
+] }

--- a/tests/json/test-jwks.json
+++ b/tests/json/test-jwks.json
@@ -1,0 +1,24 @@
+{"keys": [
+  {
+    "string": "__string_value_1__",
+    "array": [
+      "__array_value_1__",
+      "__array_value_2__"
+    ]
+  },
+  {
+    "string": "__unused_string_value__",
+    "array": [
+      "__unused_item_1__",
+      "__unused_item_2__"
+    ]
+  },
+  {
+    "kid": "__kid_value__",
+    "string": "__string_value_2__",
+    "array": [
+      "__array_value_3__",
+      "__array_value_4__"
+    ]
+  }
+] }


### PR DESCRIPTION
Add a custom path to a JWKS and kid checking (this will be added to the ID token validation in another PR). 

- Add `$kid` and `$path` parameters to `\Auth0\SDK\Helpers\JWKFetcher::fetchKeys`
- Add `\Auth0\SDK\Helpers\JWKFetcher::getJwks` to call the JWKS URL
- Add `\Auth0\SDK\Helpers\JWKFetcher::getProp` to get a key from the JWKS

Closes #283 