### PR TITLE
Fix default session set to 0

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -272,8 +272,9 @@ class Auth0
             $this->dontPersist('id_token');
         }
 
-        $session_base_name      = ! empty( $config['session_base_name'] ) ? $config['session_base_name'] : null;
-        $session_cookie_expires = isset( $config['session_cookie_expires'] ) ? $config['session_cookie_expires'] : null;
+        $session_base_name = ! empty( $config['session_base_name'] ) ? $config['session_base_name'] : SessionStore::BASE_NAME;
+
+        $session_cookie_expires = isset( $config['session_cookie_expires'] ) ? $config['session_cookie_expires'] : SessionStore::COOKIE_EXPIRES;
 
         if (isset($config['store'])) {
             if ($config['store'] === false) {

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -10,9 +10,14 @@ namespace Auth0\SDK\Store;
 class SessionStore implements StoreInterface
 {
     /**
-     * Session base name, if not configured.
+     * Default session base name.
      */
     const BASE_NAME = 'auth0_';
+
+    /**
+     * Default session cookie expiration.
+     */
+    const COOKIE_EXPIRES = 604800;
 
     /**
      * Session base name, configurable on instantiation.
@@ -34,12 +39,9 @@ class SessionStore implements StoreInterface
      * @param string|null $base_name      Session base name.
      * @param integer     $cookie_expires Session expiration in seconds; default is 1 week.
      */
-    public function __construct($base_name = null, $cookie_expires = 604800)
+    public function __construct($base_name = self::BASE_NAME, $cookie_expires = self::COOKIE_EXPIRES)
     {
-        if (! empty( $base_name )) {
-            $this->session_base_name = $base_name;
-        }
-
+        $this->session_base_name      = (string) $base_name;
         $this->session_cookie_expires = (int) $cookie_expires;
     }
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -36,8 +36,8 @@ class SessionStore implements StoreInterface
     /**
      * SessionStore constructor.
      *
-     * @param string|null $base_name      Session base name.
-     * @param integer     $cookie_expires Session expiration in seconds; default is 1 week.
+     * @param string  $base_name      Session base name.
+     * @param integer $cookie_expires Session expiration in seconds; default is 1 week.
      */
     public function __construct($base_name = self::BASE_NAME, $cookie_expires = self::COOKIE_EXPIRES)
     {
@@ -121,6 +121,10 @@ class SessionStore implements StoreInterface
      */
     public function getSessionKeyName($key)
     {
-        return $this->session_base_name.'_'.$key;
+        $key_name = $key;
+        if ( ! empty( $this->session_base_name ) ) {
+            $key_name = $this->session_base_name.'_'.$key_name;
+        }
+        return $key_name;
     }
 }


### PR DESCRIPTION
Initial session was being set to `0` if a config parameter was not passed in. 