### PR TITLE
Optimize Integer Casting

### DIFF
--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -33,11 +33,11 @@ class ClientGrants extends GenericResource
     public function getAll(array $params = [], $page = null, $per_page = null)
     {
         if (null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs(intval($per_page));
+            $params['per_page'] = abs((int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -51,7 +51,7 @@ class Clients extends GenericResource
 
         // Pagination.
         if (null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
             if (null !== $per_page) {
                 $params['per_page'] = $per_page;
             }

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -56,7 +56,7 @@ class Connections extends GenericResource
 
         // Pagination.
         if (null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
             if (null !== $per_page) {
                 $params['per_page'] = $per_page;
             }

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -151,7 +151,7 @@ class EmailTemplates extends GenericResource
             'subject' => (string) $subject,
             'body' => (string) $body,
             'syntax' => (string) $syntax,
-            'urlLifetimeInSeconds' => abs(intval($urlLifetime))
+            'urlLifetimeInSeconds' => abs((int) $urlLifetime)
         ];
 
         if (! empty($resultUrl)) {

--- a/src/API/Management/ResourceServers.php
+++ b/src/API/Management/ResourceServers.php
@@ -31,11 +31,11 @@ class ResourceServers extends GenericResource
 
         // Pagination parameters.
         if (null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs(intval($per_page));
+            $params['per_page'] = abs((int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -47,11 +47,11 @@ class Rules extends GenericResource
 
         // Pagination parameters.
         if (null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs(intval($per_page));
+            $params['per_page'] = abs((int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -142,11 +142,11 @@ class Users extends GenericResource
 
         // Keep existing pagination params if passed (backwards-compat), override with non-null function param if not.
         if (! isset($params['page']) && null !== $page) {
-            $params['page'] = abs(intval($page));
+            $params['page'] = abs((int) $page);
         }
 
         if (! isset($params['per_page']) && null !== $per_page) {
-            $params['per_page'] = abs(intval($per_page));
+            $params['per_page'] = abs((int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -188,7 +188,7 @@ class Auth0
      *
      * @var string
      */
-    protected $idTokenAlg = null;
+    protected $idTokenAlg;
 
     /**
      * Valid audiences for ID tokens.
@@ -385,7 +385,7 @@ class Auth0
      * @see \Auth0\SDK\API\Authentication::get_authorize_link()
      * @see https://auth0.com/docs/api/authentication#login
      */
-    public function login($state = null, $connection = null, $additionalParams = [])
+    public function login($state = null, $connection = null, array $additionalParams = [])
     {
         $params = [];
         if ($this->audience) {

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -22,14 +22,14 @@ class JWKFetcher
      *
      * @var CacheHandler|null
      */
-    private $cache = null;
+    private $cache;
 
     /**
      * Options for the Guzzle HTTP client.
      *
      * @var array
      */
-    private $guzzleOptions = null;
+    private $guzzleOptions;
 
     /**
      * JWKFetcher constructor.
@@ -111,7 +111,7 @@ class JWKFetcher
      */
     public function requestJwkX5c($jwks_url, $kid = null)
     {
-        $cache_key = $jwks_url.'|'.(string) $kid;
+        $cache_key = $jwks_url.'|'.$kid;
 
         $x5c = $this->cache->get($cache_key);
         if (! is_null($x5c)) {

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -23,7 +23,7 @@ class JWTVerifier
      *
      * @var JWKFetcher|null
      */
-    protected $JWKFetcher = null;
+    protected $JWKFetcher;
 
     /**
      * Algorithms supported.
@@ -46,7 +46,7 @@ class JWTVerifier
      *
      * @var array|null
      */
-    protected $authorized_iss = null;
+    protected $authorized_iss;
 
     /**
      * Application Client Secret.
@@ -54,7 +54,7 @@ class JWTVerifier
      *
      * @var string|null
      */
-    protected $client_secret = null;
+    protected $client_secret;
 
     /**
      * Path to the JWKS for RS256 tokens.

--- a/tests/API/Management/EmailTemplatesTest.php
+++ b/tests/API/Management/EmailTemplatesTest.php
@@ -58,7 +58,7 @@ class EmailTemplateTest extends ApiTests
      *
      * @var boolean
      */
-    protected static $setUpEmailError = null;
+    protected static $setUpEmailError;
 
     /**
      * Can this email template be created?


### PR DESCRIPTION
What this PR does is:
   
- Use (int) casting which is pretty much faster than intval. - [Reference](https://stackoverflow.com/questions/239136/fastest-way-to-convert-string-to-integer-in-php)
- Remove null assignments to class properties since variables with no value are null already. - [Reference](http://php.net/manual/en/language.types.null.php)
- [Concatenation](https://github.com/ozdemirburak/auth0-PHP/commit/15499e7e6bec93e83c5475f7a88063bd1657d4d0#diff-8397559345a7685d64dc018493eeb7a1R114) already casts string. - [Example](https://3v4l.org/gKnf8)