### PR TITLE
Fix bad exception message generation

### DIFF
--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -199,9 +199,9 @@ class JWTVerifier
         if (! empty($body_decoded->aud)) {
             $audience = is_array($body_decoded->aud) ? $body_decoded->aud : [$body_decoded->aud];
             if (! count(array_intersect($audience, $this->valid_audiences))) {
-                throw new InvalidTokenException(
-                    'Invalid audience '.$body_decoded->aud.'; expected '.implode( ', ', $this->valid_audiences )
-                );
+                $message  = 'Invalid token audience '.implode( ', ', $audience );
+                $message .= '; expected '.implode( ', ', $this->valid_audiences );
+                throw new InvalidTokenException($message);
             }
         }
 

--- a/tests/API/Helpers/TokenTest.php
+++ b/tests/API/Helpers/TokenTest.php
@@ -251,7 +251,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $jwt_head      = JWT::urlsafeB64Encode(JWT::jsonEncode($head_obj));
 
         $payload_obj      = new \stdClass();
-        $payload_obj->aud = '__invalid_aud__';
+        $payload_obj->aud = ['__invalid_aud__'];
         $jwt_payload      = JWT::urlsafeB64Encode(JWT::jsonEncode($payload_obj));
 
         $caught_exception = false;
@@ -260,7 +260,10 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             $verifier->verifyAndDecode( $jwt_head.'.'.$jwt_payload.'.'.uniqid() );
         } catch (InvalidTokenException $e) {
             $error_msg        = $e->getMessage();
-            $caught_exception = $this->errorHasString($e, 'Invalid audience __invalid_aud__; expected __valid_aud__');
+            $caught_exception = $this->errorHasString(
+                $e,
+                'Invalid token audience __invalid_aud__; expected __valid_aud__'
+            );
         }
 
         $this->assertTrue($caught_exception, $error_msg);


### PR DESCRIPTION
Exception message was not being parsed properly, leading to the wrong error being thrown. Was using the direct `aud` property rather than the converted one. The test was setup up improperly as well, leading to it passing incorrectly. Fixed the error message and the test. 

Closes #296 
