### PR TITLE
Change telemetry headers to new format and add tests

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -233,6 +233,8 @@ class Authentication
      * @see https://auth0.com/docs/api/authentication#social-with-provider-s-access-token
      * @see https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html
      * @see https://auth0.com/docs/api-auth/intro
+     *
+     * @codeCoverageIgnore - Deprecated
      */
     public function authorize_with_accesstoken(
         $access_token,
@@ -373,6 +375,8 @@ class Authentication
      *
      * @see https://auth0.com/docs/api/authentication#resource-owner
      * @see https://auth0.com/docs/api-auth/intro
+     *
+     * @codeCoverageIgnore - Deprecated
      */
     public function authorize_with_ro(
         $username,

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -14,7 +14,7 @@ use Auth0\SDK\API\Header\ContentType;
 class ApiClient
 {
 
-    const API_VERSION = '5.0.4';
+    const API_VERSION = '5.3.1';
 
     protected static $infoHeadersDataEnabled = true;
 
@@ -39,7 +39,7 @@ class ApiClient
             self::$infoHeadersData = new InformationHeaders;
 
             self::$infoHeadersData->setPackage('auth0-php', self::API_VERSION);
-            self::$infoHeadersData->setEnvironment('PHP', phpversion());
+            self::$infoHeadersData->setEnvProperty('php', phpversion());
         }
 
         return self::$infoHeadersData;

--- a/src/API/Helpers/InformationHeaders.php
+++ b/src/API/Helpers/InformationHeaders.php
@@ -23,9 +23,27 @@ class InformationHeaders
     }
 
     /**
+     * Add an optional env property for SDK telemetry.
+     *
+     * @param string $name    - Property name to set, name of dependency or platform.
+     * @param string $version - Version number.
+     */
+    public function setEnvProperty($name, $version)
+    {
+        if (! isset($this->data['env']) || ! is_array($this->data['env'])) {
+            $this->data['env'] = [];
+        }
+
+        $this->data['env'][$name] = $version;
+    }
+
+    /**
+     * TODO: Deprecate, not used.
      *
      * @param string $name
      * @param string $version
+     *
+     * @codeCoverageIgnore - Slated for deprecation
      */
     public function setEnvironment($name, $version)
     {
@@ -36,8 +54,11 @@ class InformationHeaders
     }
 
     /**
+     * TODO: Deprecate, not used.
      *
      * @param array $data
+     *
+     * @codeCoverageIgnore - Slated for deprecation
      */
     public function setEnvironmentData($data)
     {
@@ -45,9 +66,12 @@ class InformationHeaders
     }
 
     /**
+     * TODO: Deprecate, not used.
      *
      * @param string $name
      * @param string $version
+     *
+     * @codeCoverageIgnore - Slated for deprecation
      */
     public function setDependency($name, $version)
     {
@@ -58,8 +82,11 @@ class InformationHeaders
     }
 
     /**
+     * TODO: Deprecate, not used.
      *
      * @param array $data
+     *
+     * @codeCoverageIgnore - Slated for deprecation
      */
     public function setDependencyData($data)
     {
@@ -85,9 +112,12 @@ class InformationHeaders
     }
 
     /**
+     * TODO: Deprecate, not used.
      *
      * @param  InformationHeaders $headers
      * @return InformationHeaders
+     *
+     * @codeCoverageIgnore - Slated for deprecation
      */
     public static function Extend(InformationHeaders $headers)
     {

--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -12,6 +12,8 @@ use OAuth2\Client;
  * This class provides access to Auth0 Platform.
  *
  * @deprecated - Deprecated in 5.2.1; use \Auth0\SDK\Auth0 instead.
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class Oauth2Client
 {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -214,7 +214,7 @@ class Auth0
     /**
      * BaseAuth0 Constructor.
      *
-     * @param array $config - Required configuration options.
+     * @param  array $config - Required configuration options.
      * Configuration:
      *     - domain                 (String)  Required. Auth0 domain for your tenant
      *     - client_id              (String)  Required. Client ID found in the Application settings

--- a/src/Auth0Api.php
+++ b/src/Auth0Api.php
@@ -5,6 +5,8 @@ namespace Auth0\SDK;
  * This class provides access to Auth0 Platform API.
  *
  * @deprecated - Provided for bring backwards-compat and will be soon removed; use Auth0\SDK\API\Management instead.
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class Auth0Api extends \Auth0\SDK\API\Management
 {

--- a/src/Auth0AuthApi.php
+++ b/src/Auth0AuthApi.php
@@ -5,6 +5,8 @@ namespace Auth0\SDK;
  * This class provides access to Auth0 Platform auth API.
  *
  * @deprecated - Provided for bring backwards-compat and will be soon removed; use Auth0\SDK\API\Authentication instead
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class Auth0AuthApi extends \Auth0\SDK\API\Authentication
 {

--- a/src/Auth0JWT.php
+++ b/src/Auth0JWT.php
@@ -6,6 +6,8 @@ namespace Auth0\SDK;
  * This class provides access to Auth0 JWT decoder.
  *
  * @deprecated - Provided for bring backwards-compat and will be soon removed; use Auth0\SDK\JWTVerifier instead.
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class Auth0JWT
 {

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace Auth0\Tests\Api\Helpers;
+
+use Auth0\SDK\API\Helpers\InformationHeaders;
+
+/**
+ * Class InformationHeadersTest
+ *
+ * @package Auth0\Tests\Api\Helpers
+ */
+class InformationHeadersTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Set the package data and make sure it's returned correctly.
+     *
+     * @return void
+     */
+    public function testThatSetPackageSetsDataCorrectly()
+    {
+        $header = new InformationHeaders();
+        $header->setPackage( 'test_name', '1.2.3' );
+        $header_data = $header->get();
+
+        $this->assertCount(2, $header_data);
+        $this->assertArrayHasKey('name', $header_data);
+        $this->assertEquals('test_name', $header_data['name']);
+        $this->assertArrayHasKey('version', $header_data);
+        $this->assertEquals('1.2.3', $header_data['version']);
+    }
+
+    /**
+     * Set and override an env property and make sure it's returned correctly.
+     *
+     * @return void
+     */
+    public function testThatSetEnvPropertySetsDataCorrectly()
+    {
+        $header = new InformationHeaders();
+        $header->setEnvProperty( 'test_env_name', '2.3.4' );
+        $header_data = $header->get();
+
+        $this->assertArrayHasKey('env', $header_data);
+        $this->assertCount(1, $header_data['env']);
+        $this->assertArrayHasKey('test_env_name', $header_data['env']);
+        $this->assertEquals('2.3.4', $header_data['env']['test_env_name']);
+
+        $header->setEnvProperty( 'test_env_name', '3.4.5' );
+        $header_data = $header->get();
+        $this->assertEquals('3.4.5', $header_data['env']['test_env_name']);
+
+        $header->setEnvProperty( 'test_env_name_2', '4.5.6' );
+        $header_data = $header->get();
+        $this->assertEquals('4.5.6', $header_data['env']['test_env_name_2']);
+    }
+
+    /**
+     * Set the package and env and make sure it's built correctly.
+     *
+     * @return void
+     */
+    public function testThatBuildReturnsCorrectData()
+    {
+        $header      = new InformationHeaders();
+        $header_data = (object) [
+            'name' => 'test_name_2',
+            'version' => '5.6.7',
+            'env' => (object) [
+                'test_env_name_3' => '6.7.8',
+            ],
+        ];
+        $header->setPackage( $header_data->name, $header_data->version );
+        $header->setEnvProperty( 'test_env_name_3', $header_data->env->test_env_name_3 );
+
+        $header_built = base64_decode($header->build());
+        $this->assertEquals( json_encode($header_data), $header_built );
+    }
+}


### PR DESCRIPTION
- Add `InformationHeaders::setEnvProperty()` method to set a proper `env` property
- Mark unused `InformationHeaders` with a TODO to deprecate
- Add PhpUnit annotations for deprecated methods