### PR TITLE
Fix info headers Extend error in dependant libs

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -54,7 +54,9 @@
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
     </rule>
     <rule ref="Generic.Metrics"/>
-    <rule ref="Generic.NamingConventions"/>
+    <rule ref="Generic.NamingConventions">
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps"/>
+    </rule>
     <rule ref="Generic.PHP">
         <exclude name="Generic.PHP.ClosingPHPTag"/>
         <exclude name="Generic.PHP.UpperCaseConstant"/>

--- a/src/API/Helpers/InformationHeaders.php
+++ b/src/API/Helpers/InformationHeaders.php
@@ -16,7 +16,7 @@ class InformationHeaders
      *
      * @var array
      */
-    protected $data = [ 'name' => 'Not set (PHP)', 'version' => 'Not set (PHP)' ];
+    protected $data = [];
 
     /**
      * Set the main SDK name and version.

--- a/src/API/Helpers/InformationHeaders.php
+++ b/src/API/Helpers/InformationHeaders.php
@@ -2,19 +2,29 @@
 
 namespace Auth0\SDK\API\Helpers;
 
+/**
+ * Class InformationHeaders
+ * Builds, extends, modifies, and formats SDK telemetry data.
+ *
+ * @package Auth0\SDK\API\Helpers
+ */
 class InformationHeaders
 {
 
     /**
+     * Default header data to send.
      *
      * @var array
      */
-    protected $data = [];
+    protected $data = [ 'name' => 'Not set (PHP)', 'version' => 'Not set (PHP)' ];
 
     /**
+     * Set the main SDK name and version.
      *
-     * @param string $name
-     * @param string $version
+     * @param string $name    SDK name.
+     * @param string $version SDK version number.
+     *
+     * @return void
      */
     public function setPackage($name, $version)
     {
@@ -25,8 +35,10 @@ class InformationHeaders
     /**
      * Add an optional env property for SDK telemetry.
      *
-     * @param string $name    - Property name to set, name of dependency or platform.
-     * @param string $version - Version number.
+     * @param string $name    Property name to set, name of dependency or platform.
+     * @param string $version Version number of dependency or platform.
+     *
+     * @return void
      */
     public function setEnvProperty($name, $version)
     {
@@ -38,62 +50,63 @@ class InformationHeaders
     }
 
     /**
-     * TODO: Deprecate, not used.
+     * TODO: Deprecate and remove from all dependant libs.
      *
-     * @param string $name
-     * @param string $version
+     * @param string $name    Dependency or platform name.
+     * @param string $version Dependency or platform version.
+     *
+     * @return void
      *
      * @codeCoverageIgnore - Slated for deprecation
      */
     public function setEnvironment($name, $version)
     {
-        $this->data['environment'][] = [
-            'name' => $name,
-            'version' => $version,
-        ];
+        $this->setEnvProperty($name, $version);
     }
 
     /**
-     * TODO: Deprecate, not used.
+     * Replace the current env data with new data.
      *
-     * @param array $data
+     * @param array $data Env data to add.
      *
-     * @codeCoverageIgnore - Slated for deprecation
+     * @return void
      */
-    public function setEnvironmentData($data)
+    public function setEnvironmentData(array $data)
     {
-        $this->data['environment'] = $data;
+        $this->data['env'] = $data;
     }
 
     /**
      * TODO: Deprecate, not used.
      *
-     * @param string $name
-     * @param string $version
+     * @param string $name    Dependency name.
+     * @param string $version Dependency version.
+     *
+     * @return void
      *
      * @codeCoverageIgnore - Slated for deprecation
      */
     public function setDependency($name, $version)
     {
-        $this->data['dependencies'][] = [
-            'name' => $name,
-            'version' => $version,
-        ];
+        $this->setEnvProperty($name, $version);
     }
 
     /**
      * TODO: Deprecate, not used.
      *
-     * @param array $data
+     * @param array $data Dependency data to store.
+     *
+     * @return void
      *
      * @codeCoverageIgnore - Slated for deprecation
      */
-    public function setDependencyData($data)
+    public function setDependencyData(array $data)
     {
         $this->data['dependencies'] = $data;
     }
 
     /**
+     * Get the current header data as an array.
      *
      * @return array
      */
@@ -103,6 +116,7 @@ class InformationHeaders
     }
 
     /**
+     * Return a header-formatted string.
      *
      * @return string
      */
@@ -112,22 +126,24 @@ class InformationHeaders
     }
 
     /**
-     * TODO: Deprecate, not used.
+     * Extend an existing InformationHeaders object.
+     * Used in dependant modules to set a new SDK name and version but keep existing PHP SDK data.
      *
-     * @param  InformationHeaders $headers
+     * @param InformationHeaders $headers InformationHeaders object to extend.
+     *
      * @return InformationHeaders
-     *
-     * @codeCoverageIgnore - Slated for deprecation
      */
     public static function Extend(InformationHeaders $headers)
     {
-        $newHeaders = new InformationHeaders;
+        $new_headers = new InformationHeaders;
+        $old_headers = $headers->get();
 
-        $oldData = $headers->get();
+        if (! empty( $old_headers['env'] ) && is_array( $old_headers['env'] )) {
+            $new_headers->setEnvironmentData($old_headers['env']);
+        }
 
-        $newHeaders->setEnvironmentData($oldData['environment']);
-        $newHeaders->setDependency($oldData['name'], $oldData['version']);
+        $new_headers->setEnvProperty($old_headers['name'], $old_headers['version']);
 
-        return $newHeaders;
+        return $new_headers;
     }
 }

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -2,6 +2,7 @@
 namespace Auth0\Tests\Api\Helpers;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Helpers\ApiClient;
 
 /**
  * Class InformationHeadersTest
@@ -55,6 +56,31 @@ class InformationHeadersTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Set and override an env property with the deprecated method and make sure it's returned correctly.
+     *
+     * @return void
+     */
+    public function testThatSetEnvironmentSetsDataCorrectly()
+    {
+        $header = new InformationHeaders();
+        $header->setEnvironment( 'test_env_name', '2.3.4' );
+        $header_data = $header->get();
+
+        $this->assertArrayHasKey('env', $header_data);
+        $this->assertCount(1, $header_data['env']);
+        $this->assertArrayHasKey('test_env_name', $header_data['env']);
+        $this->assertEquals('2.3.4', $header_data['env']['test_env_name']);
+
+        $header->setEnvironment( 'test_env_name', '3.4.5' );
+        $header_data = $header->get();
+        $this->assertEquals('3.4.5', $header_data['env']['test_env_name']);
+
+        $header->setEnvironment( 'test_env_name_2', '4.5.6' );
+        $header_data = $header->get();
+        $this->assertEquals('4.5.6', $header_data['env']['test_env_name_2']);
+    }
+
+    /**
      * Set the package and env and make sure it's built correctly.
      *
      * @return void
@@ -62,17 +88,45 @@ class InformationHeadersTest extends \PHPUnit_Framework_TestCase
     public function testThatBuildReturnsCorrectData()
     {
         $header      = new InformationHeaders();
-        $header_data = (object) [
+        $header_data = [
             'name' => 'test_name_2',
             'version' => '5.6.7',
-            'env' => (object) [
+            'env' => [
                 'test_env_name_3' => '6.7.8',
             ],
         ];
-        $header->setPackage( $header_data->name, $header_data->version );
-        $header->setEnvProperty( 'test_env_name_3', $header_data->env->test_env_name_3 );
+        $header->setPackage( $header_data['name'], $header_data['version'] );
+        $header->setEnvProperty( 'test_env_name_3', '6.7.8' );
 
         $header_built = base64_decode($header->build());
         $this->assertEquals( json_encode($header_data), $header_built );
+    }
+
+    /**
+     * Extend existing headers and make sure existing data stays intact.
+     *
+     * @link https://github.com/auth0/jwt-auth-bundle/blob/master/src/JWTAuthBundle.php
+     * @link https://github.com/auth0/laravel-auth0/blob/master/src/Auth0/Login/LoginServiceProvider.php
+     *
+     * @return void
+     */
+    public function testThatExtendedHeadersBuildCorrectly()
+    {
+        $headers     = ApiClient::getInfoHeadersData();
+        $new_headers = InformationHeaders::Extend($headers);
+
+        $new_headers->setEnvironment('test_env_name_5', '8.9.10');
+        $new_headers->setPackage('test_name_4', '7.8.9');
+
+        $new_header_data = $new_headers->get();
+
+        $this->assertEquals( 'test_name_4', $new_header_data['name'] );
+        $this->assertEquals( '7.8.9', $new_header_data['version'] );
+
+        $this->assertArrayHasKey('env', $new_header_data);
+        $this->assertArrayHasKey('php', $new_header_data['env']);
+        $this->assertEquals( phpversion(), $new_header_data['env']['php'] );
+        $this->assertArrayHasKey('auth0-php', $new_header_data['env']);
+        $this->assertEquals(ApiClient::API_VERSION, $new_header_data['env']['auth0-php']);
     }
 }


### PR DESCRIPTION
- Add a check for existing `env` data before extending. 
- Remove deprecation TODOs for methods used in other libs
- Added tests for dependent lib usage. 
- Docblocks

Reported in [auth0/laravel-auth0#108](https://github.com/auth0/laravel-auth0/issues/108)
Closes #303 