### PR TITLE
Fix Auth0::exchange() to handle missing id_token

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -80,6 +80,9 @@
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
         <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
     </rule>
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude-pattern>tests/*\.php</exclude-pattern>
+    </rule>
     <rule ref="Squiz.ControlStructures"/>
     <rule ref="Squiz.Functions">
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -16,7 +16,8 @@ use Auth0\SDK\API\Authentication;
 use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\API\Helpers\State\DummyStateHandler;
-use Firebase\JWT\JWT;
+
+use GuzzleHttp\Exception\RequestException;
 
 /**
  * Class Auth0
@@ -153,6 +154,13 @@ class Auth0
     protected $idToken;
 
     /**
+     * Decoded version of the ID token
+     *
+     * @var array
+     */
+    protected $idTokenDecoded;
+
+    /**
      * Storage engine for persistence
      *
      * @var StoreInterface
@@ -181,6 +189,13 @@ class Auth0
      * @see http://docs.guzzlephp.org/en/stable/request-options.html
      */
     protected $guzzleOptions;
+
+    /**
+     * Skip the /userinfo endpoint call and use the ID token.
+     *
+     * @var boolean
+     */
+    protected $skipUserinfo;
 
     /**
      * Algorithm used for ID token validation.
@@ -232,8 +247,11 @@ class Auth0
      *                                                  leave empty to default to SessionStore SessionStateHandler
      *     - debug                  (Boolean) Optional. Turn on debug mode, default false
      *     - guzzle_options         (Object)  Optional. Options passed to Guzzle
+     *     - skip_userinfo          (Boolean) Optional. True to use id_token for user, false to call the
+     *                                                  userinfo endpoint, default false
      *     - session_base_name      (String)  Optional. A common prefix for all session keys. Default `auth0_`
-     *     - session_cookie_expires (Integer) Optional. Seconds for session cookie to expire (if default store is used). Default `604800`
+     *     - session_cookie_expires (Integer) Optional. Seconds for session cookie to expire (if default store is used).
+     *                                                  Default `604800`
      * @throws CoreException If `domain` is not provided.
      * @throws CoreException If `client_id` is not provided.
      * @throws CoreException If `client_secret` is not provided.
@@ -281,6 +299,11 @@ class Auth0
 
         if (isset($config['guzzle_options'])) {
             $this->guzzleOptions = $config['guzzle_options'];
+        }
+
+        $this->skipUserinfo = false;
+        if (isset($config['skip_userinfo']) && is_bool($config['skip_userinfo'])) {
+            $this->skipUserinfo = $config['skip_userinfo'];
         }
 
         // If a token algorithm is passed, make sure it's a specific string.
@@ -492,8 +515,10 @@ class Auth0
     /**
      * Exchange authorization code for access, ID, and refresh tokens
      *
-     * @throws CoreException - if an active session already or state cannot be validated.
-     * @throws ApiException - if access token is invalid.
+     * @throws CoreException If the state value is missing or invalid.
+     * @throws CoreException If there is already an active session.
+     * @throws ApiException If access token is missing from the response.
+     * @throws RequestException If HTTP request fails (e.g. access token does not have userinfo scope).
      *
      * @return boolean
      *
@@ -507,7 +532,6 @@ class Auth0
         }
 
         $state = $this->getState();
-
         if (! $this->stateHandler->validate($state)) {
             throw new CoreException('Invalid state');
         }
@@ -522,24 +546,25 @@ class Auth0
             throw new ApiException('Invalid access_token - Retry login.');
         }
 
-        $accessToken = $response['access_token'];
+        $this->setAccessToken($response['access_token']);
 
-        $refreshToken = false;
         if (isset($response['refresh_token'])) {
-            $refreshToken = $response['refresh_token'];
+            $this->setRefreshToken($response['refresh_token']);
         }
 
-        $idToken = false;
-        if (isset($response['id_token'])) {
-            $idToken = $response['id_token'];
+        if (! empty($response['id_token'])) {
+            $this->setIdToken($response['id_token']);
         }
 
-        $this->setAccessToken($accessToken);
-        $this->setIdToken($idToken);
-        $this->setRefreshToken($refreshToken);
+        if ($this->skipUserinfo) {
+            $user = $this->idTokenDecoded;
+        } else {
+            $user = $this->authentication->userinfo($this->accessToken);
+        }
 
-        $user = $this->authentication->userinfo($accessToken);
-        $this->setUser($user);
+        if ($user) {
+            $this->setUser($user);
+        }
 
         return true;
     }
@@ -623,7 +648,7 @@ class Auth0
      */
     public function setIdToken($idToken)
     {
-        $jwtVerifier = new JWTVerifier([
+        $jwtVerifier          = new JWTVerifier([
             'valid_audiences' => ! empty($this->idTokenAud) ? $this->idTokenAud : [ $this->clientId ],
             'supported_algs' => $this->idTokenAlg ? [ $this->idTokenAlg ] : [ 'HS256', 'RS256' ],
             'authorized_iss' => $this->idTokenIss ? $this->idTokenIss : [ 'https://'.$this->domain.'/' ],
@@ -631,7 +656,7 @@ class Auth0
             'secret_base64_encoded' => $this->clientSecretEncoded,
             'guzzle_options' => $this->guzzleOptions,
         ]);
-        $jwtVerifier->verifyAndDecode( $idToken );
+        $this->idTokenDecoded = (array) $jwtVerifier->verifyAndDecode( $idToken );
 
         if (in_array('id_token', $this->persistantMap)) {
             $this->store->set('id_token', $idToken);

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -1,0 +1,108 @@
+<?php
+namespace Auth0\Tests;
+
+use Auth0\SDK\Auth0;
+use Firebase\JWT\JWT;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Class Auth0Test
+ *
+ * @package Auth0\Tests
+ */
+class Auth0Test extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Basic Auth0 class config options.
+     *
+     * @var array
+     */
+    public static $baseConfig = [
+        'domain'        => '__test_domain__',
+        'client_id'     => '__test_client_id__',
+        'client_secret' => '__test_client_secret__',
+        'redirect_uri'  => '__test_redirect_uri__',
+        'store' => false,
+        'state_handler' => false,
+    ];
+
+    /**
+     * Default request headers.
+     *
+     * @var array
+     */
+    protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs after each test completes.
+     */
+    public function tearDown() {
+        parent::tearDown();
+        $_GET = [];
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Auth0\SDK\Exception\CoreException
+     */
+    public function testThatExchangeReturnsFalseIfNoCodePresent() {
+        $auth0 = new Auth0( self::$baseConfig );
+        $this->assertFalse( $auth0->exchange() );
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Auth0\SDK\Exception\CoreException
+     */
+    public function testThatExchangeSucceedsWithIdToken() {
+
+        $id_token_payload = ['sub' => '123'];
+        $id_token = JWT::encode( $id_token_payload, '__test_client_secret__' );
+
+        $mock = new MockHandler( [
+            // Code exchange response.
+            new Response( 200, self::$headers, '{"access_token":"1.2.3","id_token":"' . $id_token . '"}' ),
+            // Userinfo response.
+            new Response( 200, self::$headers, json_encode( $id_token_payload ) ),
+        ] );
+
+        $config = self::$baseConfig + [ 'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ] ];
+        $_GET['code'] = uniqid();
+
+        $auth0 = new Auth0( $config );
+
+        $this->assertTrue( $auth0->exchange() );
+        $this->assertEquals( $id_token_payload, $auth0->getUser() );
+        $this->assertEquals( $id_token, $auth0->getIdToken() );
+        $this->assertEquals( '1.2.3', $auth0->getAccessToken() );
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Auth0\SDK\Exception\CoreException
+     */
+    public function testThatExchangeSucceedsWithNoIdToken() {
+
+        $mock = new MockHandler( [
+            // Code exchange response.
+            // Respond with no ID token, access token with correct number of segments.
+            new Response( 200, self::$headers, '{"access_token":"1.2.3"}' ),
+            // Userinfo response.
+            new Response( 200, self::$headers, '{"sub":"123"}' ),
+        ] );
+
+        $config = self::$baseConfig + [ 'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ] ];
+        $_GET['code'] = uniqid();
+
+        $auth0 = new Auth0( $config );
+
+        $this->assertTrue( $auth0->exchange() );
+        $this->assertEquals( ['sub' => '123'], $auth0->getUser() );
+        $this->assertEquals( '1.2.3', $auth0->getAccessToken() );
+    }
+}

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -29,6 +29,7 @@ class Auth0Test extends \PHPUnit_Framework_TestCase
         'redirect_uri'  => '__test_redirect_uri__',
         'store' => false,
         'state_handler' => false,
+        'scope' => 'openid offline_access',
     ];
 
     /**
@@ -41,68 +42,111 @@ class Auth0Test extends \PHPUnit_Framework_TestCase
     /**
      * Runs after each test completes.
      */
-    public function tearDown() {
+    public function tearDown()
+    {
         parent::tearDown();
         $_GET = [];
     }
 
     /**
+     * Test that the exchange call returns false before making any HTTP calls if no code is present.
+     *
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Auth0\SDK\Exception\CoreException
      */
-    public function testThatExchangeReturnsFalseIfNoCodePresent() {
+    public function testThatExchangeReturnsFalseIfNoCodePresent()
+    {
         $auth0 = new Auth0( self::$baseConfig );
         $this->assertFalse( $auth0->exchange() );
     }
 
     /**
+     * Test that the exchanges succeeds when there is both and access token and an ID token present.
+     *
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Auth0\SDK\Exception\CoreException
      */
-    public function testThatExchangeSucceedsWithIdToken() {
-
+    public function testThatExchangeSucceedsWithIdToken()
+    {
         $id_token_payload = ['sub' => '123'];
-        $id_token = JWT::encode( $id_token_payload, '__test_client_secret__' );
+        $id_token         = JWT::encode( $id_token_payload, '__test_client_secret__' );
+        $response_body    = '{"access_token":"1.2.3","id_token":"'.$id_token.'","refresh_token":"4.5.6"}';
 
         $mock = new MockHandler( [
             // Code exchange response.
-            new Response( 200, self::$headers, '{"access_token":"1.2.3","id_token":"' . $id_token . '"}' ),
+            new Response( 200, self::$headers, $response_body ),
             // Userinfo response.
             new Response( 200, self::$headers, json_encode( $id_token_payload ) ),
         ] );
 
-        $config = self::$baseConfig + [ 'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ] ];
+        $add_config   = ['guzzle_options' => ['handler' => HandlerStack::create($mock)]];
+        $auth0        = new Auth0( self::$baseConfig + $add_config );
         $_GET['code'] = uniqid();
-
-        $auth0 = new Auth0( $config );
 
         $this->assertTrue( $auth0->exchange() );
         $this->assertEquals( $id_token_payload, $auth0->getUser() );
         $this->assertEquals( $id_token, $auth0->getIdToken() );
         $this->assertEquals( '1.2.3', $auth0->getAccessToken() );
+        $this->assertEquals( '4.5.6', $auth0->getRefreshToken() );
     }
 
     /**
+     * Test that the exchanges succeeds when there is only an access token.
+     *
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Auth0\SDK\Exception\CoreException
      */
-    public function testThatExchangeSucceedsWithNoIdToken() {
-
+    public function testThatExchangeSucceedsWithNoIdToken()
+    {
         $mock = new MockHandler( [
             // Code exchange response.
             // Respond with no ID token, access token with correct number of segments.
-            new Response( 200, self::$headers, '{"access_token":"1.2.3"}' ),
+            new Response( 200, self::$headers, '{"access_token":"1.2.3","refresh_token":"4.5.6"}' ),
             // Userinfo response.
             new Response( 200, self::$headers, '{"sub":"123"}' ),
         ] );
 
-        $config = self::$baseConfig + [ 'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ] ];
+        $add_config   = [
+            'scope' => 'offline_access read:messages',
+            'audience' => 'https://api.identifier',
+            'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ]
+        ];
+        $auth0        = new Auth0( self::$baseConfig + $add_config );
         $_GET['code'] = uniqid();
-
-        $auth0 = new Auth0( $config );
 
         $this->assertTrue( $auth0->exchange() );
         $this->assertEquals( ['sub' => '123'], $auth0->getUser() );
+        $this->assertEquals( '1.2.3', $auth0->getAccessToken() );
+        $this->assertEquals( '4.5.6', $auth0->getRefreshToken() );
+    }
+
+    /**
+     * Test that the skip_userinfo config option uses the ID token instead of calling /userinfo.
+     *
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Auth0\SDK\Exception\CoreException
+     */
+    public function testThatExchangeSkipsUserinfo()
+    {
+        $id_token_payload = ['sub' => 'correct_sub'];
+        $id_token         = JWT::encode( $id_token_payload, '__test_client_secret__' );
+
+        $mock = new MockHandler( [
+            // Code exchange response.
+            new Response( 200, self::$headers, '{"access_token":"1.2.3","id_token":"'.$id_token.'"}' ),
+        ] );
+
+        $add_config   = [
+            'scope' => 'openid',
+            'skip_userinfo' => true,
+            'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ]
+        ];
+        $auth0        = new Auth0( self::$baseConfig + $add_config );
+        $_GET['code'] = uniqid();
+
+        $this->assertTrue( $auth0->exchange() );
+        $this->assertEquals( ['sub' => 'correct_sub'], $auth0->getUser() );
+        $this->assertEquals( $id_token, $auth0->getIdToken() );
         $this->assertEquals( '1.2.3', $auth0->getAccessToken() );
     }
 }


### PR DESCRIPTION
### Changes

Fix Auth0::exchange() to properly handle code exchanges that do not return an `id_token`.

### References

Issue #317 

### Testing

- [x] This change adds test coverage
- [x] This change has been tested up to PHP 7.1.16
