### PR TITLE
Add Telemetry to Generated URLs; Improve API Telemetry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: hhvm
-      dist: trusty
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -70,8 +70,7 @@ class Authentication
         $this->setApiClient();
 
         $infoHeadersData = new InformationHeaders;
-        $infoHeadersData->setPackage('auth0-php', \Auth0\SDK\API\Helpers\ApiClient::API_VERSION);
-        $infoHeadersData->setEnvProperty('php', phpversion());
+        $infoHeadersData->setCorePackage();
         $this->telemetry = $infoHeadersData->build();
     }
 

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -14,6 +14,7 @@ use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\Exception\ApiException;
+use Auth0\SDK\API\Helpers\InformationHeaders;
 use GuzzleHttp\Psr7;
 
 /**
@@ -37,6 +38,8 @@ class Authentication
     private $audience;
 
     private $scope;
+
+    private $telemetry;
 
     /**
      * Authentication constructor.
@@ -65,6 +68,11 @@ class Authentication
         $this->scope         = $scope;
 
         $this->setApiClient();
+
+        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData->setPackage('auth0-php', \Auth0\SDK\API\Helpers\ApiClient::API_VERSION);
+        $infoHeadersData->setEnvProperty('php', phpversion());
+        $this->telemetry = $infoHeadersData->build();
     }
 
     /**
@@ -120,6 +128,8 @@ class Authentication
         if ($state !== null) {
             $additional_params['state'] = $state;
         }
+
+        $additional_params['auth0Client'] = $this->telemetry;
 
         $query_string = Psr7\build_query($additional_params);
 
@@ -210,6 +220,8 @@ class Authentication
         if ($federated) {
             $params['federated'] = '';
         }
+
+        $params['auth0Client'] = $this->telemetry;
 
         $query_string = Psr7\build_query($params);
 

--- a/src/API/Header/Telemetry.php
+++ b/src/API/Header/Telemetry.php
@@ -1,0 +1,16 @@
+<?php
+namespace Auth0\SDK\API\Header;
+
+class Telemetry extends Header
+{
+
+    /**
+     * Telemetry constructor.
+     *
+     * @param string $telemetryData
+     */
+    public function __construct($telemetryData)
+    {
+        parent::__construct('Auth0-Client', $telemetryData);
+    }
+}

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -10,6 +10,7 @@ namespace Auth0\SDK\API\Helpers;
 
 use Auth0\SDK\API\Header\Header;
 use Auth0\SDK\API\Header\ContentType;
+use Auth0\SDK\API\Header\Telemetry;
 
 class ApiClient
 {
@@ -67,7 +68,7 @@ class ApiClient
         $this->guzzleOptions = isset($config['guzzleOptions']) ? $config['guzzleOptions'] : [];
 
         if (self::$infoHeadersDataEnabled) {
-            $this->headers[] = new Header('Auth0-Client', self::getInfoHeadersData()->build());
+            $this->headers[] = new Telemetry(self::getInfoHeadersData()->build());
         }
     }
 

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -37,9 +37,7 @@ class ApiClient
 
         if (self::$infoHeadersData === null) {
             self::$infoHeadersData = new InformationHeaders;
-
-            self::$infoHeadersData->setPackage('auth0-php', self::API_VERSION);
-            self::$infoHeadersData->setEnvProperty('php', phpversion());
+            self::$infoHeadersData->setCorePackage();
         }
 
         return self::$infoHeadersData;

--- a/src/API/Helpers/InformationHeaders.php
+++ b/src/API/Helpers/InformationHeaders.php
@@ -33,6 +33,17 @@ class InformationHeaders
     }
 
     /**
+     * Set the main SDK name and version to the PHP SDK.
+     *
+     * @return void
+     */
+    public function setCorePackage()
+    {
+        $this->setPackage('auth0-php', ApiClient::API_VERSION);
+        $this->setEnvProperty('php', phpversion());
+    }
+
+    /**
      * Add an optional env property for SDK telemetry.
      *
      * @param string $name    Property name to set, name of dependency or platform.

--- a/tests/API/AuthApiTest.php
+++ b/tests/API/AuthApiTest.php
@@ -7,22 +7,25 @@ use Auth0\Tests\API\ApiTests;
 
 class AuthApiTest extends ApiTests
 {
+
     public static $telemetry;
+
     public static $telemetryParam;
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass()
+    {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
 
-        self::$telemetry = urlencode( $infoHeadersData->build() );
-        self::$telemetryParam = 'auth0Client=' . self::$telemetry;
+        self::$telemetry      = urlencode( $infoHeadersData->build() );
+        self::$telemetryParam = 'auth0Client='.self::$telemetry;
     }
 
     public function testThatBasicAuthorizeLinkIsBuiltCorrectly()
     {
         $api = new Authentication('test-domain.auth0.com', '__test_client_id__');
 
-        $authorize_url = $api->get_authorize_link('code', 'https://example.com/cb');
+        $authorize_url       = $api->get_authorize_link('code', 'https://example.com/cb');
         $authorize_url_parts = parse_url( $authorize_url );
 
         $this->assertEquals('https', $authorize_url_parts['scheme']);
@@ -42,7 +45,7 @@ class AuthApiTest extends ApiTests
     {
         $api = new Authentication('test-domain.auth0.com', '__test_client_id__');
 
-        $authorize_url = $api->get_authorize_link('code', 'https://example.com/cb', 'test-connection');
+        $authorize_url       = $api->get_authorize_link('code', 'https://example.com/cb', 'test-connection');
         $authorize_url_query = parse_url( $authorize_url, PHP_URL_QUERY );
         $authorize_url_query = explode( '&', $authorize_url_query );
 
@@ -54,7 +57,7 @@ class AuthApiTest extends ApiTests
     {
         $api = new Authentication('test-domain.auth0.com', '__test_client_id__');
 
-        $authorize_url = $api->get_authorize_link('code', 'https://example.com/cb', null, '__test_state__');
+        $authorize_url       = $api->get_authorize_link('code', 'https://example.com/cb', null, '__test_state__');
         $authorize_url_query = parse_url( $authorize_url, PHP_URL_QUERY );
         $authorize_url_query = explode( '&', $authorize_url_query );
 
@@ -66,8 +69,8 @@ class AuthApiTest extends ApiTests
     {
         $api = new Authentication('test-domain.auth0.com', '__test_client_id__');
 
-        $additional_params = [ 'param1' => 'value1' ];
-        $authorize_url = $api->get_authorize_link('code', 'https://example.com/cb', null, null, $additional_params);
+        $additional_params   = [ 'param1' => 'value1' ];
+        $authorize_url       = $api->get_authorize_link('code', 'https://example.com/cb', null, null, $additional_params);
         $authorize_url_query = parse_url( $authorize_url, PHP_URL_QUERY );
         $authorize_url_query = explode( '&', $authorize_url_query );
 
@@ -169,7 +172,7 @@ class AuthApiTest extends ApiTests
         $logout_link_query = parse_url($api->get_logout_link(null, '__test_client_id__'), PHP_URL_QUERY);
         $logout_link_query = explode( '&', $logout_link_query );
 
-        $this->assertContains('client_id=' . '__test_client_id__', $logout_link_query);
+        $this->assertContains('client_id='.'__test_client_id__', $logout_link_query);
         $this->assertContains(self::$telemetryParam, $logout_link_query);
     }
 

--- a/tests/API/Header/HeaderTest.php
+++ b/tests/API/Header/HeaderTest.php
@@ -5,6 +5,7 @@ namespace Auth0\Tests;
 use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
 use Auth0\SDK\API\Header\Header;
+use Auth0\SDK\API\Header\Telemetry;
 
 class HeaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -39,5 +40,15 @@ class HeaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Content-Type', $header->getHeader());
         $this->assertEquals($contentType, $header->getValue());
         $this->assertEquals("Content-Type: $contentType\n", $header->get());
+    }
+
+    public function testTelemetry()
+    {
+        $telemetry = uniqid();
+        $header    = new Telemetry($telemetry);
+
+        $this->assertEquals('Auth0-Client', $header->getHeader());
+        $this->assertEquals($telemetry, $header->getValue());
+        $this->assertEquals("Auth0-Client: $telemetry\n", $header->get());
     }
 }

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -129,4 +129,25 @@ class InformationHeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('auth0-php', $new_header_data['env']);
         $this->assertEquals(ApiClient::API_VERSION, $new_header_data['env']['auth0-php']);
     }
+
+    /**
+     * Check that setting the core package works correctly.
+     *
+     * @return void
+     */
+    public function testThatCorePackageIsSet()
+    {
+        $header = new InformationHeaders;
+        $header->setCorePackage();
+        $header_data = $header->get();
+
+        $this->assertArrayHasKey( 'name', $header_data );
+        $this->assertArrayHasKey( 'version', $header_data );
+        $this->assertArrayHasKey( 'env', $header_data );
+        $this->assertArrayHasKey( 'php', $header_data['env'] );
+
+        $this->assertEquals( 'auth0-php', $header_data['name'] );
+        $this->assertEquals( ApiClient::API_VERSION, $header_data['version'] );
+        $this->assertEquals( phpversion(), $header_data['env']['php'] );
+    }
 }

--- a/tests/API/Management/ConnectionsTestMocked.php
+++ b/tests/API/Management/ConnectionsTestMocked.php
@@ -3,6 +3,9 @@ namespace Auth0\Tests\API\Management;
 
 use Auth0\Tests\MockApi;
 use Auth0\Tests\Traits\ErrorHelpers;
+
+use Auth0\SDK\API\Helpers\InformationHeaders;
+
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -16,11 +19,28 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
     use ErrorHelpers;
 
     /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $telemetry;
+
+    /**
      * Default request headers.
      *
      * @var array
      */
     protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs before test suite starts.
+     */
+    public static function setUpBeforeClass()
+    {
+        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData->setCorePackage();
+        self::$telemetry = $infoHeadersData->build();
+    }
 
     /**
      * Test a basic getAll connection call.
@@ -38,6 +58,10 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
         $this->assertEmpty( $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$telemetry, $headers['Auth0-Client'][0] );
     }
 
 

--- a/tests/MockApi.php
+++ b/tests/MockApi.php
@@ -111,6 +111,16 @@ class MockApi
     }
 
     /**
+     * Get the headers from a mocked request.
+     *
+     * @return array
+     */
+    public function getHistoryHeaders()
+    {
+        return $this->getHistory()->getHeaders();
+    }
+
+    /**
      * Get a Guzzle history record from an array populated by Middleware::history().
      *
      * @return Request


### PR DESCRIPTION
### Changes

- Remove HHVM from Travis CI ([PHP no longer supported](https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html))
- Add telemetry URL parameter to logout and authorize URLs + additional testing
- Add `Telemetry` child class to consistently set telemetry header
- Add `InformationHeaders->setCorePackage()` to set core SDK and PHP version
- Add telemetry header test to mocked Connections test

### Testing

- [Job with breaking tests](https://travis-ci.org/auth0/auth0-PHP/jobs/491929691) 
- [Job with fixed tests](https://travis-ci.org/auth0/auth0-PHP/jobs/491930372)

- [x] This PR adds unit testing