### PR TITLE
Authentication class cleanup and tests

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -100,7 +100,7 @@ class Authentication
         $client_secret = null,
         $audience = null,
         $scope = null,
-        array $guzzleOptions = []
+        $guzzleOptions = []
     )
     {
         $this->domain        = $domain;

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -1,14 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: germanlena
- * Date: 4/22/15
- * Time: 3:06 PM
- */
-
 namespace Auth0\SDK\API\Helpers;
 
-use Auth0\SDK\API\Header\Header;
 use Auth0\SDK\API\Header\ContentType;
 use Auth0\SDK\API\Header\Telemetry;
 

--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -341,8 +341,6 @@ class Oauth2Client
      * To delete an attribute, just set it null. ie: [ 'old_attr' => null ]
      * It will only update the existing attrs and keep the others untouched
      *
-     * TODO: Replace Auth0Api with Management
-     *
      * @see https://auth0.com/docs/apiv2#!/users/patch_users_by_id
      *
      * @param array $metadata

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -188,7 +188,7 @@ class Auth0
      *
      * @see http://docs.guzzlephp.org/en/stable/request-options.html
      */
-    protected $guzzleOptions;
+    protected $guzzleOptions = [];
 
     /**
      * Skip the /userinfo endpoint call and use the ID token.

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: germanlena
- * Date: 4/23/15
- * Time: 12:03 PM
- */
 
 namespace Auth0\SDK\Exception;
 

--- a/src/Exception/CoreException.php
+++ b/src/Exception/CoreException.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: germanlena
- * Date: 4/23/15
- * Time: 12:04 PM
- */
 
 namespace Auth0\SDK\Exception;
 

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: germanlena
- * Date: 4/23/15
- * Time: 12:04 PM
- */
 
 namespace Auth0\SDK\Exception;
 

--- a/tests/API/Authentication/UrlBuildersTest.php
+++ b/tests/API/Authentication/UrlBuildersTest.php
@@ -121,4 +121,76 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('federated=', $logout_link_query);
         $this->assertContains(self::$telemetryParam, $logout_link_query);
     }
+
+    public function testThatSamlLinkIsBuiltProperly()
+    {
+        $api = new Authentication('test-domain.auth0.com', 'test-client-id-1');
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/samlp/test-client-id-1?connection=',
+            $api->get_samlp_link()
+        );
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/samlp/test-client-id-2?connection=',
+            $api->get_samlp_link( 'test-client-id-2' )
+        );
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/samlp/test-client-id-3?connection=test-connection',
+            $api->get_samlp_link( 'test-client-id-3', 'test-connection' )
+        );
+    }
+
+    public function testThatSamlMetadataLinkIsBuiltProperly()
+    {
+        $api = new Authentication('test-domain.auth0.com', 'test-client-id-1');
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/samlp/metadata/test-client-id-1',
+            $api->get_samlp_metadata_link()
+        );
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/samlp/metadata/test-client-id-2',
+            $api->get_samlp_metadata_link( 'test-client-id-2' )
+        );
+    }
+
+    public function testThatWsFedLinkIsBuiltProperly()
+    {
+        $api = new Authentication('test-domain.auth0.com', 'test-client-id-1');
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/wsfed/test-client-id-1?',
+            $api->get_wsfed_link()
+        );
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/wsfed/test-client-id-2?',
+            $api->get_wsfed_link( 'test-client-id-2' )
+        );
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/wsfed/test-client-id-3?wtrealm=test_wtrealm&whr=test_whr&wctx=test_wctx',
+            $api->get_wsfed_link(
+                'test-client-id-3',
+                [
+                    'wtrealm' => 'test_wtrealm',
+                    'whr' => 'test_whr',
+                    'wctx' => 'test_wctx',
+                ]
+            )
+        );
+    }
+
+    public function testThatWsFedMetadataLinkIsBuiltProperly()
+    {
+        $api = new Authentication('test-domain.auth0.com');
+
+        $this->assertEquals(
+            'https://test-domain.auth0.com/wsfed/FederationMetadata/2007-06/FederationMetadata.xml',
+            $api->get_wsfed_metadata_link()
+        );
+    }
 }


### PR DESCRIPTION
### Changes

Very minimal functionality changes. 

- Allow null `$client_id` for `Authentication::get_samlp_link()`, `Authentication::get_samlp_metadata_link()`, and `Authentication::get_wsfed_link()` to use initialized client ID value.
-  Add request parameters to `Authentication::get_wsfed_link()`
- Docblock improvements throughout `Authentication` class, along with TODOs for deprecation and exclusions from code quality scan. 

### Testing

- [x] This change adds test coverage

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
