### PR TITLE
Remove URL telemetry; add extended telemetry header tests

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -75,13 +75,6 @@ class Authentication
     private $apiClient;
 
     /**
-     * Telemetry data to add to headers and URL parameters.
-     *
-     * @var string
-     */
-    private $telemetry;
-
-    /**
      * Authentication constructor.
      *
      * @param string      $domain        Tenant domain, found in Application settings.
@@ -110,14 +103,11 @@ class Authentication
         $this->scope         = $scope;
         $this->guzzleOptions = $guzzleOptions;
 
-        $apiClient = new ApiClient( [
+        $this->apiClient = new ApiClient( [
             'domain' => 'https://'.$this->domain,
             'basePath' => '/',
             'guzzleOptions' => $guzzleOptions
         ] );
-
-        $this->apiClient = $apiClient;
-        $this->telemetry = $apiClient::getInfoHeadersData()->build();
     }
 
     // phpcs:disable
@@ -170,7 +160,6 @@ class Authentication
         $additional_params['response_type'] = $response_type;
         $additional_params['redirect_uri']  = $redirect_uri;
         $additional_params['client_id']     = $this->client_id;
-        $additional_params['auth0Client']   = $this->telemetry;
 
         if ($connection !== null) {
             $additional_params['connection'] = $connection;
@@ -275,9 +264,7 @@ class Authentication
      */
     public function get_logout_link($returnTo = null, $client_id = null, $federated = false)
     {
-        $params = [
-            'auth0Client' => $this->telemetry,
-        ];
+        $params = [];
 
         if ($returnTo !== null) {
             $params['returnTo'] = $returnTo;

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -110,15 +110,14 @@ class Authentication
         $this->scope         = $scope;
         $this->guzzleOptions = $guzzleOptions;
 
-        $this->apiClient = new ApiClient( [
+        $apiClient = new ApiClient( [
             'domain' => 'https://'.$this->domain,
             'basePath' => '/',
             'guzzleOptions' => $guzzleOptions
         ] );
 
-        $infoHeadersData = new InformationHeaders;
-        $infoHeadersData->setCorePackage();
-        $this->telemetry = $infoHeadersData->build();
+        $this->apiClient = $apiClient;
+        $this->telemetry = $apiClient::getInfoHeadersData()->build();
     }
 
     // phpcs:disable

--- a/tests/API/Authentication/UrlBuildersTest.php
+++ b/tests/API/Authentication/UrlBuildersTest.php
@@ -7,19 +7,6 @@ use Auth0\SDK\API\Helpers\InformationHeaders;
 class UrlBuildersTest extends \PHPUnit_Framework_TestCase
 {
 
-    public static $telemetry;
-
-    public static $telemetryParam;
-
-    public static function setUpBeforeClass()
-    {
-        $infoHeadersData = new InformationHeaders;
-        $infoHeadersData->setCorePackage();
-
-        self::$telemetry      = urlencode( $infoHeadersData->build() );
-        self::$telemetryParam = 'auth0Client='.self::$telemetry;
-    }
-
     public function testThatBasicAuthorizeLinkIsBuiltCorrectly()
     {
         $api = new Authentication('test-domain.auth0.com', '__test_client_id__');
@@ -35,7 +22,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('redirect_uri=https%3A%2F%2Fexample.com%2Fcb', $authorize_url_query);
         $this->assertContains('response_type=code', $authorize_url_query);
         $this->assertContains('client_id=__test_client_id__', $authorize_url_query);
-        $this->assertContains(self::$telemetryParam, $authorize_url_query);
         $this->assertNotContains('connection=', $authorize_url_parts['query']);
         $this->assertNotContains('state=', $authorize_url_parts['query']);
     }
@@ -49,7 +35,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $authorize_url_query = explode( '&', $authorize_url_query );
 
         $this->assertContains('connection=test-connection', $authorize_url_query);
-        $this->assertContains(self::$telemetryParam, $authorize_url_query);
     }
 
     public function testThatAuthorizeLinkIncludesState()
@@ -61,7 +46,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $authorize_url_query = explode( '&', $authorize_url_query );
 
         $this->assertContains('state=__test_state__', $authorize_url_query);
-        $this->assertContains(self::$telemetryParam, $authorize_url_query);
     }
 
     public function testThatAuthorizeLinkIncludesAdditionalParams()
@@ -74,7 +58,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $authorize_url_query = explode( '&', $authorize_url_query );
 
         $this->assertContains('param1=value1', $authorize_url_query);
-        $this->assertContains(self::$telemetryParam, $authorize_url_query);
     }
 
     public function testThatBasicLogoutLinkIsBuiltCorrectly()
@@ -86,7 +69,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https', $logout_link_parts['scheme']);
         $this->assertEquals('test-domain.auth0.com', $logout_link_parts['host']);
         $this->assertEquals('/v2/logout', $logout_link_parts['path']);
-        $this->assertEquals(self::$telemetryParam, $logout_link_parts['query']);
     }
 
     public function testThatReturnToLogoutLinkIsBuiltCorrectly()
@@ -97,7 +79,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $logout_link_query = explode( '&', $logout_link_query );
 
         $this->assertContains('returnTo=https%3A%2F%2Fexample.com%2Freturn-to', $logout_link_query);
-        $this->assertContains(self::$telemetryParam, $logout_link_query);
     }
 
     public function testThatClientIdLogoutLinkIsBuiltCorrectly()
@@ -108,7 +89,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $logout_link_query = explode( '&', $logout_link_query );
 
         $this->assertContains('client_id='.'__test_client_id__', $logout_link_query);
-        $this->assertContains(self::$telemetryParam, $logout_link_query);
     }
 
     public function testThatFederatedLogoutLinkIsBuiltCorrectly()
@@ -119,7 +99,6 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $logout_link_query = explode( '&', $logout_link_query );
 
         $this->assertContains('federated=', $logout_link_query);
-        $this->assertContains(self::$telemetryParam, $logout_link_query);
     }
 
     public function testThatSamlLinkIsBuiltProperly()

--- a/tests/API/Authentication/UrlBuildersTest.php
+++ b/tests/API/Authentication/UrlBuildersTest.php
@@ -24,6 +24,9 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('client_id=__test_client_id__', $authorize_url_query);
         $this->assertNotContains('connection=', $authorize_url_parts['query']);
         $this->assertNotContains('state=', $authorize_url_parts['query']);
+
+        // Telemetry should not be added to any browser URLs.
+        $this->assertNotContains('auth0Client=', $authorize_url_parts['query']);
     }
 
     public function testThatAuthorizeLinkIncludesConnection()
@@ -69,6 +72,10 @@ class UrlBuildersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https', $logout_link_parts['scheme']);
         $this->assertEquals('test-domain.auth0.com', $logout_link_parts['host']);
         $this->assertEquals('/v2/logout', $logout_link_parts['path']);
+
+        // Telemetry should not be added to browser URLs.
+        // If a query is added in the future, change this to check that auth0Client is not present.
+        $this->assertTrue( empty( $logout_link_parts['query'] ) );
     }
 
     public function testThatReturnToLogoutLinkIsBuiltCorrectly()

--- a/tests/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/API/Helpers/InformationHeadersExtendTest.php
@@ -78,38 +78,6 @@ class InformationHeadersExtendTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals( $new_headers->build(), $headers['Auth0-Client'][0] );
     }
 
-    /**
-     * Test that extending the headers works for built authorize URLs.
-     *
-     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
-     */
-    public function testThatExtendedHeadersAreUsedForAuthorizeUrl()
-    {
-        $new_headers      = self::setExtendedHeaders('test-extend-sdk-4', '4.5.6');
-        $expect_telemetry = rawurlencode($new_headers->build());
-
-        $api      = new MockAuthenticationApi( [ new Response( 200 ) ] );
-        $auth_url = $api->call()->get_authorize_link( uniqid(), uniqid() );
-
-        $this->assertContains( 'auth0Client='.$expect_telemetry, $auth_url );
-    }
-
-    /**
-     * Test that extending the headers works for built logout URLs.
-     *
-     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
-     */
-    public function testThatExtendedHeadersAreUsedForLogoutUrl()
-    {
-        $new_headers      = self::setExtendedHeaders('test-extend-sdk-5', '5.6.7');
-        $expect_telemetry = rawurlencode($new_headers->build());
-
-        $api        = new MockAuthenticationApi( [ new Response( 200 ) ] );
-        $logout_url = $api->call()->get_logout_link();
-
-        $this->assertContains( 'auth0Client='.$expect_telemetry, $logout_url );
-    }
-
     /*
      * Test helper methods.
      */

--- a/tests/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/API/Helpers/InformationHeadersExtendTest.php
@@ -1,0 +1,137 @@
+<?php
+namespace Auth0\Tests\Api\Helpers;
+
+use Auth0\Tests\API\Management\MockManagementApi;
+use Auth0\Tests\API\Authentication\MockAuthenticationApi;
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Helpers\ApiClient;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Class InformationHeadersExtendTest
+ *
+ * @package Auth0\Tests\Api\Helpers
+ */
+class InformationHeadersExtendTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Extend existing headers and make sure existing data stays intact.
+     *
+     * @link https://github.com/auth0/jwt-auth-bundle/blob/master/src/JWTAuthBundle.php
+     * @link https://github.com/auth0/laravel-auth0/blob/master/src/Auth0/Login/LoginServiceProvider.php
+     *
+     * @return void
+     */
+    public function testThatExtendedHeadersBuildCorrectly()
+    {
+        $new_headers = self::setExtendedHeaders('test-extend-sdk-1', '1.2.3');
+        $new_headers->setEnvironment('test-extend-env', '2.3.4');
+
+        $new_header_data = $new_headers->get();
+
+        // Look for new SDK name and version.
+        $this->assertEquals( 'test-extend-sdk-1', $new_header_data['name'] );
+        $this->assertEquals( '1.2.3', $new_header_data['version'] );
+
+        // Look for original env data.
+        $this->assertArrayHasKey('env', $new_header_data);
+        $this->assertArrayHasKey('php', $new_header_data['env']);
+        $this->assertEquals( phpversion(), $new_header_data['env']['php'] );
+        $this->assertArrayHasKey('auth0-php', $new_header_data['env']);
+        $this->assertEquals(ApiClient::API_VERSION, $new_header_data['env']['auth0-php']);
+
+        // Look for extended env data.
+        $this->assertArrayHasKey('test-extend-env', $new_header_data['env']);
+        $this->assertEquals('2.3.4', $new_header_data['env']['test-extend-env']);
+    }
+
+    /**
+     * Test that extending the headers works for Management API calls.
+     *
+     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
+     */
+    public function testThatExtendedHeadersAreUsedForManagementApiCalls()
+    {
+        $new_headers = self::setExtendedHeaders('test-extend-sdk-2', '2.3.4');
+
+        $api = new MockManagementApi( [ new Response( 200 ) ] );
+        $api->call()->connections->getAll();
+        $headers = $api->getHistoryHeaders();
+
+        $this->assertEquals( $new_headers->build(), $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that extending the headers works for Management API calls.
+     *
+     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
+     */
+    public function testThatExtendedHeadersAreUsedForAuthenticationApiCalls()
+    {
+        $new_headers = self::setExtendedHeaders('test-extend-sdk-3', '3.4.5');
+
+        $api = new MockAuthenticationApi( [ new Response( 200 ) ] );
+        $api->call()->oauth_token( [ 'grant_type' => uniqid() ] );
+        $headers = $api->getHistoryHeaders();
+
+        $this->assertEquals( $new_headers->build(), $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that extending the headers works for built authorize URLs.
+     *
+     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
+     */
+    public function testThatExtendedHeadersAreUsedForAuthorizeUrl()
+    {
+        $new_headers      = self::setExtendedHeaders('test-extend-sdk-4', '4.5.6');
+        $expect_telemetry = rawurlencode($new_headers->build());
+
+        $api      = new MockAuthenticationApi( [ new Response( 200 ) ] );
+        $auth_url = $api->call()->get_authorize_link( uniqid(), uniqid() );
+
+        $this->assertContains( 'auth0Client='.$expect_telemetry, $auth_url );
+    }
+
+    /**
+     * Test that extending the headers works for built logout URLs.
+     *
+     * @throws \Exception Unsuccessful HTTP call or empty mock history queue.
+     */
+    public function testThatExtendedHeadersAreUsedForLogoutUrl()
+    {
+        $new_headers      = self::setExtendedHeaders('test-extend-sdk-5', '5.6.7');
+        $expect_telemetry = rawurlencode($new_headers->build());
+
+        $api        = new MockAuthenticationApi( [ new Response( 200 ) ] );
+        $logout_url = $api->call()->get_logout_link();
+
+        $this->assertContains( 'auth0Client='.$expect_telemetry, $logout_url );
+    }
+
+    /*
+     * Test helper methods.
+     */
+
+    /**
+     * Reset and extend telemetry headers.
+     *
+     * @param string $name New SDK name.
+     * @param string $version New SDK version.
+     *
+     * @return InformationHeaders
+     */
+    public static function setExtendedHeaders($name, $version)
+    {
+        $reset_headers = new InformationHeaders;
+        $reset_headers->setCorePackage();
+        ApiClient::setInfoHeadersData($reset_headers);
+
+        $headers     = ApiClient::getInfoHeadersData();
+        $new_headers = InformationHeaders::Extend($headers);
+        $new_headers->setPackage($name, $version);
+        ApiClient::setInfoHeadersData($new_headers);
+        return $new_headers;
+    }
+}

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -103,34 +103,6 @@ class InformationHeadersTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Extend existing headers and make sure existing data stays intact.
-     *
-     * @link https://github.com/auth0/jwt-auth-bundle/blob/master/src/JWTAuthBundle.php
-     * @link https://github.com/auth0/laravel-auth0/blob/master/src/Auth0/Login/LoginServiceProvider.php
-     *
-     * @return void
-     */
-    public function testThatExtendedHeadersBuildCorrectly()
-    {
-        $headers     = ApiClient::getInfoHeadersData();
-        $new_headers = InformationHeaders::Extend($headers);
-
-        $new_headers->setEnvironment('test_env_name_5', '8.9.10');
-        $new_headers->setPackage('test_name_4', '7.8.9');
-
-        $new_header_data = $new_headers->get();
-
-        $this->assertEquals( 'test_name_4', $new_header_data['name'] );
-        $this->assertEquals( '7.8.9', $new_header_data['version'] );
-
-        $this->assertArrayHasKey('env', $new_header_data);
-        $this->assertArrayHasKey('php', $new_header_data['env']);
-        $this->assertEquals( phpversion(), $new_header_data['env']['php'] );
-        $this->assertArrayHasKey('auth0-php', $new_header_data['env']);
-        $this->assertEquals(ApiClient::API_VERSION, $new_header_data['env']['auth0-php']);
-    }
-
-    /**
      * Check that setting the core package works correctly.
      *
      * @return void


### PR DESCRIPTION
### Changes

- Remove telemetry from generated URLs
- Add tests specifically for extended telemetry headers

### Testing

- [x] This change adds test coverage
- [x] This change was developed on PHP 7.1.25. See CI for additional testing. 
