### PR TITLE
Official deprecation of ClientGrants::get()

### DIFF
--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -169,9 +169,16 @@ class ClientGrants extends GenericResource
             ->call();
     }
 
+    /*
+     * Deprecated
+     */
+
+    // phpcs:disable
+
     /**
      * Get a Client Grant.
-     * TODO: Deprecate, cannot get a Client Grant by ID.
+     *
+     * @deprecated 5.4.0, no such endpoint.
      *
      * @param string      $id       Client Grant ID.
      * @param null|string $audience Client Grant audience to filter by.
@@ -179,6 +186,8 @@ class ClientGrants extends GenericResource
      * @return mixed
      *
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @codeCoverageIgnore - Deprecated.
      */
     public function get($id, $audience = null)
     {
@@ -191,4 +200,6 @@ class ClientGrants extends GenericResource
 
         return $request->call();
     }
+
+    // phpcs:enable
 }


### PR DESCRIPTION
### Changes

Deprecate `\Auth0\SDK\API\Management\ClientGrants::get()` (so such endpoint)

### References

[Client Grants API docs](https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants)
