### PR TITLE
Add jwk format rsa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php": "^5.5 || ^7.0",
     "guzzlehttp/guzzle": "~6.0",
     "ext-json": "*",
-    "firebase/php-jwt" : "^5.0"
+    "firebase/php-jwt" : "^5.0",
+    "phpseclib/phpseclib": "~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.7",

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -217,7 +217,7 @@ class JWTVerifier
             }
 
             $jwks_url                   = $body_decoded->iss.$this->jwks_path;
-            $secret[$head_decoded->kid] = $this->JWKFetcher->requestJwkX5c($jwks_url, $head_decoded->kid);
+            $secret[$head_decoded->kid] = $this->JWKFetcher->requestJwkSig($jwks_url, $head_decoded->kid);
         }
 
         try {


### PR DESCRIPTION
### Changes

- Add dependancy to phpseclib
- Permit to use RSA key to verify JWT if remote JWK server not support x5c

### References

Auth0 not works with Keycloak server which not provide x5c and publish keys on URL : /realms/<realm>/protocol/openid-connect/certs intead of /realms/<realm>/.well-known/jwks.json

### Testing

Use a JWK JSON like this :
```json
{"keys":[{"kid":"8RFM03BotlgHRqV3f1bdJVgtCEr116PxYEkB2ZWdWUI","kty":"RSA","alg":"RS256","use":"sig","n":"ty5-obtXjnBAC-nfNQZ_3lxVqor3X-s08XN1ui-8ipgO1AtZeW1G2uBoXA39sux9ub77-9QuT7cLtWWBGugP2UVfvU9kiyEpRJLg9JANR-A49LjWwM-w61buPCaFxxXWyFwJTMapTXDFQGT6yLpocJj1WOmJ6Z1V5B--3EZrAvtAd6-HrFI8L5V8d0yJ-PoK6A3n46q60SxV6MRPP19uCpGL2HKotCyB9TROrNqq1_6NrRPmPpLQTzgzsqnaAm7Hj2YXQnORUpSk2m3iEuPnoa5l9hxHOa6LCFDrQLDgnz1AvjzcXc3GYr4FtVAqF-D_bwUwZp9i95QMj6ZE95gk8w","e":"AQAB"}]}
```
