### PR TITLE
Add missing User endpoints for Management API

### DIFF
--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -106,6 +106,7 @@ class GenericResource
         }
 
         foreach ($permissions as $permission) {
+            
             if (empty( $permission['permission_name'] )) {
                 throw new InvalidPermissionsArrayException();
             }

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -79,19 +79,19 @@ class Users extends GenericResource
             throw new \Exception('Missing required "connection" field.');
         }
 
+        // A phone number is required for sms connections.
         if ('sms' === $data['connection'] && empty($data['phone_number'])) {
-            // "phone_number" field is required for an sms connection.
             throw new \Exception('Missing required "phone_number" field for sms connection.');
-        } else if ('sms' !== $data['connection']) {
-            // "email" field is required for email and DB connections.
-            if (empty($data['email'])) {
-                throw new \Exception('Missing required "email" field.');
-            }
+        }
 
-            // Passwords are required for DB connections.
-            if ('email' !== $data['connection'] && empty($data['password'])) {
-                throw new \Exception('Missing required "password" field for "'.$data['connection'].'" connection.');
-            }
+        // An email is required for email and DB connections.
+        if ('sms' !== $data['connection'] && empty($data['email'])) {
+            throw new \Exception('Missing required "email" field.');
+        }
+
+        // A password is required for DB connections.
+        if (! in_array( $data['connection'], [ 'email', 'sms' ] ) && empty($data['password'])) {
+            throw new \Exception('Missing required "password" field for "'.$data['connection'].'" connection.');
         }
 
         return $this->apiClient->method('post')
@@ -244,7 +244,7 @@ class Users extends GenericResource
      *      - "read:roles"
      *
      * @param string $user_id User ID to get roles for.
-     * @param array $params Additional listing params like page, per_page, and include_totals.
+     * @param array  $params  Additional listing params like page, per_page, and include_totals.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
@@ -253,7 +253,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
      */
-    public function getRoles( $user_id, array $params = [] )
+    public function getRoles($user_id, array $params = [])
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -277,16 +277,17 @@ class Users extends GenericResource
      * Required scope: "update:users"
      *
      * @param string $user_id User ID to remove roles from.
-     * @param array $roles Array of permissions to remove.
+     * @param array  $roles   Array of permissions to remove.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws CoreException Thrown if the roles parameter is empty.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_user_roles
      */
-    public function removeRoles( $user_id, array $roles )
+    public function removeRoles($user_id, array $roles)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -312,16 +313,17 @@ class Users extends GenericResource
      *      - "read:roles"
      *
      * @param string $user_id User ID to add roles to.
-     * @param array $roles Array of roles to add.
+     * @param array  $roles   Array of roles to add.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws CoreException Thrown if the roles parameter is empty.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_user_roles
      */
-    public function addRoles( $user_id, array $roles )
+    public function addRoles($user_id, array $roles)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -353,7 +355,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
      */
-    public function getEnrollments( $user_id )
+    public function getEnrollments($user_id)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -370,7 +372,7 @@ class Users extends GenericResource
      * Required scope: "read:users"
      *
      * @param string $user_id User ID to get permissions for.
-     * @param array $params Additional listing params like page, per_page, and include_totals.
+     * @param array  $params  Additional listing params like page, per_page, and include_totals.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
@@ -379,7 +381,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_permissions
      */
-    public function getPermissions( $user_id, array $params = [] )
+    public function getPermissions($user_id, array $params = [])
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -402,24 +404,21 @@ class Users extends GenericResource
      * Remove one or more permissions from a specific user.
      * Required scope: "update:users"
      *
-     * @param string $user_id User ID to remove permissions from.
-     * @param array $permissions Array of permissions to remove.
+     * @param string $user_id     User ID to remove permissions from.
+     * @param array  $permissions Array of permissions to remove.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws CoreException Thrown if the permissions parameter is malformed.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_permissions
      */
-    public function removePermissions( $user_id, array $permissions )
+    public function removePermissions($user_id, array $permissions)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
-        }
-
-        if (empty($permissions)) {
-            throw new CoreException('Empty permissions parameter.');
         }
 
         if ($this->containsInvalidPermissions( $permissions )) {
@@ -441,24 +440,21 @@ class Users extends GenericResource
      * Add one or more permissions to a specific user.
      * Required scope: "update:users"
      *
-     * @param string $user_id User ID to add permissions to.
-     * @param array $permissions Array of permissions to add.
+     * @param string $user_id     User ID to add permissions to.
+     * @param array  $permissions Array of permissions to add.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws CoreException Thrown if the permissions parameter is malformed.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_permissions
      */
-    public function addPermissions( $user_id, array $permissions )
+    public function addPermissions($user_id, array $permissions)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
-        }
-
-        if (empty($permissions)) {
-            throw new CoreException('Empty permissions parameter.');
         }
 
         if ($this->containsInvalidPermissions( $permissions )) {
@@ -481,7 +477,7 @@ class Users extends GenericResource
      * Required scope: "read:logs"
      *
      * @param string $user_id User ID to get logs entries for.
-     * @param array $params Additional listing params like page, per_page, sort, and include_totals.
+     * @param array  $params  Additional listing params like page, per_page, sort, and include_totals.
      *
      * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
@@ -490,7 +486,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_logs_by_user
      */
-    public function getLogs( $user_id, array $params = [] )
+    public function getLogs($user_id, array $params = [])
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -522,7 +518,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
      */
-    public function generateRecoveryCode( $user_id )
+    public function generateRecoveryCode($user_id)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');
@@ -547,7 +543,7 @@ class Users extends GenericResource
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
      */
-    public function invalidateBrowsers( $user_id )
+    public function invalidateBrowsers($user_id)
     {
         if (empty($user_id) || ! is_string($user_id)) {
             throw new CoreException('Invalid or missing user_id parameter.');

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -2,7 +2,8 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+use Auth0\SDK\Exception\InvalidPermissionsArrayException;
 
 /**
  * Class Users.
@@ -246,7 +247,7 @@ class Users extends GenericResource
      * @param string $user_id User ID to get roles for.
      * @param array  $params  Additional listing params like page, per_page, and include_totals.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -255,15 +256,10 @@ class Users extends GenericResource
      */
     public function getRoles($user_id, array $params = [])
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         $params = $this->normalizePagination( $params );
-
-        if (isset( $params['include_totals'] )) {
-            $params['include_totals'] = boolval( $params['include_totals'] );
-        }
+        $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
@@ -279,8 +275,8 @@ class Users extends GenericResource
      * @param string $user_id User ID to remove roles from.
      * @param array  $roles   Array of permissions to remove.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
-     * @throws CoreException Thrown if the roles parameter is empty.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the roles parameter is empty.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -289,12 +285,10 @@ class Users extends GenericResource
      */
     public function removeRoles($user_id, array $roles)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         if (empty($roles)) {
-            throw new CoreException('Empty roles parameter.');
+            throw new EmptyOrInvalidParameterException('roles');
         }
 
         $data = [ 'roles' => $roles ];
@@ -315,8 +309,8 @@ class Users extends GenericResource
      * @param string $user_id User ID to add roles to.
      * @param array  $roles   Array of roles to add.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
-     * @throws CoreException Thrown if the roles parameter is empty.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the roles parameter is empty.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -325,12 +319,10 @@ class Users extends GenericResource
      */
     public function addRoles($user_id, array $roles)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         if (empty($roles)) {
-            throw new CoreException('Empty roles parameter.');
+            throw new EmptyOrInvalidParameterException('roles');
         }
 
         $data = [ 'roles' => $roles ];
@@ -348,7 +340,7 @@ class Users extends GenericResource
      *
      * @param string $user_id User ID to get enrollments for.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -357,9 +349,7 @@ class Users extends GenericResource
      */
     public function getEnrollments($user_id)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
@@ -374,7 +364,7 @@ class Users extends GenericResource
      * @param string $user_id User ID to get permissions for.
      * @param array  $params  Additional listing params like page, per_page, and include_totals.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -383,15 +373,10 @@ class Users extends GenericResource
      */
     public function getPermissions($user_id, array $params = [])
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         $params = $this->normalizePagination( $params );
-
-        if (isset( $params['include_totals'] )) {
-            $params['include_totals'] = boolval( $params['include_totals'] );
-        }
+        $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
@@ -407,8 +392,8 @@ class Users extends GenericResource
      * @param string $user_id     User ID to remove permissions from.
      * @param array  $permissions Array of permissions to remove.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
-     * @throws CoreException Thrown if the permissions parameter is malformed.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
+     * @throws InvalidPermissionsArrayException Thrown if the permissions parameter is malformed.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -417,15 +402,8 @@ class Users extends GenericResource
      */
     public function removePermissions($user_id, array $permissions)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
-
-        if ($this->containsInvalidPermissions( $permissions )) {
-            throw new CoreException(
-                'Permissions must include both permission_name and resource_server_identifier keys.'
-            );
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
+        $this->checkInvalidPermissions( $permissions );
 
         $data = [ 'permissions' => $permissions ];
 
@@ -443,8 +421,8 @@ class Users extends GenericResource
      * @param string $user_id     User ID to add permissions to.
      * @param array  $permissions Array of permissions to add.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
-     * @throws CoreException Thrown if the permissions parameter is malformed.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
+     * @throws InvalidPermissionsArrayException Thrown if the permissions parameter is malformed.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -453,15 +431,8 @@ class Users extends GenericResource
      */
     public function addPermissions($user_id, array $permissions)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
-
-        if ($this->containsInvalidPermissions( $permissions )) {
-            throw new CoreException(
-                'Permissions must include both permission_name and resource_server_identifier keys.'
-            );
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
+        $this->checkInvalidPermissions( $permissions );
 
         $data = [ 'permissions' => $permissions ];
 
@@ -479,7 +450,7 @@ class Users extends GenericResource
      * @param string $user_id User ID to get logs entries for.
      * @param array  $params  Additional listing params like page, per_page, sort, and include_totals.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -488,15 +459,10 @@ class Users extends GenericResource
      */
     public function getLogs($user_id, array $params = [])
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         $params = $this->normalizePagination( $params );
-
-        if (isset( $params['include_totals'] )) {
-            $params['include_totals'] = boolval( $params['include_totals'] );
-        }
+        $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
@@ -511,7 +477,7 @@ class Users extends GenericResource
      *
      * @param string $user_id User ID to remove and generate recovery codes for.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -520,9 +486,7 @@ class Users extends GenericResource
      */
     public function generateRecoveryCode($user_id)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)
@@ -536,7 +500,7 @@ class Users extends GenericResource
      *
      * @param string $user_id User ID to invalidate browsers for.
      *
-     * @throws CoreException Thrown if the user_id parameter is empty or is not a string.
+     * @throws EmptyOrInvalidParameterException Thrown if the user_id parameter is empty or is not a string.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
@@ -545,9 +509,7 @@ class Users extends GenericResource
      */
     public function invalidateBrowsers($user_id)
     {
-        if (empty($user_id) || ! is_string($user_id)) {
-            throw new CoreException('Invalid or missing user_id parameter.');
-        }
+        $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -2,6 +2,7 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\SDK\API\Management;
+use Auth0\SDK\Exception\CoreException;
 use Auth0\Tests\Traits\ErrorHelpers;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
@@ -9,11 +10,11 @@ use Auth0\SDK\API\Helpers\InformationHeaders;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * Class UsersTestMocked.
+ * Class UsersMockedTest.
  *
  * @package Auth0\Tests\API\Management
  */
-class UsersTestMocked extends \PHPUnit_Framework_TestCase
+class UsersMockedTest extends \PHPUnit_Framework_TestCase
 {
 
     use ErrorHelpers;
@@ -49,7 +50,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatGetUserRequestIsFormedProperly()
+    public function testThatGetUserRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -71,7 +72,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatUpdateUserRequestIsFormedProperly()
+    public function testThatUpdateUserRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -164,7 +165,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatCreateUserRequestIsFormedProperly()
+    public function testThatCreateUserRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -198,7 +199,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatGetAllUsersRequestIsFormedProperly()
+    public function testThatGetAllUsersRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -417,7 +418,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatDeleteUserRequestIsFormedProperly()
+    public function testThatDeleteUserRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -439,7 +440,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatLinkAccountRequestIsFormedProperly()
+    public function testThatLinkAccountRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -476,7 +477,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatUnlinkAccountRequestIsFormedProperly()
+    public function testThatUnlinkAccountRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -505,7 +506,7 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
      *
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatDeleteMfProviderIsFormedProperly()
+    public function testThatDeleteMfProviderIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
@@ -517,6 +518,611 @@ class UsersTestMocked extends \PHPUnit_Framework_TestCase
             $api->getHistoryUrl()
         );
         $this->assertEmpty( $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that a get roles call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetRolesThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->getRoles( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a get roles call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetRolesRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->getRoles( '__test_user_id__', [ 'per_page' => 5, 'page' => 1, 'include_totals' => 1 ] );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertStringStartsWith( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertContains( 'per_page=5', $query );
+        $this->assertContains( 'page=1', $query );
+        $this->assertContains( 'include_totals=true', $query );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that a remove roles call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemoveRolesThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->removeRoles( '', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a remove roles call throws an exception if roles are missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemoveRolesThrowsExceptionIfRolesAreMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->removeRoles( '__test_user_id__', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Empty roles parameter', $caught_message );
+    }
+
+    /**
+     * Test that a remove roles call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemoveRolesRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->removeRoles( '__test_user_id__', [ '__test_role_id__' ] );
+
+        $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/roles',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'roles', $body );
+        $this->assertCount( 1, $body['roles'] );
+        $this->assertEquals( '__test_role_id__', $body['roles'][0] );
+    }
+
+    /**
+     * Test that an add roles call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddRolesThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->addRoles( '', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that an add roles call throws an exception if roles are missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddRolesThrowsExceptionIfRolesAreMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->addRoles( '__test_user_id__', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Empty roles parameter', $caught_message );
+    }
+
+    /**
+     * Test that an add roles call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddRolesRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->addRoles( '__test_user_id__', [ '__test_role_id__' ] );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/roles',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'roles', $body );
+        $this->assertCount( 1, $body['roles'] );
+        $this->assertEquals( '__test_role_id__', $body['roles'][0] );
+    }
+
+    /**
+     * Test that a get enrollments call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetEnrollmentsThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->getEnrollments( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a get enrollments call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetEnrollmentsRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->getEnrollments( '__test_user_id__' );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertEquals(
+            'https://api.test.local/api/v2/users/__test_user_id__/enrollments',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that a remove permissions call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetPermissionsThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->getPermissions( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a get permissions call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetPermissionsRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->getPermissions(
+            '__test_user_id__',
+            [ 'per_page' => 3, 'page' => 2, 'include_totals' => 0 ]
+        );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/permissions',
+            $api->getHistoryUrl()
+        );
+
+        $query = $api->getHistoryQuery();
+        $this->assertContains( 'per_page=3', $query );
+        $this->assertContains( 'page=2', $query );
+        $this->assertContains( 'include_totals=false', $query );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that a remove permissions call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemovePermissionsThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->removePermissions( '', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a remove permissions call throws an exception if permissions are missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemovePermissionsThrowsExceptionIfPermissionsAreMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->removePermissions( '__test_user_id__', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains(
+            'Permissions must include both permission_name and resource_server_identifier keys',
+            $caught_message
+        );
+    }
+
+    /**
+     * Test that a remove permissions call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatRemovePermissionsRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->removePermissions(
+            '__test_user_id__',
+            [
+                [
+                    'permission_name' => 'test:permission',
+                    'resource_server_identifier' => '__test_api_id__',
+                ]
+            ]
+        );
+
+        $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/permissions',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'permissions', $body );
+        $this->assertCount( 1, $body['permissions'] );
+        $this->assertArrayHasKey( 'permission_name', $body['permissions'][0] );
+        $this->assertEquals( 'test:permission', $body['permissions'][0]['permission_name'] );
+        $this->assertArrayHasKey( 'resource_server_identifier', $body['permissions'][0] );
+        $this->assertEquals( '__test_api_id__', $body['permissions'][0]['resource_server_identifier'] );
+    }
+
+    /**
+     * Test that an add permissions call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddPermissionsThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->addPermissions( '', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that an add permissions call throws an exception if permissions are missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddPermissionsThrowsExceptionIfPermissionsAreMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->addPermissions( '__test_user_id__', [] );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains(
+            'Permissions must include both permission_name and resource_server_identifier keys',
+            $caught_message
+        );
+    }
+
+    /**
+     * Test that an add permissions call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatAddPermissionsRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->addPermissions(
+            '__test_user_id__',
+            [
+                [
+                    'permission_name' => 'test:permission',
+                    'resource_server_identifier' => '__test_api_id__',
+                ]
+            ]
+        );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/permissions',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'permissions', $body );
+        $this->assertCount( 1, $body['permissions'] );
+        $this->assertArrayHasKey( 'permission_name', $body['permissions'][0] );
+        $this->assertEquals( 'test:permission', $body['permissions'][0]['permission_name'] );
+        $this->assertArrayHasKey( 'resource_server_identifier', $body['permissions'][0] );
+        $this->assertEquals( '__test_api_id__', $body['permissions'][0]['resource_server_identifier'] );
+    }
+
+    /**
+     * Test that a get logs call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetLogsThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->getLogs( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that a get logs call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetLogsRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->getLogs(
+            '__test_user_id__',
+            [ 'per_page' => 3, 'page' => 2, 'include_totals' => 0, 'fields' => 'date,type,ip' ]
+        );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/logs',
+            $api->getHistoryUrl()
+        );
+
+        $query = $api->getHistoryQuery();
+        $this->assertContains( 'per_page=3', $query );
+        $this->assertContains( 'page=2', $query );
+        $this->assertContains( 'include_totals=false', $query );
+        $this->assertContains( 'fields=date,type,ip', $query );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that a generate recovery code call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGenerateRecoveryCodeThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->generateRecoveryCode( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that an generate recovery code call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGenerateRecoveryCodeRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->generateRecoveryCode( '__test_user_id__' );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/recovery-code-regeneration',
+            $api->getHistoryUrl()
+        );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * Test that an invalidate browsers call throws an exception if the user ID is missing.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatInvalidateBrowsersThrowsExceptionIfUserIdIsMissing()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->users->invalidateBrowsers( '' );
+            $caught_message = '';
+        } catch (CoreException $e) {
+            $caught_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+    }
+
+    /**
+     * Test that an invalidate browsers call is formatted properly.
+     *
+     * @return void
+     *
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatInvalidateBrowsersRequestIsFormattedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->users->invalidateBrowsers( '__test_user_id__' );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/multifactor/actions/invalidate-remember-browser',
+            $api->getHistoryUrl()
+        );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -3,6 +3,8 @@ namespace Auth0\Tests\API\Management;
 
 use Auth0\SDK\API\Management;
 use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+use Auth0\SDK\Exception\InvalidPermissionsArrayException;
 use Auth0\Tests\Traits\ErrorHelpers;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
@@ -538,11 +540,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->getRoles( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -585,11 +587,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->removeRoles( '', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -606,11 +608,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->removeRoles( '__test_user_id__', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty roles parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid roles', $caught_message );
     }
 
     /**
@@ -657,11 +659,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->addRoles( '', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -678,11 +680,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->addRoles( '__test_user_id__', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty roles parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid roles', $caught_message );
     }
 
     /**
@@ -729,11 +731,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->getEnrollments( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -774,11 +776,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->getPermissions( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -827,11 +829,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->removePermissions( '', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -847,15 +849,12 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         try {
             $api->call()->users->removePermissions( '__test_user_id__', [] );
-            $caught_message = '';
-        } catch (CoreException $e) {
-            $caught_message = $e->getMessage();
+            $caught_exception = false;
+        } catch (InvalidPermissionsArrayException $e) {
+            $caught_exception = true;
         }
 
-        $this->assertContains(
-            'Permissions must include both permission_name and resource_server_identifier keys',
-            $caught_message
-        );
+        $this->assertTrue( $caught_exception );
     }
 
     /**
@@ -913,11 +912,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->addPermissions( '', [] );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -933,15 +932,12 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         try {
             $api->call()->users->addPermissions( '__test_user_id__', [] );
-            $caught_message = '';
-        } catch (CoreException $e) {
-            $caught_message = $e->getMessage();
+            $caught_exception = false;
+        } catch (InvalidPermissionsArrayException $e) {
+            $caught_exception = true;
         }
 
-        $this->assertContains(
-            'Permissions must include both permission_name and resource_server_identifier keys',
-            $caught_message
-        );
+        $this->assertTrue( $caught_exception );
     }
 
     /**
@@ -999,11 +995,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->getLogs( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -1053,11 +1049,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->generateRecoveryCode( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -1098,11 +1094,11 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         try {
             $api->call()->users->invalidateBrowsers( '' );
             $caught_message = '';
-        } catch (CoreException $e) {
+        } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Invalid or missing user_id parameter', $caught_message );
+        $this->assertContains( 'Empty or invalid user_id', $caught_message );
     }
 
     /**


### PR DESCRIPTION
### Changes

Add methods for missing Users endpoints on the Management API:

- `\Auth0\SDK\API\Management\Users::getRoles()`
- `\Auth0\SDK\API\Management\Users::removeRoles()`
- `\Auth0\SDK\API\Management\Users::addRoles()`
- `\Auth0\SDK\API\Management\Users::getEnrollments()`
- `\Auth0\SDK\API\Management\Users::getPermissions()`
- `\Auth0\SDK\API\Management\Users::removePermissions()`
- `\Auth0\SDK\API\Management\Users::addPermissions()`
- `\Auth0\SDK\API\Management\Users::getLogs()`
- `\Auth0\SDK\API\Management\Users::generateRecoveryCode()`
- `\Auth0\SDK\API\Management\Users::invalidateBrowsers()`

## References

[Management API Users docs](https://auth0.com/docs/api/management/v2#!/Users/get_users)

### Testing

- [x] This change adds test coverage

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
