### PR TITLE
Fix user endpoint tests

### DIFF
--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -33,11 +33,11 @@ class ClientGrants extends GenericResource
     public function getAll(array $params = [], $page = null, $per_page = null)
     {
         if (null !== $page) {
-            $params['page'] = abs((int) $page);
+            $params['page'] = abs( (int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs((int) $per_page);
+            $params['per_page'] = abs( (int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -51,7 +51,7 @@ class Clients extends GenericResource
 
         // Pagination.
         if (null !== $page) {
-            $params['page'] = abs((int) $page);
+            $params['page'] = abs( (int) $page);
             if (null !== $per_page) {
                 $params['per_page'] = $per_page;
             }

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -56,7 +56,7 @@ class Connections extends GenericResource
 
         // Pagination.
         if (null !== $page) {
-            $params['page'] = abs((int) $page);
+            $params['page'] = abs( (int) $page);
             if (null !== $per_page) {
                 $params['per_page'] = $per_page;
             }

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -151,7 +151,7 @@ class EmailTemplates extends GenericResource
             'subject' => (string) $subject,
             'body' => (string) $body,
             'syntax' => (string) $syntax,
-            'urlLifetimeInSeconds' => abs((int) $urlLifetime)
+            'urlLifetimeInSeconds' => abs( (int) $urlLifetime)
         ];
 
         if (! empty($resultUrl)) {

--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -106,7 +106,6 @@ class GenericResource
         }
 
         foreach ($permissions as $permission) {
-            
             if (empty( $permission['permission_name'] )) {
                 throw new InvalidPermissionsArrayException();
             }

--- a/src/API/Management/ResourceServers.php
+++ b/src/API/Management/ResourceServers.php
@@ -31,11 +31,11 @@ class ResourceServers extends GenericResource
 
         // Pagination parameters.
         if (null !== $page) {
-            $params['page'] = abs((int) $page);
+            $params['page'] = abs( (int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs((int) $per_page);
+            $params['per_page'] = abs( (int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -47,11 +47,11 @@ class Rules extends GenericResource
 
         // Pagination parameters.
         if (null !== $page) {
-            $params['page'] = abs((int) $page);
+            $params['page'] = abs( (int) $page);
         }
 
         if (null !== $per_page) {
-            $params['per_page'] = abs((int) $per_page);
+            $params['per_page'] = abs( (int) $per_page);
         }
 
         return $this->apiClient->method('get')

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -60,7 +60,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -90,7 +89,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -179,7 +177,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -209,7 +206,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -428,7 +424,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -457,7 +452,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__/identities', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -494,7 +488,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
             'https://api.test.local/api/v2/users/__test_user_id__/identities/__test_provider__/__test_identity_id__',
             $api->getHistoryUrl()
         );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -519,7 +512,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
             'https://api.test.local/api/v2/users/__test_user_id__/multifactor/duo',
             $api->getHistoryUrl()
         );
-        $this->assertEmpty( $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -561,7 +553,10 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api->call()->users->getRoles( '__test_user_id__', [ 'per_page' => 5, 'page' => 1, 'include_totals' => 1 ] );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
-        $this->assertStringStartsWith( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
+        $this->assertStringStartsWith(
+            'https://api.test.local/api/v2/users/__test_user_id__/roles?',
+            $api->getHistoryUrl()
+        );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'per_page=5', $query );
@@ -629,7 +624,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api->call()->users->removeRoles( '__test_user_id__', [ '__test_role_id__' ] );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/roles',
             $api->getHistoryUrl()
         );
@@ -701,7 +696,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api->call()->users->addRoles( '__test_user_id__', [ '__test_role_id__' ] );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/roles',
             $api->getHistoryUrl()
         );
@@ -801,7 +796,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith(
-            'https://api.test.local/api/v2/users/__test_user_id__/permissions',
+            'https://api.test.local/api/v2/users/__test_user_id__/permissions?',
             $api->getHistoryUrl()
         );
 
@@ -879,7 +874,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/permissions',
             $api->getHistoryUrl()
         );
@@ -962,7 +957,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/permissions',
             $api->getHistoryUrl()
         );
@@ -1020,7 +1015,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith(
-            'https://api.test.local/api/v2/users/__test_user_id__/logs',
+            'https://api.test.local/api/v2/users/__test_user_id__/logs?',
             $api->getHistoryUrl()
         );
 
@@ -1070,7 +1065,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api->call()->users->generateRecoveryCode( '__test_user_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/recovery-code-regeneration',
             $api->getHistoryUrl()
         );
@@ -1115,7 +1110,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api->call()->users->invalidateBrowsers( '__test_user_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
-        $this->assertStringStartsWith(
+        $this->assertEquals(
             'https://api.test.local/api/v2/users/__test_user_id__/multifactor/actions/invalidate-remember-browser',
             $api->getHistoryUrl()
         );


### PR DESCRIPTION
### Changes

- Tests were not checking URLs in a way that would account for missing pieces. 
- Small fixes to whitespace based on recent PHP Code Sniffer update

