### PR TITLE
Change normalizeIncludeTotals() in GenericResource to have sane defaults

### DIFF
--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -83,7 +83,7 @@ class GenericResource
         }
 
         // Make sure we have a boolean.
-        $params['include_totals'] = filter_var( $params['include_totals'], FILTER_VALIDATE_BOOLEAN );
+        $params['include_totals'] = filter_var( $params['include_totals'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 
         return $params;
     }

--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -83,7 +83,7 @@ class GenericResource
         }
 
         // Make sure we have a boolean.
-        $params['include_totals'] = boolval( $params['include_totals'] );
+        $params['include_totals'] = filter_var( $params['include_totals'], FILTER_VALIDATE_BOOLEAN );
 
         return $params;
     }

--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -75,7 +75,7 @@ class GenericResource
      *
      * @return array
      */
-    protected function normalizeIncludeTotals(array $params, $include_totals = false)
+    protected function normalizeIncludeTotals(array $params, $include_totals = null)
     {
         // User parameter include_totals if params does not have the key.
         if (! isset( $params['include_totals'] )) {

--- a/src/API/Management/GenericResource.php
+++ b/src/API/Management/GenericResource.php
@@ -75,17 +75,15 @@ class GenericResource
      *
      * @return array
      */
-    protected function normalizeIncludeTotals(array $params, $include_totals = null)
+    protected function normalizeIncludeTotals(array $params, $include_totals = false)
     {
         // User parameter include_totals if params does not have the key.
         if (! isset( $params['include_totals'] )) {
             $params['include_totals'] = $include_totals;
         }
 
-        // If include_totals is set (not null), then make sure we have a boolean.
-        if (isset( $params['include_totals'] )) {
-            $params['include_totals'] = boolval( $params['include_totals'] );
-        }
+        // Make sure we have a boolean.
+        $params['include_totals'] = boolval( $params['include_totals'] );
 
         return $params;
     }


### PR DESCRIPTION
### Changes

- Change default param `include_totals` to be `false` instead of `null`
The endpoint `GET	/api/v2/users/{id}/roles` accepts a param called `include_totals`, which is expected to be a boolean. However, the default in `GenericResource::normalizeIncludeTotals()` is `null`.

I argue that false should be the default, or that the default should be removed all along _(`normalizeIncludeTotals()` unconditionally adds the param, which I believe is wrong, however in this PR I only changed the default though)_.

On submitting `include_totals=null` this is what the API will respond:
```
POST https://xyz.auth0.com/api/v2/users/abc/roles` resulted in a `400 Bad Request` response:
{"statusCode":400,"error":"Bad Request","message":"Payload validation error: 'Expected type string but found type null'  (truncated...)
```

On top of this the function `normalizeIncludeTotals()` had an unnecessary check:
```
if (isset( $params['include_totals'] )) {
```
The key `include_totals` in `$params` will always be set, because either the user provides it, or if not it's added in the statement above. I removed the check whether it's set or not.


### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

[ ] All existing and new tests complete without errors.
=> No, since the testing tenant needs to be precisely tailored for the test.
Getting for instance:
```
POST https://xyz.auth0.com/dbconnections/signup` resulted in a `400 Bad Request` response:
{"error":"public signup is disabled"}
```
And test doesn't contain necessary backoff algorithm, resulting in `too_many_requests`

[x] The correct base branch is being used.
