### PR TITLE
Fix tests to reduce the number of sensitive credentials used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ commands:
   run-tests:
     steps:
       - run: ./vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml
-      - run:
-          command: bash <(curl -s https://codecov.io/bash)
-          when: on_success
+      - store_artifacts:
+          path:  build/coverage.xml
+
 
 jobs:
   php_5:
@@ -39,6 +39,9 @@ jobs:
     steps:
       - prepare
       - run-tests
+      - run:
+          command: bash <(curl -s https://codecov.io/bash)
+          when: on_success
   snyk:
     docker:
       - image: snyk/snyk-cli:composer

--- a/src/API/Helpers/TokenGenerator.php
+++ b/src/API/Helpers/TokenGenerator.php
@@ -7,6 +7,8 @@ use Firebase\JWT\JWT;
  * Class TokenGenerator.
  * Generates HS256 ID tokens.
  *
+ * TODO: Deprecate
+ *
  * @package Auth0\SDK\API\Helpers
  */
 class TokenGenerator

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -3,7 +3,6 @@ namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Authentication;
 use Auth0\Tests\Traits\ErrorHelpers;
-use Auth0\SDK\API\Helpers\TokenGenerator;
 use Auth0\SDK\API\Management;
 use josegonzalez\Dotenv\Loader;
 
@@ -41,7 +40,7 @@ class ApiTests extends \PHPUnit_Framework_TestCase
             }
 
             $auth_api = new Authentication( getenv('DOMAIN'), getenv('APP_CLIENT_ID'), getenv('APP_CLIENT_SECRET') );
-            $response = $auth_api->client_credentials( [ 'audience' => 'https://' . getenv('DOMAIN') . '/api/v2/' ] );
+            $response = $auth_api->client_credentials( [ 'audience' => 'https://'.getenv('DOMAIN').'/api/v2/' ] );
 
             self::$env = [
                 'DOMAIN' => getenv('DOMAIN'),

--- a/tests/API/Authentication/ClientCredentialsTest.php
+++ b/tests/API/Authentication/ClientCredentialsTest.php
@@ -11,7 +11,7 @@ class ClientCredentialsTest extends ApiTests
     {
         $env = self::getEnv();
 
-        $api = new Authentication($env['DOMAIN'], $env['NIC_ID'], $env['NIC_SECRET']);
+        $api = new Authentication($env['DOMAIN'], $env['APP_CLIENT_ID'], $env['APP_CLIENT_SECRET']);
 
         $token = $api->client_credentials(
             [

--- a/tests/API/Authentication/DeprecatedTest.php
+++ b/tests/API/Authentication/DeprecatedTest.php
@@ -33,24 +33,4 @@ class DeprecatedTest extends ApiTests
         $this->assertEquals('german@auth0.com', $userinfo['email']);
         $this->assertEquals('auth0|58adc60b82b0ca0774643eef', $userinfo['user_id']);
     }
-
-    public function testImpersonation()
-    {
-        $env = self::getEnv();
-
-        $api = new Authentication($env['DOMAIN'], $env['GLOBAL_CLIENT_ID'], $env['GLOBAL_CLIENT_SECRET']);
-
-        $token = $api->client_credentials([]);
-
-        $url = $api->impersonate(
-            $token['access_token'],
-            'facebook|1434903327',
-            'oauth2',
-            'auth0|56b110b8d9d327e705e1d2da',
-            'ycynBrUeQUnFqNacG3GAsaTyDhG4h0qT',
-            [ 'response_type' => 'code' ]
-        );
-
-        $this->assertStringStartsWith('https://'.$env['DOMAIN'], $url);
-    }
 }

--- a/tests/API/Helpers/RequestBuilderTest.php
+++ b/tests/API/Helpers/RequestBuilderTest.php
@@ -118,7 +118,7 @@ class RequestBuilderTest extends ApiTests
     public function testReturnType()
     {
         $env   = self::getEnv();
-        $token = self::getToken($env, ['tenant_settings' => ['actions' => ['read']]]);
+        $token = self::getToken($env);
 
         // Test default return type matches "body".
         $api             = new Management($token, $env['DOMAIN'], []);

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -9,22 +9,19 @@ class BlacklistsTest extends ApiTests
 
     private $domain;
 
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     */
     public function testBlacklistAndGet()
     {
         $env   = self::getEnv();
-        $token = self::getToken(
-            $env, [
-                'tokens' => [
-                    'actions' => ['blacklist']
-                ]
-            ]
-        );
+        $token = self::getToken($env);
 
         $this->domain = $env['DOMAIN'];
 
         $api = new Management($token, $env['DOMAIN']);
 
-        $aud = $env['GLOBAL_CLIENT_ID'];
+        $aud = $env['APP_CLIENT_ID'];
         $jti = 'somerandomJTI'.rand();
 
         $api->blacklists->blacklist($aud, $jti);

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -37,11 +37,11 @@ class ClientGrantsTest extends ApiTests
     /**
      * Sets up API client for the testing class.
      *
-     * @return void
+     * @throws \Auth0\SDK\Exception\ApiException
      */
     public static function setUpBeforeClass()
     {
-        self::$api = self::getApi( 'client_grants', ['read', 'create', 'delete', 'update'] );
+        self::$api = self::getApi( 'client_grants' );
     }
 
     /**

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -27,7 +27,7 @@ class ClientsTest extends BasicCrudTest
      */
     protected function getApiClient()
     {
-        $token = self::getToken(self::$env, [ 'clients' => [ 'actions' => ['create', 'read', 'delete', 'update' ] ] ]);
+        $token = self::getToken(self::$env);
         $api   = new Management($token, $this->domain);
         return $api->clients;
     }
@@ -66,8 +66,8 @@ class ClientsTest extends BasicCrudTest
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
 
-        // Make sure we only have the 4 fields we requested.
-        $this->assertEquals(count($fields), count($paged_results[0]));
+        // Make sure we only have the 4 fields we requested plus "tenant".
+        $this->assertEquals(count($fields) + 1, count($paged_results[0]));
 
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -66,7 +66,7 @@ class ClientsTest extends BasicCrudTest
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
 
-        // Make sure we only have the 4 fields we requested plus "tenant".
+        // Make sure we only have the 6 fields we requested.
         $this->assertEquals(count($fields), count($paged_results[0]));
 
         // Get many results (needs to include the created result if self::findCreatedItem === true).

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -57,7 +57,7 @@ class ClientsTest extends BasicCrudTest
     protected function getAllEntities()
     {
         $fields   = array_keys($this->getCreateBody());
-        $fields[] = $this->id_name;
+        $fields   = array_merge( $fields, [ $this->id_name, 'tenant' ] );
         $page_num = 1;
 
         // Get the second page of Clients with 1 per page (second result).
@@ -67,7 +67,7 @@ class ClientsTest extends BasicCrudTest
         $this->assertEquals(1, count($paged_results));
 
         // Make sure we only have the 4 fields we requested plus "tenant".
-        $this->assertEquals(count($fields) + 1, count($paged_results[0]));
+        $this->assertEquals(count($fields), count($paged_results[0]));
 
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;

--- a/tests/API/Management/EmailTemplatesTest.php
+++ b/tests/API/Management/EmailTemplatesTest.php
@@ -77,12 +77,7 @@ class EmailTemplatesTest extends ApiTests
         $env = self::getEnv();
 
         self::$domain = $env['DOMAIN'];
-        self::$token  = self::getToken(
-            $env, [
-                'email_templates' => [ 'actions' => ['create', 'read', 'update'] ],
-                'email_provider' => [ 'actions' => ['read'] ],
-            ]
-        );
+        self::$token  = self::getToken($env);
 
         self::$api = new Management(self::$token, self::$domain);
 

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -24,11 +24,13 @@ class LogsTest extends ApiTests
      * Sets up API client for entire testing class.
      *
      * @return void
+     *
+     * @throws \Auth0\SDK\Exception\ApiException
      */
     public static function setUpBeforeClass()
     {
         $env   = self::getEnv();
-        $token = self::getToken($env, [ 'logs' => [ 'actions' => ['read'] ] ]);
+        $token = self::getToken($env);
         $api   = new Management($token, $env['DOMAIN'], ['timeout' => 30]);
 
         self::$api = $api->logs;

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -49,10 +49,12 @@ class ResourceServersTest extends ApiTests
      * Sets up API client for the testing class.
      *
      * @return void
+     *
+     * @throws \Auth0\SDK\Exception\ApiException
      */
     public static function setUpBeforeClass()
     {
-        self::$api              = self::getApi( 'resource_servers', ['read', 'create', 'delete', 'update'] );
+        self::$api              = self::getApi( 'resource_servers' );
         self::$serverIdentifier = 'TEST_PHP_SDK_ID_'.uniqid();
     }
 

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -25,10 +25,12 @@ class RulesTest extends ApiTests
      * Sets up API client for the testing class.
      *
      * @return void
+     *
+     * @throws \Auth0\SDK\Exception\ApiException
      */
     public static function setUpBeforeClass()
     {
-        self::$api = self::getApi( 'rules', ['read', 'create', 'delete', 'update'] );
+        self::$api = self::getApi( 'rules' );
     }
 
     /**


### PR DESCRIPTION
### Changes

- Generate Management API token from client credentials grant
- Switch testing app to a single application
- Remove impersonation test
- Remove need for global tenant client information

### Testing

- [x] This change modifies test coverage
- [x] This change has been tested on PHP 7.1.29
