### PR TITLE
Fix empty url params

### DIFF
--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -191,15 +191,14 @@ class RequestBuilder
      */
     public function getParams()
     {
-        if (empty($this->params)) {
-            return '';
+        $paramsClean = [];
+        foreach ( $this->params as $param => $value ) {
+            if ( ! is_null( $value ) && '' !== $value ) {
+                $paramsClean[] = sprintf( '%s=%s', $param, $value );
+            }
         }
 
-        $params = array_map(function ($key, $value) {
-            return "$key=$value";
-        }, array_keys($this->params), $this->params);
-
-        return '?'.implode('&', $params);
+        return empty($paramsClean) ? '' : '?'.implode('&', $paramsClean);
     }
 
     /**

--- a/tests/API/Helpers/RequestBuilderTest.php
+++ b/tests/API/Helpers/RequestBuilderTest.php
@@ -85,9 +85,10 @@ class RequestBuilderTest extends ApiTests
     {
         $builder = self::getUrlBuilder();
         $builder->withParam('param1', 'value1');
-        $builder->withParam('param2', 'value2');
+        $builder->withParam('param2', null);
+        $builder->withParam('param3', 'value3');
 
-        $this->assertEquals('?param1=value1&param2=value2', $builder->getParams());
+        $this->assertEquals('?param1=value1&param3=value3', $builder->getParams());
     }
 
     public function testThatASingleUrlParamValueIsReplaced()


### PR DESCRIPTION
### Changes

Fixed the URL parameter building pipeline to exclude parameters with `null` or `""` values. 

### References

Fixing issue brought up by #347 

### Testing

[Failing tests for changed functionality.](https://github.com/auth0/auth0-PHP/pull/349/commits/d45b1ee90efe2e8aa01a76fe85eb78a877c8d1c6)

- [x] This change adds test coverage
- [x] This change was developed in PHP 7.1.29

### Checklist

- [x] All existing and new tests complete without errors.
