### PR TITLE
Persist snyk policy file if available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
           root: .
           paths:
             - composer.*
+            - .snyk
       - save_cache:
           key: composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}
           paths:


### PR DESCRIPTION
### Changes

Pass down the policy file to the snyk build. This will save a lot of headaches.

