### PR TITLE
Add additional API params to Jobs > importUsers

### DIFF
--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -54,7 +54,7 @@ class Jobs extends GenericResource
             $request->addFormParam('send_completion_email', filter_var($params['send_completion_email'], FILTER_VALIDATE_BOOLEAN));
         }
 
-        if (!empty($params['external_id']) && is_string($params['external_id'])) {
+        if (!empty($params['external_id'])) {
             $request->addFormParam('external_id', $params['external_id']);
         }
 

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -35,20 +35,22 @@ class Jobs extends GenericResource
      *
      * @param  string $file_path
      * @param  string $connection_id
-     * @param  boolean $upsert
-     * @param  boolean $send_completion_email
+     * @param  array  $params
      * @return mixed
      */
-    public function importUsers($file_path, $connection_id, $upsert = false, $send_completion_email = true)
+    public function importUsers($file_path, $connection_id, $params = [])
     {
-        return $this->apiClient->post()
+        $request = $this->apiClient->post()
         ->jobs()
         ->addPath('users-imports')
         ->addFile('users', $file_path)
-        ->addFormParam('connection_id', $connection_id)
-        ->addFormParam('upsert', $upsert)
-        ->addFormParam('send_completion_email', $send_completion_email)
-        ->call();
+        ->addFormParam('connection_id', $connection_id);
+
+        foreach ($params as $key => $value) {
+            $request->addFormParam($key, $value);
+        }
+
+        return $request->call();
     }
 
     /**

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -46,8 +46,16 @@ class Jobs extends GenericResource
         ->addFile('users', $file_path)
         ->addFormParam('connection_id', $connection_id);
 
-        foreach ($params as $key => $value) {
-            $request->addFormParam($key, $value);
+        if (isset($params['upsert'])) {
+            $request->addFormParam('upsert', filter_var($params['upsert'], FILTER_VALIDATE_BOOLEAN));
+        }
+
+        if (isset($params['send_completion_email'])) {
+            $request->addFormParam('send_completion_email', filter_var($params['send_completion_email'], FILTER_VALIDATE_BOOLEAN));
+        }
+
+        if (!empty($params['external_id']) && is_string($params['external_id'])) {
+            $request->addFormParam('external_id', $params['external_id']);
         }
 
         return $request->call();

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -35,15 +35,19 @@ class Jobs extends GenericResource
      *
      * @param  string $file_path
      * @param  string $connection_id
+     * @param  boolean $upsert
+     * @param  boolean $send_completion_email
      * @return mixed
      */
-    public function importUsers($file_path, $connection_id)
+    public function importUsers($file_path, $connection_id, $upsert = false, $send_completion_email = true)
     {
         return $this->apiClient->post()
         ->jobs()
         ->addPath('users-imports')
         ->addFile('users', $file_path)
         ->addFormParam('connection_id', $connection_id)
+        ->addFormParam('upsert', $upsert)
+        ->addFormParam('send_completion_email', $send_completion_email)
         ->call();
     }
 


### PR DESCRIPTION
### Changes

Added `upsert` and `send_completion_email` parameters to `Jobs::importUsers`.

### References

Closes https://github.com/auth0/auth0-PHP/issues/353

### Testing

Functionality can be tested by setting the `upsert` and `send_completion_email` boolean parameters for `Jobs::importUsers`. This should create a request which is compatible with the API docs of Auth0 Management V2 API: https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports

- [ ] This change adds test coverage

- [x] This change has been tested on the latest version of PHP

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

- [x] All existing and new tests complete without errors.

- [x] The correct base branch is being used.
