### PR TITLE
Fix boolean form parameters not sending as strings

### DIFF
--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -192,8 +192,8 @@ class RequestBuilder
     public function getParams()
     {
         $paramsClean = [];
-        foreach ( $this->params as $param => $value ) {
-            if ( ! is_null( $value ) && '' !== $value ) {
+        foreach ($this->params as $param => $value) {
+            if (! is_null( $value ) && '' !== $value) {
                 $paramsClean[] = sprintf( '%s=%s', $param, $value );
             }
         }
@@ -202,6 +202,7 @@ class RequestBuilder
     }
 
     /**
+     * TODO: Deprecate
      *
      * @return RequestBuilder
      */
@@ -244,7 +245,7 @@ class RequestBuilder
      */
     public function addFormParam($key, $value)
     {
-        $this->form_params[$key] = $value;
+        $this->form_params[$key] = $this->prepareBoolParam( $value );
         return $this;
     }
 
@@ -355,10 +356,7 @@ class RequestBuilder
      */
     public function withParam($key, $value)
     {
-        $value = ($value === true ? 'true' : $value);
-        $value = ($value === false ? 'false' : $value);
-
-        $this->params[$key] = $value;
+        $this->params[$key] = $this->prepareBoolParam( $value );
         return $this;
     }
 
@@ -435,5 +433,21 @@ class RequestBuilder
         }
 
         return $multipart;
+    }
+
+    /**
+     * Translate a boolean value to a string for use in a URL or form parameter.
+     *
+     * @param mixed $value Parameter value to check.
+     *
+     * @return mixed string
+     */
+    private function prepareBoolParam($value)
+    {
+        if (is_bool( $value )) {
+            return true === $value ? 'true' : 'false';
+        }
+
+        return $value;
     }
 }

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -41,7 +41,8 @@ class ClientGrantsTest extends ApiTests
      *
      * @throws \Auth0\SDK\Exception\ApiException
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass()
+    {
         self::$api = self::getApi( 'client_grants' );
 
         $create_data = [
@@ -50,7 +51,7 @@ class ClientGrantsTest extends ApiTests
             'signing_alg' => 'RS256'
         ];
 
-        $rs_api = self::getApi( 'resource_servers' );
+        $rs_api              = self::getApi( 'resource_servers' );
         self::$apiIdentifier = 'TEST_PHP_SDK_CLIENT_GRANT_API_'.uniqid();
         $rs_api->create(self::$apiIdentifier, $create_data);
     }

--- a/tests/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/API/Management/EmailTemplatesMockedTest.php
@@ -45,7 +45,8 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
     /**
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatGetTemplateRequestIsFormattedProperly() {
+    public function testThatGetTemplateRequestIsFormattedProperly()
+    {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
         $api->call()->emailTemplates->get( EmailTemplates::TEMPLATE_VERIFY_EMAIL );
 
@@ -60,8 +61,9 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
     /**
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatPatchTemplateRequestIsFormattedProperly() {
-        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+    public function testThatPatchTemplateRequestIsFormattedProperly()
+    {
+        $api        = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
         $patch_data = [
             'body' => '__test_email_body__',
             'from' => 'test@auth0.com',
@@ -85,7 +87,8 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
     /**
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatCreateTemplateRequestIsFormattedProperly() {
+    public function testThatCreateTemplateRequestIsFormattedProperly()
+    {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
         $api->call()->emailTemplates->create(

--- a/tests/API/Management/EmailsMockedTest.php
+++ b/tests/API/Management/EmailsMockedTest.php
@@ -45,7 +45,8 @@ class EmailsMockedTest extends \PHPUnit_Framework_TestCase
     /**
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatGetEmailProviderRequestIsFormattedProperly() {
+    public function testThatGetEmailProviderRequestIsFormattedProperly()
+    {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
         $api->call()->emails->getEmailProvider();
 
@@ -60,7 +61,8 @@ class EmailsMockedTest extends \PHPUnit_Framework_TestCase
     /**
      * @throws \Exception Should not be thrown in this test.
      */
-    public function testThatGetEmailProviderRequestAddsFieldsParams() {
+    public function testThatGetEmailProviderRequestAddsFieldsParams()
+    {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
         $api->call()->emails->getEmailProvider( [ 'name', 'credentials' ], true );
 


### PR DESCRIPTION
### Changes

In the PR linked below, we found that `true` boolean form parameters were being sent as `1` and ignored by the Management API (specifically the import users endpoint). URL parameters are already converted to string versions of their boolean counterparts but not form parameters. This only affects the import users endpoint, which is only sending boolean params in the PR below.

### References

Found in #354 

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on PHP 7.1

