### PR TITLE
Deprecate addPathVariable and dump methods on RequestBuilder

### DIFF
--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -146,6 +146,8 @@ class RequestBuilder
     /**
      * Add a path and an optional argument to this request.
      *
+     * TODO: Allow array or unlimited arguments
+     *
      * @param string      $name     Path to add.
      * @param string|null $argument Optional argument to add.
      *
@@ -163,6 +165,8 @@ class RequestBuilder
 
     /**
      * Add a path variable.
+     *
+     * @deprecated 5.6.0, use $this->addPath() instead.
      *
      * @param string $variable Path variable to add.
      *
@@ -202,7 +206,7 @@ class RequestBuilder
     }
 
     /**
-     * TODO: Deprecate
+     * @deprecated 5.6.0, no alternative provided.
      *
      * @return RequestBuilder
      */

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -54,7 +54,7 @@ class Jobs extends GenericResource
             $request->addFormParam('send_completion_email', filter_var($params['send_completion_email'], FILTER_VALIDATE_BOOLEAN));
         }
 
-        if (!empty($params['external_id'])) {
+        if (! empty($params['external_id'])) {
             $request->addFormParam('external_id', $params['external_id']);
         }
 

--- a/src/API/Management/Roles.php
+++ b/src/API/Management/Roles.php
@@ -151,7 +151,7 @@ class Roles extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('roles', $role_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withDictParams($params)
             ->call();
     }
@@ -180,7 +180,7 @@ class Roles extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('roles', $role_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -209,7 +209,7 @@ class Roles extends GenericResource
 
         return $this->apiClient->method('delete')
             ->addPath('roles', $role_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -239,7 +239,7 @@ class Roles extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('roles', $role_id)
-            ->addPathVariable('users')
+            ->addPath('users')
             ->withDictParams($params)
             ->call();
     }
@@ -271,7 +271,7 @@ class Roles extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('roles', $role_id)
-            ->addPathVariable('users')
+            ->addPath('users')
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -212,7 +212,7 @@ class Users extends GenericResource
         return $this->apiClient->method('delete')
             ->addPath('users', $user_id)
             ->addPath('identities', $provider)
-            ->addPathVariable($identity_id)
+            ->addPath($identity_id)
             ->call();
     }
 
@@ -263,7 +263,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
-            ->addPathVariable('roles')
+            ->addPath('roles')
             ->withDictParams($params)
             ->call();
     }
@@ -295,7 +295,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('delete')
             ->addPath('users', $user_id)
-            ->addPathVariable('roles')
+            ->addPath('roles')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -329,7 +329,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)
-            ->addPathVariable('roles')
+            ->addPath('roles')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -353,7 +353,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
-            ->addPathVariable('enrollments')
+            ->addPath('enrollments')
             ->call();
     }
 
@@ -380,7 +380,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withDictParams($params)
             ->call();
     }
@@ -409,7 +409,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('delete')
             ->addPath('users', $user_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -438,7 +438,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)
-            ->addPathVariable('permissions')
+            ->addPath('permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -466,7 +466,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('get')
             ->addPath('users', $user_id)
-            ->addPathVariable('logs')
+            ->addPath('logs')
             ->withDictParams($params)
             ->call();
     }
@@ -490,7 +490,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)
-            ->addPathVariable('recovery-code-regeneration')
+            ->addPath('recovery-code-regeneration')
             ->call();
     }
 
@@ -513,7 +513,7 @@ class Users extends GenericResource
 
         return $this->apiClient->method('post')
             ->addPath('users', $user_id)
-            ->addPathVariable('multifactor/actions/invalidate-remember-browser')
+            ->addPath('multifactor/actions/invalidate-remember-browser')
             ->call();
     }
 


### PR DESCRIPTION
### Changes

- Deprecate `\Auth0\SDK\API\Helpers\RequestBuilder::addPathVariable()`
- Deprecate `\Auth0\SDK\API\Helpers\RequestBuilder::dump()`
