### PR TITLE
Deprecate and stop using magic call method on ApiClient

### DIFF
--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -64,6 +64,16 @@ class ApiClient
         }
     }
 
+    /**
+     * Magic method to map HTTP verbs to request types.
+     *
+     * @deprecated 5.6.0, use $this->method().
+     *
+     * @param string $name      - Method name used to call the magic method.
+     * @param array  $arguments - Arguments used in the magic method call.
+     *
+     * @return RequestBuilder
+     */
     public function __call($name, $arguments)
     {
         $builder = new RequestBuilder([
@@ -81,11 +91,12 @@ class ApiClient
      * Create a new RequestBuilder.
      * Similar to the above but does not use a magic method.
      *
-     * @param string $method - HTTP method to use (GET, POST, PATCH, etc).
+     * @param string  $method           - HTTP method to use (GET, POST, PATCH, etc).
+     * @param boolean $set_content_type - Automatically set a content-type header.
      *
      * @return RequestBuilder
      */
-    public function method($method)
+    public function method($method, $set_content_type = true)
     {
         $method  = strtolower($method);
         $builder = new RequestBuilder([
@@ -97,7 +108,7 @@ class ApiClient
         ]);
         $builder->withHeaders($this->headers);
 
-        if (in_array($method, [ 'patch', 'post', 'put', 'delete' ])) {
+        if ($set_content_type && in_array($method, [ 'patch', 'post', 'put' ])) {
             $builder->withHeader(new ContentType('application/json'));
         }
 

--- a/src/API/Management/Blacklists.php
+++ b/src/API/Management/Blacklists.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class Blacklists extends GenericResource
 {
     /**
@@ -13,9 +11,9 @@ class Blacklists extends GenericResource
      */
     public function getAll($aud)
     {
-        return $this->apiClient->get()
-            ->blacklists()
-            ->tokens()
+        return $this->apiClient->method('get')
+            ->addPath('blacklists')
+            ->addPath('tokens')
             ->withParam('aud', $aud)
             ->call();
     }
@@ -28,10 +26,9 @@ class Blacklists extends GenericResource
      */
     public function blacklist($aud, $jti)
     {
-        return $this->apiClient->post()
-            ->blacklists()
-            ->tokens()
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+            ->addPath('blacklists')
+            ->addPath('tokens')
             ->withBody(json_encode([
                 'aud' => $aud,
                 'jti' => $jti

--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -191,7 +191,7 @@ class ClientGrants extends GenericResource
      */
     public function get($id, $audience = null)
     {
-        $request = $this->apiClient->get()
+        $request = $this->apiClient->method('get')
             ->addPath('client-grants');
 
         if ($audience !== null) {

--- a/src/API/Management/DeviceCredentials.php
+++ b/src/API/Management/DeviceCredentials.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class DeviceCredentials extends GenericResource
 {
     const TYPE_PUBLIC_KEY   = 'public_key';
@@ -20,7 +18,7 @@ class DeviceCredentials extends GenericResource
      */
     public function getAll($user_id = null, $client_id = null, $type = null, $fields = null, $include_fields = null)
     {
-        $request = $this->apiClient->get()
+        $request = $this->apiClient->method('get')
         ->addPath('device-credentials');
 
         if ($fields !== null) {
@@ -57,9 +55,8 @@ class DeviceCredentials extends GenericResource
      */
     public function createPublicKey($data)
     {
-        return $this->apiClient->post()
+        return $this->apiClient->method('post')
         ->addPath('device-credentials')
-        ->withHeader(new ContentType('application/json'))
         ->withBody(json_encode($data))
         ->call();
     }
@@ -71,7 +68,7 @@ class DeviceCredentials extends GenericResource
      */
     public function deleteDeviceCredential($id)
     {
-        return $this->apiClient->delete()
+        return $this->apiClient->method('delete')
         ->addPath('device-credentials', $id)
         ->call();
     }

--- a/src/API/Management/Emails.php
+++ b/src/API/Management/Emails.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class Emails extends GenericResource
 {
     /**
@@ -14,9 +12,9 @@ class Emails extends GenericResource
      */
     public function getEmailProvider($fields = null, $include_fields = null)
     {
-        $request = $this->apiClient->get()
-        ->emails()
-        ->provider();
+        $request = $this->apiClient->method('get')
+        ->addPath('emails')
+        ->addPath('provider');
 
         if ($fields !== null) {
             if (is_array($fields)) {
@@ -40,10 +38,9 @@ class Emails extends GenericResource
      */
     public function configureEmailProvider($data)
     {
-        return $this->apiClient->post()
-        ->emails()
-        ->provider()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+        ->addPath('emails')
+        ->addPath('provider')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -55,10 +52,9 @@ class Emails extends GenericResource
      */
     public function updateEmailProvider($data)
     {
-        return $this->apiClient->patch()
-        ->emails()
-        ->provider()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('patch')
+        ->addPath('emails')
+        ->addPath('provider')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -69,9 +65,9 @@ class Emails extends GenericResource
      */
     public function deleteEmailProvider()
     {
-        return $this->apiClient->delete()
-        ->emails()
-        ->provider()
+        return $this->apiClient->method('delete')
+        ->addPath('emails')
+        ->addPath('provider')
         ->call();
     }
 }

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class Jobs extends GenericResource
 {
     /**
@@ -40,8 +38,8 @@ class Jobs extends GenericResource
      */
     public function importUsers($file_path, $connection_id, $params = [])
     {
-        $request = $this->apiClient->post()
-        ->jobs()
+        $request = $this->apiClient->method('post', false)
+        ->addPath('jobs')
         ->addPath('users-imports')
         ->addFile('users', $file_path)
         ->addFormParam('connection_id', $connection_id);
@@ -54,7 +52,7 @@ class Jobs extends GenericResource
             $request->addFormParam('send_completion_email', filter_var($params['send_completion_email'], FILTER_VALIDATE_BOOLEAN));
         }
 
-        if (!empty($params['external_id'])) {
+        if (! empty($params['external_id'])) {
             $request->addFormParam('external_id', $params['external_id']);
         }
 
@@ -68,10 +66,9 @@ class Jobs extends GenericResource
      */
     public function sendVerificationEmail($user_id)
     {
-        return $this->apiClient->post()
-        ->jobs()
+        return $this->apiClient->method('post')
+        ->addPath('jobs')
         ->addPath('verification-email')
-        ->withHeader(new ContentType('application/json'))
         ->withBody(json_encode([
             'user_id' => $user_id
         ]))

--- a/src/API/Management/Stats.php
+++ b/src/API/Management/Stats.php
@@ -10,8 +10,8 @@ class Stats extends GenericResource
      */
     public function getActiveUsersCount()
     {
-        return $this->apiClient->get()
-        ->stats()
+        return $this->apiClient->method('get')
+        ->addPath('stats')
         ->addPath('active-users')
         ->call();
     }
@@ -24,9 +24,9 @@ class Stats extends GenericResource
      */
     public function getDailyStats($from, $to)
     {
-        return $this->apiClient->get()
-        ->stats()
-        ->daily()
+        return $this->apiClient->method('get')
+        ->addPath('stats')
+        ->addPath('daily')
         ->withParam('from', $from)
         ->withParam('to', $to)
         ->call();

--- a/src/API/Management/Tenants.php
+++ b/src/API/Management/Tenants.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class Tenants extends GenericResource
 {
     /**
@@ -14,9 +12,9 @@ class Tenants extends GenericResource
      */
     public function get($fields = null, $include_fields = null)
     {
-        $request = $this->apiClient->get()
-        ->tenants()
-        ->settings();
+        $request = $this->apiClient->method('get')
+        ->addPath('tenants')
+        ->addPath('settings');
 
         if ($fields !== null) {
             if (is_array($fields)) {
@@ -40,10 +38,9 @@ class Tenants extends GenericResource
      */
     public function update($data)
     {
-        return $this->apiClient->patch()
-        ->tenants()
-        ->settings()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('patch')
+        ->addPath('tenants')
+        ->addPath('settings')
         ->withBody(json_encode($data))
         ->call();
     }

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -2,8 +2,6 @@
 
 namespace Auth0\SDK\API\Management;
 
-use Auth0\SDK\API\Header\ContentType;
-
 class Tickets extends GenericResource
 {
     /**
@@ -19,10 +17,9 @@ class Tickets extends GenericResource
             $body['result_url'] = $result_url;
         }
 
-        $request = $this->apiClient->post()
-            ->tickets()
+        $request = $this->apiClient->method('post')
+            ->addPath('tickets')
             ->addPath('email-verification')
-            ->withHeader(new ContentType('application/json'))
             ->withBody(json_encode($body));
 
         return $request->call();
@@ -103,10 +100,9 @@ class Tickets extends GenericResource
             $body['connection_id'] = $connection_id;
         }
 
-        return $this->apiClient->post()
-            ->tickets()
+        return $this->apiClient->method('post')
+            ->addPath('tickets')
             ->addPath('password-change')
-            ->withHeader(new ContentType('application/json'))
             ->withBody(json_encode($body))
             ->call();
     }

--- a/src/API/Management/UserBlocks.php
+++ b/src/API/Management/UserBlocks.php
@@ -11,7 +11,7 @@ class UserBlocks extends GenericResource
      */
     public function get($user_id)
     {
-        return $this->apiClient->get()
+        return $this->apiClient->method('get')
         ->addPath('user-blocks', $user_id)
         ->call();
     }
@@ -23,7 +23,7 @@ class UserBlocks extends GenericResource
      */
     public function getByIdentifier($identifier)
     {
-        return $this->apiClient->get()
+        return $this->apiClient->method('get')
         ->addPath('user-blocks')
         ->withParam('identifier', $identifier)
         ->call();
@@ -36,7 +36,7 @@ class UserBlocks extends GenericResource
      */
     public function unblock($user_id)
     {
-        return $this->apiClient->delete()
+        return $this->apiClient->method('delete')
         ->addPath('user-blocks', $user_id)
         ->call();
     }
@@ -48,7 +48,7 @@ class UserBlocks extends GenericResource
      */
     public function unblockByIdentifier($identifier)
     {
-        return $this->apiClient->delete()
+        return $this->apiClient->method('delete')
         ->addPath('user-blocks')
         ->withParam('identifier', $identifier)
         ->call();

--- a/src/API/Management/UsersByEmail.php
+++ b/src/API/Management/UsersByEmail.php
@@ -6,7 +6,7 @@ class UsersByEmail extends GenericResource
 {
     public function get($params = [])
     {
-        $client = $this->apiClient->get()
+        $client = $this->apiClient->method('get')
             ->addPath('users-by-email');
 
         foreach ($params as $param => $value) {

--- a/tests/API/Management/RolesMockedTest.php
+++ b/tests/API/Management/RolesMockedTest.php
@@ -198,7 +198,6 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
-        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
     }
 
@@ -490,7 +489,6 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
-        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
         $body = $api->getHistoryBody();

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -631,7 +631,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
-        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
         $body = $api->getHistoryBody();
@@ -881,7 +880,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
-        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
         $body = $api->getHistoryBody();


### PR DESCRIPTION
### Changes

- Deprecate `\Auth0\SDK\API\Helpers\ApiClient::__call()` magic method
- Replace all uses of this method with `\Auth0\SDK\API\Helpers\ApiClient::method()`
- Stop sending `Content-Type: application/json` header with DELETE requests
