### PR TITLE
Deprecate Management properties; add lazy-load methods

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -58,114 +58,133 @@ class Management
     private $returnType;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->blacklists() instead.
      *
      * @var Blacklists
      */
     public $blacklists;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->clients() instead.
      *
      * @var Clients
      */
     public $clients;
 
     /**
+     * @deprecated 5.6.0, will be renamed and lose public access; use $this->clientGrants() instead.
      *
      * @var ClientGrants
      */
     public $client_grants;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->connections() instead.
      *
      * @var Connections
      */
     public $connections;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->deviceCredentials() instead.
      *
      * @var DeviceCredentials
      */
     public $deviceCredentials;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->emails() instead.
      *
      * @var Emails
      */
     public $emails;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->emailTemplates() instead.
      *
      * @var EmailTemplates
      */
     public $emailTemplates;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->jobs() instead.
      *
      * @var Jobs
      */
     public $jobs;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->grants() instead.
      *
      * @var Grants
      */
     public $grants;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->logs() instead.
      *
      * @var Logs
      */
     public $logs;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->roles() instead.
      *
      * @var Roles
      */
     public $roles;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->rules() instead.
      *
      * @var Rules
      */
     public $rules;
 
     /**
+     * @deprecated 5.6.0, will be renamed and lose public access; use $this->resourceServers() instead.
      *
      * @var ResourceServers
      */
     public $resource_servers;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->stats() instead.
      *
      * @var Stats
      */
     public $stats;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->tenants() instead.
      *
      * @var Tenants
      */
     public $tenants;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->tickets() instead.
      *
      * @var Tickets
      */
     public $tickets;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->userBlocks() instead.
      *
      * @var UserBlocks
      */
     public $userBlocks;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->users() instead.
      *
      * @var Users
      */
     public $users;
 
     /**
+     * @deprecated 5.6.0, will lose public access; use $this->usersByEmail() instead.
      *
      * @var UsersByEmail
      */

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -209,6 +209,272 @@ class Management
         $this->usersByEmail      = new UsersByEmail($this->apiClient);
     }
 
+    /**
+     * Return an instance of the Blacklists class.
+     *
+     * @return Blacklists
+     */
+    public function blacklists()
+    {
+        if (! $this->blacklists instanceof Blacklists) {
+            $this->blacklists = new Blacklists($this->apiClient);
+        }
+
+        return $this->blacklists;
+    }
+
+    /**
+     * Return an instance of the Clients class.
+     *
+     * @return Clients
+     */
+    public function clients()
+    {
+        if (! $this->clients instanceof Clients) {
+            $this->clients = new Clients($this->apiClient);
+        }
+
+        return $this->clients;
+    }
+
+    /**
+     * Return an instance of the ClientGrants class.
+     *
+     * @return ClientGrants
+     */
+    public function clientGrants()
+    {
+        if (! $this->client_grants instanceof ClientGrants) {
+            $this->client_grants = new ClientGrants($this->apiClient);
+        }
+
+        return $this->client_grants;
+    }
+
+    /**
+     * Return an instance of the Connections class.
+     *
+     * @return Connections
+     */
+    public function connections()
+    {
+        if (! $this->connections instanceof Connections) {
+            $this->connections = new Connections($this->apiClient);
+        }
+
+        return $this->connections;
+    }
+
+    /**
+     * Return an instance of the DeviceCredentials class.
+     *
+     * @return DeviceCredentials
+     */
+    public function deviceCredentials()
+    {
+        if (! $this->deviceCredentials instanceof DeviceCredentials) {
+            $this->deviceCredentials = new DeviceCredentials($this->apiClient);
+        }
+
+        return $this->deviceCredentials;
+    }
+
+    /**
+     * Return an instance of the Emails class.
+     *
+     * @return Emails
+     */
+    public function emails()
+    {
+        if (! $this->emails instanceof Emails) {
+            $this->emails = new Emails($this->apiClient);
+        }
+
+        return $this->emails;
+    }
+
+    /**
+     * Return an instance of the EmailTemplates class.
+     *
+     * @return EmailTemplates
+     */
+    public function emailTemplates()
+    {
+        if (! $this->emailTemplates instanceof EmailTemplates) {
+            $this->emailTemplates = new EmailTemplates($this->apiClient);
+        }
+
+        return $this->emailTemplates;
+    }
+
+    /**
+     * Return an instance of the Grants class.
+     *
+     * @return Grants
+     */
+    public function grants()
+    {
+        if (! $this->grants instanceof Grants) {
+            $this->grants = new Grants($this->apiClient);
+        }
+
+        return $this->grants;
+    }
+
+    /**
+     * Return an instance of the Jobs class.
+     *
+     * @return Jobs
+     */
+    public function jobs()
+    {
+        if (! $this->jobs instanceof Jobs) {
+            $this->jobs = new Jobs($this->apiClient);
+        }
+
+        return $this->jobs;
+    }
+
+    /**
+     * Return an instance of the Logs class.
+     *
+     * @return Logs
+     */
+    public function logs()
+    {
+        if (! $this->logs instanceof Logs) {
+            $this->logs = new Logs($this->apiClient);
+        }
+
+        return $this->logs;
+    }
+
+    /**
+     * Return an instance of the Roles class.
+     *
+     * @return Roles
+     */
+    public function roles()
+    {
+        if (! $this->roles instanceof Roles) {
+            $this->roles = new Roles($this->apiClient);
+        }
+
+        return $this->roles;
+    }
+
+    /**
+     * Return an instance of the Rules class.
+     *
+     * @return Rules
+     */
+    public function rules()
+    {
+        if (! $this->rules instanceof Rules) {
+            $this->rules = new Rules($this->apiClient);
+        }
+
+        return $this->rules;
+    }
+
+    /**
+     * Return an instance of the ResourceServers class.
+     *
+     * @return ResourceServers
+     */
+    public function resourceServers()
+    {
+        if (! $this->resource_servers instanceof ResourceServers) {
+            $this->resource_servers = new ResourceServers($this->apiClient);
+        }
+
+        return $this->resource_servers;
+    }
+
+    /**
+     * Return an instance of the Stats class.
+     *
+     * @return Stats
+     */
+    public function stats()
+    {
+        if (! $this->stats instanceof Stats) {
+            $this->stats = new Stats($this->apiClient);
+        }
+
+        return $this->stats;
+    }
+
+    /**
+     * Return an instance of the Tenants class.
+     *
+     * @return Tenants
+     */
+    public function tenants()
+    {
+        if (! $this->tenants instanceof Tenants) {
+            $this->tenants = new Tenants($this->apiClient);
+        }
+
+        return $this->tenants;
+    }
+
+    /**
+     * Return an instance of the Tickets class.
+     *
+     * @return Tickets
+     */
+    public function tickets()
+    {
+        if (! $this->tickets instanceof Tickets) {
+            $this->tickets = new Tickets($this->apiClient);
+        }
+
+        return $this->tickets;
+    }
+
+    /**
+     * Return an instance of the UserBlocks class.
+     *
+     * @return UserBlocks
+     */
+    public function userBlocks()
+    {
+        if (! $this->userBlocks instanceof UserBlocks) {
+            $this->userBlocks = new UserBlocks($this->apiClient);
+        }
+
+        return $this->userBlocks;
+    }
+
+    /**
+     * Return an instance of the Users class.
+     *
+     * @return Users
+     */
+    public function users()
+    {
+        if (! $this->users instanceof Users) {
+            $this->users = new Users($this->apiClient);
+        }
+
+        return $this->users;
+    }
+
+    /**
+     * Return an instance of the UsersByEmail class.
+     *
+     * @return UsersByEmail
+     */
+    public function usersByEmail()
+    {
+        if (! $this->usersByEmail instanceof UsersByEmail) {
+            $this->usersByEmail = new UsersByEmail($this->apiClient);
+        }
+
+        return $this->usersByEmail;
+    }
+
     protected function setApiClient()
     {
         $apiDomain = "https://{$this->domain}";

--- a/tests/API/BasicCrudTest.php
+++ b/tests/API/BasicCrudTest.php
@@ -43,7 +43,7 @@ abstract class BasicCrudTest extends ApiTests
      *
      * @var boolean
      */
-    protected $findCreatedItem = true;
+    protected $findCreatedItem = false;
 
     /**
      * CRUD API client to test.

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -40,7 +40,7 @@ class BlacklistsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->blacklists->getAll( '__test_aud__' );
+        $api->call()->blacklists()->getAll( '__test_aud__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/blacklists/tokens', $api->getHistoryUrl() );
@@ -59,7 +59,7 @@ class BlacklistsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->blacklists->blacklist( '__test_aud__', '__test_jti__' );
+        $api->call()->blacklists()->blacklist( '__test_aud__', '__test_jti__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/blacklists/tokens', $api->getHistoryUrl() );
@@ -100,10 +100,10 @@ class BlacklistsTest extends ApiTests
         $api      = new Management($env['API_TOKEN'], $env['DOMAIN']);
         $test_jti = uniqid().uniqid().uniqid();
 
-        $api->blacklists->blacklist($env['APP_CLIENT_ID'], $test_jti);
+        $api->blacklists()->blacklist($env['APP_CLIENT_ID'], $test_jti);
         sleep(0.2);
 
-        $blacklisted = $api->blacklists->getAll($env['APP_CLIENT_ID']);
+        $blacklisted = $api->blacklists()->getAll($env['APP_CLIENT_ID']);
         sleep(0.2);
 
         $this->assertGreaterThan( 0, count( $blacklisted ) );

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -77,6 +77,15 @@ class BlacklistsTest extends ApiTests
         $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists );
+        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists() );
+        $api->blacklists = null;
+        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists() );
+    }
+
     /**
      * @throws \Auth0\SDK\Exception\ApiException
      */

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -59,7 +59,15 @@ class ClientGrantsTest extends ApiTests
     public function setUp()
     {
         parent::setUp();
-        sleep(2);
+    }
+
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\ClientGrants::class, $api->client_grants );
+        $this->assertInstanceOf( Management\ClientGrants::class, $api->clientGrants() );
+        $api->client_grants = null;
+        $this->assertInstanceOf( Management\ClientGrants::class, $api->clientGrants() );
     }
 
 

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -44,7 +44,7 @@ class ClientsTest extends BasicCrudTest
     {
         $token = self::getToken(self::$env);
         $api   = new Management($token, $this->domain);
-        return $api->clients;
+        return $api->clients();
     }
 
     /**
@@ -71,8 +71,7 @@ class ClientsTest extends BasicCrudTest
      */
     protected function getAllEntities()
     {
-        $fields   = array_keys($this->getCreateBody());
-        $fields[] = $this->id_name;
+        $fields   = [ 'name', 'tenant', $this->id_name ];
         $page_num = 1;
 
         // Get the second page of Clients with 1 per page (second result).

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -26,6 +26,15 @@ class ClientsTest extends BasicCrudTest
         sleep(2);
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Clients::class, $api->clients );
+        $this->assertInstanceOf( Management\Clients::class, $api->clients() );
+        $api->clients = null;
+        $this->assertInstanceOf( Management\Clients::class, $api->clients() );
+    }
+
     /**
      * Return the Clients API to test.
      *

--- a/tests/API/Management/ConnectionsMockedTest.php
+++ b/tests/API/Management/ConnectionsMockedTest.php
@@ -2,9 +2,8 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\Tests\Traits\ErrorHelpers;
-
 use Auth0\SDK\API\Helpers\InformationHeaders;
-
+use Auth0\SDK\API\Management;
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -39,6 +38,15 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
         self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Connections::class, $api->connections );
+        $this->assertInstanceOf( Management\Connections::class, $api->connections() );
+        $api->connections = null;
+        $this->assertInstanceOf( Management\Connections::class, $api->connections() );
     }
 
     /**

--- a/tests/API/Management/ConnectionsMockedTest.php
+++ b/tests/API/Management/ConnectionsMockedTest.php
@@ -60,7 +60,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->connections->getAll();
+        $api->call()->connections()->getAll();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -84,7 +84,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
         $strategy = 'test-strategy-01';
-        $api->call()->connections->getAll($strategy);
+        $api->call()->connections()->getAll($strategy);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -104,7 +104,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $strategy = null;
         $fields   = ['id', 'name'];
-        $api->call()->connections->getAll($strategy, $fields);
+        $api->call()->connections()->getAll($strategy, $fields);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -113,7 +113,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         // Test an explicit true for includeFields.
         $include_fields = true;
-        $api->call()->connections->getAll($strategy, $fields, $include_fields);
+        $api->call()->connections()->getAll($strategy, $fields, $include_fields);
 
         $this->assertContains( 'include_fields=true', $api->getHistoryQuery() );
     }
@@ -132,7 +132,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $strategy       = null;
         $fields         = ['id', 'name'];
         $include_fields = false;
-        $api->call()->connections->getAll($strategy, $fields, $include_fields);
+        $api->call()->connections()->getAll($strategy, $fields, $include_fields);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -156,7 +156,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $include_fields = null;
         $page           = 0;
         $per_page       = 5;
-        $api->call()->connections->getAll($strategy, $fields, $include_fields, $page, $per_page);
+        $api->call()->connections()->getAll($strategy, $fields, $include_fields, $page, $per_page);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -181,7 +181,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $page           = null;
         $per_page       = null;
         $add_params     = ['param1' => 'value1', 'param2' => 'value2'];
-        $api->call()->connections->getAll($strategy, $fields, $include_fields, $page, $per_page, $add_params);
+        $api->call()->connections()->getAll($strategy, $fields, $include_fields, $page, $per_page, $add_params);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
@@ -201,7 +201,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
         $id = 'con_testConnection10';
-        $api->call()->connections->get($id);
+        $api->call()->connections()->get($id);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
@@ -221,7 +221,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $id     = 'con_testConnection10';
         $fields = ['name', 'strategy'];
-        $api->call()->connections->get($id, $fields);
+        $api->call()->connections()->get($id, $fields);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
@@ -230,7 +230,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         // Test an explicit true for includeFields.
         $include_fields = true;
-        $api->call()->connections->get($id, $fields, $include_fields);
+        $api->call()->connections()->get($id, $fields, $include_fields);
 
         $this->assertContains( 'include_fields=true', $api->getHistoryQuery() );
     }
@@ -249,7 +249,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $id             = 'con_testConnection10';
         $fields         = ['name', 'strategy'];
         $include_fields = false;
-        $api->call()->connections->get($id, $fields, $include_fields);
+        $api->call()->connections()->get($id, $fields, $include_fields);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
@@ -269,7 +269,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 204 ) ] );
 
         $id = 'con_testConnection10';
-        $api->call()->connections->delete($id);
+        $api->call()->connections()->delete($id);
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
@@ -289,7 +289,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $id    = 'con_testConnection10';
         $email = 'con_testConnection10@auth0.com';
-        $api->call()->connections->deleteUser($id, $email);
+        $api->call()->connections()->deleteUser($id, $email);
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertContains( 'https://api.test.local/api/v2/connections/'.$id.'/users', $api->getHistoryUrl() );
@@ -309,7 +309,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $name     = 'TestConnection01';
         $strategy = 'test-strategy-01';
-        $api->call()->connections->create( [ 'name' => $name, 'strategy' => $strategy ] );
+        $api->call()->connections()->create( [ 'name' => $name, 'strategy' => $strategy ] );
         $request_body = $api->getHistoryBody();
 
         $this->assertEquals( $name, $request_body['name'] );
@@ -332,7 +332,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $caught_no_name_exception = false;
         try {
-            $api->call()->connections->create(['strategy' => uniqid()]);
+            $api->call()->connections()->create(['strategy' => uniqid()]);
         } catch (\Exception $e) {
             $caught_no_name_exception = $this->errorHasString($e, 'Missing required "name" field');
         }
@@ -341,7 +341,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $caught_no_strategy_exception = false;
         try {
-            $api->call()->connections->create(['name' => uniqid()]);
+            $api->call()->connections()->create(['name' => uniqid()]);
         } catch (\Exception $e) {
             $caught_no_strategy_exception = $this->errorHasString($e, 'Missing required "strategy" field');
         }
@@ -362,7 +362,7 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
 
         $id          = 'con_testConnection10';
         $update_data = [ 'metadata' => [ 'meta1' => 'value1' ] ];
-        $api->call()->connections->update($id, $update_data);
+        $api->call()->connections()->update($id, $update_data);
         $request_body = $api->getHistoryBody();
 
         $this->assertEquals( $update_data, $request_body );

--- a/tests/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/API/Management/EmailTemplatesMockedTest.php
@@ -3,9 +3,8 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\Tests\Traits\ErrorHelpers;
-use Auth0\SDK\API\Management\EmailTemplates;
 use Auth0\SDK\API\Helpers\InformationHeaders;
-
+use Auth0\SDK\API\Management;
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -42,13 +41,22 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates );
+        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates() );
+        $api->emailTemplates = null;
+        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates() );
+    }
+
     /**
      * @throws \Exception Should not be thrown in this test.
      */
     public function testThatGetTemplateRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
-        $api->call()->emailTemplates->get( EmailTemplates::TEMPLATE_VERIFY_EMAIL );
+        $api->call()->emailTemplates->get( Management\EmailTemplates::TEMPLATE_VERIFY_EMAIL );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/email-templates/verify_email', $api->getHistoryUrl() );
@@ -71,7 +79,7 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
             'subject' => '__test_email_subject__',
         ];
 
-        $api->call()->emailTemplates->patch( EmailTemplates::TEMPLATE_RESET_EMAIL, $patch_data );
+        $api->call()->emailTemplates->patch( Management\EmailTemplates::TEMPLATE_RESET_EMAIL, $patch_data );
 
         $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/email-templates/reset_email', $api->getHistoryUrl() );
@@ -92,7 +100,7 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
         $api->call()->emailTemplates->create(
-            EmailTemplates::TEMPLATE_WELCOME_EMAIL,
+            Management\EmailTemplates::TEMPLATE_WELCOME_EMAIL,
             true,
             'test@auth0.com',
             '__test_email_subject__',

--- a/tests/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/API/Management/EmailTemplatesMockedTest.php
@@ -56,7 +56,7 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
     public function testThatGetTemplateRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
-        $api->call()->emailTemplates->get( Management\EmailTemplates::TEMPLATE_VERIFY_EMAIL );
+        $api->call()->emailTemplates()->get( Management\EmailTemplates::TEMPLATE_VERIFY_EMAIL );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/email-templates/verify_email', $api->getHistoryUrl() );
@@ -79,7 +79,7 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
             'subject' => '__test_email_subject__',
         ];
 
-        $api->call()->emailTemplates->patch( Management\EmailTemplates::TEMPLATE_RESET_EMAIL, $patch_data );
+        $api->call()->emailTemplates()->patch( Management\EmailTemplates::TEMPLATE_RESET_EMAIL, $patch_data );
 
         $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/email-templates/reset_email', $api->getHistoryUrl() );
@@ -99,7 +99,7 @@ class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->emailTemplates->create(
+        $api->call()->emailTemplates()->create(
             Management\EmailTemplates::TEMPLATE_WELCOME_EMAIL,
             true,
             'test@auth0.com',

--- a/tests/API/Management/EmailsMockedTest.php
+++ b/tests/API/Management/EmailsMockedTest.php
@@ -3,9 +3,8 @@
 namespace Auth0\Tests\API\Management;
 
 use Auth0\Tests\Traits\ErrorHelpers;
-use Auth0\SDK\API\Management\Emails;
 use Auth0\SDK\API\Helpers\InformationHeaders;
-
+use Auth0\SDK\API\Management;
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -40,6 +39,15 @@ class EmailsMockedTest extends \PHPUnit_Framework_TestCase
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
         self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Emails::class, $api->emails );
+        $this->assertInstanceOf( Management\Emails::class, $api->emails() );
+        $api->emails = null;
+        $this->assertInstanceOf( Management\Emails::class, $api->emails() );
     }
 
     /**

--- a/tests/API/Management/EmailsMockedTest.php
+++ b/tests/API/Management/EmailsMockedTest.php
@@ -56,7 +56,7 @@ class EmailsMockedTest extends \PHPUnit_Framework_TestCase
     public function testThatGetEmailProviderRequestIsFormattedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
-        $api->call()->emails->getEmailProvider();
+        $api->call()->emails()->getEmailProvider();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/emails/provider', $api->getHistoryUrl() );
@@ -72,7 +72,7 @@ class EmailsMockedTest extends \PHPUnit_Framework_TestCase
     public function testThatGetEmailProviderRequestAddsFieldsParams()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
-        $api->call()->emails->getEmailProvider( [ 'name', 'credentials' ], true );
+        $api->call()->emails()->getEmailProvider( [ 'name', 'credentials' ], true );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/emails/provider', $api->getHistoryUrl() );

--- a/tests/API/Management/GrantsMockedTest.php
+++ b/tests/API/Management/GrantsMockedTest.php
@@ -36,6 +36,15 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
         self::$telemetry = $infoHeadersData->build();
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Grants::class, $api->grants );
+        $this->assertInstanceOf( Management\Grants::class, $api->grants() );
+        $api->grants = null;
+        $this->assertInstanceOf( Management\Grants::class, $api->grants() );
+    }
+
     /**
      * Test that getAll requests properly.
      *

--- a/tests/API/Management/GrantsMockedTest.php
+++ b/tests/API/Management/GrantsMockedTest.php
@@ -56,7 +56,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getAll();
+        $api->call()->grants()->getAll();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
@@ -80,7 +80,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         $page     = 1;
         $per_page = 5;
-        $api->call()->grants->getAll($page, $per_page);
+        $api->call()->grants()->getAll($page, $per_page);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
@@ -89,14 +89,14 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         $page     = 2;
         $per_page = null;
-        $api->call()->grants->getAll($page, $per_page);
+        $api->call()->grants()->getAll($page, $per_page);
 
         $this->assertContains( 'page=2', $api->getHistoryQuery() );
         $this->assertNotContains( 'per_page=', $api->getHistoryQuery() );
 
         $page     = false;
         $per_page = false;
-        $api->call()->grants->getAll($page, $per_page);
+        $api->call()->grants()->getAll($page, $per_page);
 
         $this->assertNull( $api->getHistoryQuery() );
     }
@@ -113,7 +113,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
         $add_params = ['param1' => 'value1', 'param2' => 'value2'];
-        $api->call()->grants->getAll(null, null, $add_params);
+        $api->call()->grants()->getAll(null, null, $add_params);
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
@@ -132,7 +132,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByClientId('__test_client_id__');
+        $api->call()->grants()->getByClientId('__test_client_id__');
 
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
         $this->assertEquals( 'client_id=__test_client_id__', $api->getHistoryQuery() );
@@ -149,7 +149,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByClientId('__test_client_id__', 1, 2);
+        $api->call()->grants()->getByClientId('__test_client_id__', 1, 2);
 
         $this->assertContains( 'page=1', $api->getHistoryQuery() );
         $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
@@ -168,7 +168,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByClientId( '' );
+            $api->grants()->getByClientId( '' );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "client_id" parameter' );
         }
@@ -177,7 +177,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByClientId( [ '__not_empty__' ] );
+            $api->grants()->getByClientId( [ '__not_empty__' ] );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "client_id" parameter' );
         }
@@ -196,7 +196,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByAudience('__test_audience__');
+        $api->call()->grants()->getByAudience('__test_audience__');
 
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
         $this->assertEquals( 'audience=__test_audience__', $api->getHistoryQuery() );
@@ -213,7 +213,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByAudience('__test_audience__', 1, 2);
+        $api->call()->grants()->getByAudience('__test_audience__', 1, 2);
 
         $this->assertContains( 'page=1', $api->getHistoryQuery() );
         $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
@@ -232,7 +232,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByAudience( '' );
+            $api->grants()->getByAudience( '' );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "audience" parameter' );
         }
@@ -241,7 +241,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByAudience( [ '__not_empty__' ] );
+            $api->grants()->getByAudience( [ '__not_empty__' ] );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "audience" parameter' );
         }
@@ -260,7 +260,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByUserId('__test_user_id__');
+        $api->call()->grants()->getByUserId('__test_user_id__');
 
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
         $this->assertEquals( 'user_id=__test_user_id__', $api->getHistoryQuery() );
@@ -277,7 +277,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200 ) ] );
 
-        $api->call()->grants->getByUserId('__test_user_id__', 1, 2);
+        $api->call()->grants()->getByUserId('__test_user_id__', 1, 2);
 
         $this->assertContains( 'page=1', $api->getHistoryQuery() );
         $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
@@ -296,7 +296,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByUserId( '' );
+            $api->grants()->getByUserId( '' );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "user_id" parameter' );
         }
@@ -305,7 +305,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->getByUserId( [ '__not_empty__' ] );
+            $api->grants()->getByUserId( [ '__not_empty__' ] );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "user_id" parameter' );
         }
@@ -325,7 +325,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi( [ new Response( 204 ) ] );
 
         $id = uniqid();
-        $api->call()->grants->delete($id);
+        $api->call()->grants()->delete($id);
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/grants/'.$id, $api->getHistoryUrl() );
@@ -349,7 +349,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->delete( '' );
+            $api->grants()->delete( '' );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "id" parameter' );
         }
@@ -358,7 +358,7 @@ class GrantsTestMocked extends \PHPUnit_Framework_TestCase
 
         try {
             $caught_exception = false;
-            $api->grants->delete( [ '__not_empty__' ] );
+            $api->grants()->delete( [ '__not_empty__' ] );
         } catch (CoreException $e) {
             $caught_exception = $this->errorHasString( $e, 'Empty or invalid "id" parameter' );
         }

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -37,6 +37,15 @@ class JobsTest extends ApiTests
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Jobs::class, $api->jobs );
+        $this->assertInstanceOf( Management\Jobs::class, $api->jobs() );
+        $api->jobs = null;
+        $this->assertInstanceOf( Management\Jobs::class, $api->jobs() );
+    }
+
     /**
      * @throws \Exception Should not be thrown in this test.
      */
@@ -44,7 +53,7 @@ class JobsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->jobs->get( '__test_id__' );
+        $api->call()->jobs()->get( '__test_id__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/jobs/__test_id__', $api->getHistoryUrl() );
@@ -61,7 +70,7 @@ class JobsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->jobs->getErrors( '__test_id__' );
+        $api->call()->jobs()->getErrors( '__test_id__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/jobs/__test_id__/errors', $api->getHistoryUrl() );
@@ -78,7 +87,7 @@ class JobsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->jobs->importUsers(
+        $api->call()->jobs()->importUsers(
             self::TEST_IMPORT_USERS_JSON_PATH,
             '__test_conn_id__',
             [
@@ -129,7 +138,7 @@ class JobsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->jobs->sendVerificationEmail( '__test_user_id__' );
+        $api->call()->jobs()->sendVerificationEmail( '__test_user_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/jobs/verification-email', $api->getHistoryUrl() );
@@ -171,7 +180,7 @@ class JobsTest extends ApiTests
             'external_id' => '__test_ext_id__',
         ];
 
-        $import_job_result = $api->jobs->importUsers(self::TEST_IMPORT_USERS_JSON_PATH, $conn_id, $import_user_params);
+        $import_job_result = $api->jobs()->importUsers(self::TEST_IMPORT_USERS_JSON_PATH, $conn_id, $import_user_params);
         sleep(0.2);
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
@@ -179,7 +188,7 @@ class JobsTest extends ApiTests
         $this->assertEquals( '__test_ext_id__', $import_job_result['external_id'] );
         $this->assertEquals( 'users_import', $import_job_result['type'] );
 
-        $get_job_result = $api->jobs->get($import_job_result['id']);
+        $get_job_result = $api->jobs()->get($import_job_result['id']);
         sleep(0.2);
 
         $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
@@ -204,7 +213,7 @@ class JobsTest extends ApiTests
 
         $create_user_data   = [
             'connection' => 'Username-Password-Authentication',
-            'email' => 'php-sdk-test-email-verification-job-' . uniqid() . '@auth0.com',
+            'email' => 'php-sdk-test-email-verification-job-'.uniqid().'@auth0.com',
             'password' => uniqid().uniqid().uniqid(),
         ];
         $create_user_result = $api->users->create( $create_user_data );
@@ -212,12 +221,12 @@ class JobsTest extends ApiTests
 
         $user_id = $create_user_result['user_id'];
 
-        $email_job_result = $api->jobs->sendVerificationEmail($user_id);
+        $email_job_result = $api->jobs()->sendVerificationEmail($user_id);
         sleep(0.2);
 
         $this->assertEquals( 'verification_email', $email_job_result['type'] );
 
-        $get_job_result = $api->jobs->get($email_job_result['id']);
+        $get_job_result = $api->jobs()->get($email_job_result['id']);
         sleep(0.2);
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -42,6 +42,15 @@ class LogsTest extends ApiTests
         sleep(1);
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Logs::class, $api->logs );
+        $this->assertInstanceOf( Management\Logs::class, $api->logs() );
+        $api->logs = null;
+        $this->assertInstanceOf( Management\Logs::class, $api->logs() );
+    }
+
     /**
      * Test a general search.
      *

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -29,11 +29,10 @@ class LogsTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
-        $env   = self::getEnv();
-        $token = self::getToken($env);
-        $api   = new Management($token, $env['DOMAIN'], ['timeout' => 30]);
+        $env = self::getEnv();
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
 
-        self::$api = $api->logs;
+        self::$api = $api->logs();
     }
 
     public function setUp()

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -54,7 +54,11 @@ class ResourceServersTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
-        self::$api              = self::getApi( 'resource_servers' );
+        $env   = self::getEnv();
+        $token = self::getToken($env);
+        $api   = new Management($token, $env['DOMAIN'], ['timeout' => 30]);
+
+        self::$api              = $api->resourceServers();
         self::$serverIdentifier = 'TEST_PHP_SDK_ID_'.uniqid();
     }
 

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -64,6 +64,15 @@ class ResourceServersTest extends ApiTests
         sleep(1);
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\ResourceServers::class, $api->resource_servers );
+        $this->assertInstanceOf( Management\ResourceServers::class, $api->resourceServers() );
+        $api->resource_servers = null;
+        $this->assertInstanceOf( Management\ResourceServers::class, $api->resourceServers() );
+    }
+
     /**
      * Test creating a Resource Server.
      *

--- a/tests/API/Management/RolesMockedTest.php
+++ b/tests/API/Management/RolesMockedTest.php
@@ -1,12 +1,11 @@
 <?php
 namespace Auth0\Tests\API\Management;
 
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Management;
 use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 use Auth0\SDK\Exception\InvalidPermissionsArrayException;
 use Auth0\Tests\Traits\ErrorHelpers;
-
-use Auth0\SDK\API\Helpers\InformationHeaders;
-
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -41,6 +40,15 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
         self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Roles::class, $api->roles );
+        $this->assertInstanceOf( Management\Roles::class, $api->roles() );
+        $api->roles = null;
+        $this->assertInstanceOf( Management\Roles::class, $api->roles() );
     }
 
     /**

--- a/tests/API/Management/RolesMockedTest.php
+++ b/tests/API/Management/RolesMockedTest.php
@@ -62,7 +62,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->getAll( [ 'name_filter' => '__test_name_filter__', 'page' => 2 ] );
+        $api->call()->roles()->getAll( [ 'name_filter' => '__test_name_filter__', 'page' => 2 ] );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/roles', $api->getHistoryUrl() );
@@ -88,7 +88,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->create( '' );
+            $api->call()->roles()->create( '' );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -108,7 +108,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->create( '__test_name__', [ 'description' => '__test_description__' ] );
+        $api->call()->roles()->create( '__test_name__', [ 'description' => '__test_description__' ] );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/roles', $api->getHistoryUrl() );
@@ -137,7 +137,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->get( '' );
+            $api->call()->roles()->get( '' );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -157,7 +157,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->get( '__test_role_id__' );
+        $api->call()->roles()->get( '__test_role_id__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/roles/__test_role_id__', $api->getHistoryUrl() );
@@ -179,7 +179,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->delete( '' );
+            $api->call()->roles()->delete( '' );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -199,7 +199,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->delete( '__test_role_id__' );
+        $api->call()->roles()->delete( '__test_role_id__' );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/roles/__test_role_id__', $api->getHistoryUrl() );
@@ -221,7 +221,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->update( '', [] );
+            $api->call()->roles()->update( '', [] );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -241,7 +241,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->update( '__test_role_id__', [ 'name' => '__test_new_name__' ] );
+        $api->call()->roles()->update( '__test_role_id__', [ 'name' => '__test_new_name__' ] );
 
         $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/roles/__test_role_id__', $api->getHistoryUrl() );
@@ -268,7 +268,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->getPermissions( '' );
+            $api->call()->roles()->getPermissions( '' );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -288,7 +288,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->getPermissions( '__test_role_id__', [ 'page' => -3, 'per_page' => -6 ] );
+        $api->call()->roles()->getPermissions( '__test_role_id__', [ 'page' => -3, 'per_page' => -6 ] );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith(
@@ -319,11 +319,11 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
             new Response( 200, self::$headers ),
         ] );
 
-        $api->call()->roles->getPermissions( '__test_role_id__', [ 'include_totals' => false ] );
+        $api->call()->roles()->getPermissions( '__test_role_id__', [ 'include_totals' => false ] );
 
         $this->assertContains( 'include_totals=false', $api->getHistoryQuery() );
 
-        $api->call()->roles->getPermissions( '__test_role_id__', [ 'include_totals' => 1 ] );
+        $api->call()->roles()->getPermissions( '__test_role_id__', [ 'include_totals' => 1 ] );
 
         $this->assertContains( 'include_totals=true', $api->getHistoryQuery() );
     }
@@ -340,7 +340,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->addPermissions( '', [] );
+            $api->call()->roles()->addPermissions( '', [] );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -361,7 +361,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->addPermissions( '__test_role_id__', [] );
+            $api->call()->roles()->addPermissions( '__test_role_id__', [] );
             $caught_exception = false;
         } catch (InvalidPermissionsArrayException $e) {
             $caught_exception = true;
@@ -381,7 +381,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->addPermissions(
+        $api->call()->roles()->addPermissions(
             '__test_role_id__',
             [
                 [
@@ -423,7 +423,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->removePermissions( '', [] );
+            $api->call()->roles()->removePermissions( '', [] );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -444,7 +444,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->removePermissions(
+            $api->call()->roles()->removePermissions(
                 '__test_role_id__',
                 [ [ 'permission_name' => uniqid() ] ]
             );
@@ -456,7 +456,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertTrue( $caught_exception );
 
         try {
-            $api->call()->roles->removePermissions(
+            $api->call()->roles()->removePermissions(
                 '__test_role_id__',
                 [ [ 'resource_server_identifier' => uniqid() ] ]
             );
@@ -479,7 +479,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->removePermissions(
+        $api->call()->roles()->removePermissions(
             '__test_role_id__',
             [
                 [
@@ -520,7 +520,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->getUsers( '' );
+            $api->call()->roles()->getUsers( '' );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -540,7 +540,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->getUsers( '__test_role_id__', [ 'per_page' => 6, 'include_totals' => 1 ] );
+        $api->call()->roles()->getUsers( '__test_role_id__', [ 'per_page' => 6, 'include_totals' => 1 ] );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith(
@@ -569,7 +569,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->addUsers( '', [] );
+            $api->call()->roles()->addUsers( '', [] );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -590,7 +590,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->roles->addUsers( '__test_role_id__', [] );
+            $api->call()->roles()->addUsers( '__test_role_id__', [] );
             $exception_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $exception_message = $e->getMessage();
@@ -610,7 +610,7 @@ class RolesTestMocked extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->roles->addUsers(
+        $api->call()->roles()->addUsers(
             '__test_role_id__',
             [ 'strategy|1234567890', 'strategy|0987654321' ]
         );

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -30,7 +30,10 @@ class RulesTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
-        self::$api = self::getApi( 'rules' );
+        $env = self::getEnv();
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
+
+        self::$api = $api->rules();
     }
 
     public function setUp()

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -39,6 +39,15 @@ class RulesTest extends ApiTests
         sleep(2);
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Rules::class, $api->rules );
+        $this->assertInstanceOf( Management\Rules::class, $api->rules() );
+        $api->rules = null;
+        $this->assertInstanceOf( Management\Rules::class, $api->rules() );
+    }
+
     /**
      * Test that get methods work as expected.
      *

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -45,6 +45,15 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
+    public function testThatMethodAndPropertyReturnSameClass()
+    {
+        $api = new Management(uniqid(), uniqid());
+        $this->assertInstanceOf( Management\Users::class, $api->users );
+        $this->assertInstanceOf( Management\Users::class, $api->users() );
+        $api->users = null;
+        $this->assertInstanceOf( Management\Users::class, $api->users() );
+    }
+
     /**
      * Test a get user call.
      *

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -65,7 +65,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->get( '__test_user_id__' );
+        $api->call()->users()->get( '__test_user_id__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
@@ -86,7 +86,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->update(
+        $api->call()->users()->update(
             '__test_user_id__',
             [
                 'given_name' => '__test_given_name__',
@@ -116,7 +116,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new Management( uniqid(), uniqid() );
 
         try {
-            $api->users->create( [] );
+            $api->users()->create( [] );
             $exception_message = '';
         } catch (\Exception $e) {
             $exception_message = $e->getMessage();
@@ -130,7 +130,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new Management( uniqid(), uniqid() );
 
         try {
-            $api->users->create( [ 'connection' => 'sms' ] );
+            $api->users()->create( [ 'connection' => 'sms' ] );
             $exception_message = '';
         } catch (\Exception $e) {
             $exception_message = $e->getMessage();
@@ -144,7 +144,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new Management( uniqid(), uniqid() );
 
         try {
-            $api->users->create( [ 'connection' => 'email' ] );
+            $api->users()->create( [ 'connection' => 'email' ] );
             $exception_message = '';
         } catch (\Exception $e) {
             $exception_message = $e->getMessage();
@@ -158,7 +158,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new Management( uniqid(), uniqid() );
 
         try {
-            $api->users->create( [ 'connection' => 'auth0', 'email' => uniqid() ] );
+            $api->users()->create( [ 'connection' => 'auth0', 'email' => uniqid() ] );
             $exception_message = '';
         } catch (\Exception $e) {
             $exception_message = $e->getMessage();
@@ -178,7 +178,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->create( [
+        $api->call()->users()->create( [
             'connection' => '__test_connection__',
             'email' => '__test_email__',
             'password' => '__test_password__',
@@ -211,7 +211,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll();
+        $api->call()->users()->getAll();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users', $api->getHistoryUrl() );
@@ -232,7 +232,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [ '__test_parameter__' => '__test_value__' ] );
+        $api->call()->users()->getAll( [ '__test_parameter__' => '__test_value__' ] );
 
         $query = $api->getHistoryQuery();
         $this->assertEquals( '__test_parameter__=__test_value__', $query );
@@ -249,7 +249,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [ 'fields' => 'field1,field2' ], 'field3' );
+        $api->call()->users()->getAll( [ 'fields' => 'field1,field2' ], 'field3' );
 
         $query = $api->getHistoryQuery();
         $this->assertEquals( 'fields=field1,field2', $query );
@@ -269,12 +269,12 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
             new Response( 200, self::$headers ),
         ] );
 
-        $api->call()->users->getAll( [ 'fields' => 'field1,field2' ] );
+        $api->call()->users()->getAll( [ 'fields' => 'field1,field2' ] );
 
         $query = $api->getHistoryQuery();
         $this->assertEquals( 'fields=field1,field2', $query );
 
-        $api->call()->users->getAll( [ 'fields' => [ 'field1', 'field2' ] ] );
+        $api->call()->users()->getAll( [ 'fields' => [ 'field1', 'field2' ] ] );
 
         $query = $api->getHistoryQuery();
         $this->assertEquals( 'fields=field1,field2', $query );
@@ -291,7 +291,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [], [ 'field3', 'field4' ], true );
+        $api->call()->users()->getAll( [], [ 'field3', 'field4' ], true );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'fields=field3,field4', $query );
@@ -309,7 +309,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [ 'include_fields' => false ], [ 'field3' ], true );
+        $api->call()->users()->getAll( [ 'include_fields' => false ], [ 'field3' ], true );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'fields=field3', $query );
@@ -327,7 +327,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [], [ 'field3' ], uniqid() );
+        $api->call()->users()->getAll( [], [ 'field3' ], uniqid() );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'fields=field3', $query );
@@ -348,12 +348,12 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
             new Response( 200, self::$headers ),
         ] );
 
-        $api->call()->users->getAll( [], [], null, 10 );
+        $api->call()->users()->getAll( [], [], null, 10 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'page=10', $query );
 
-        $api->call()->users->getAll( [], [], null, -10 );
+        $api->call()->users()->getAll( [], [], null, -10 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'page=10', $query );
@@ -370,7 +370,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [ 'page' => 11 ], [], null, 22 );
+        $api->call()->users()->getAll( [ 'page' => 11 ], [], null, 22 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'page=11', $query );
@@ -390,12 +390,12 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
             new Response( 200, self::$headers ),
         ] );
 
-        $api->call()->users->getAll( [], [], null, null, 10 );
+        $api->call()->users()->getAll( [], [], null, null, 10 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'per_page=10', $query );
 
-        $api->call()->users->getAll( [], [], null, null, -10 );
+        $api->call()->users()->getAll( [], [], null, null, -10 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'per_page=10', $query );
@@ -412,7 +412,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getAll( [ 'per_page' => 8 ], [], null, null, 9 );
+        $api->call()->users()->getAll( [ 'per_page' => 8 ], [], null, null, 9 );
 
         $query = $api->getHistoryQuery();
         $this->assertContains( 'per_page=8', $query );
@@ -429,7 +429,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->delete( '__test_user_id__' );
+        $api->call()->users()->delete( '__test_user_id__' );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/users/__test_user_id__', $api->getHistoryUrl() );
@@ -450,7 +450,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->linkAccount(
+        $api->call()->users()->linkAccount(
             '__test_user_id__',
             [
                 'provider' => '__test_provider__',
@@ -486,7 +486,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->unlinkAccount(
+        $api->call()->users()->unlinkAccount(
             '__test_user_id__',
             '__test_provider__',
             '__test_identity_id__'
@@ -514,7 +514,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->deleteMultifactorProvider( '__test_user_id__', 'duo' );
+        $api->call()->users()->deleteMultifactorProvider( '__test_user_id__', 'duo' );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals(
@@ -539,7 +539,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->getRoles( '' );
+            $api->call()->users()->getRoles( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -559,7 +559,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getRoles( '__test_user_id__', [ 'per_page' => 5, 'page' => 1, 'include_totals' => 1 ] );
+        $api->call()->users()->getRoles( '__test_user_id__', [ 'per_page' => 5, 'page' => 1, 'include_totals' => 1 ] );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith(
@@ -589,7 +589,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->removeRoles( '', [] );
+            $api->call()->users()->removeRoles( '', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -610,7 +610,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->removeRoles( '__test_user_id__', [] );
+            $api->call()->users()->removeRoles( '__test_user_id__', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -630,7 +630,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->removeRoles( '__test_user_id__', [ '__test_role_id__' ] );
+        $api->call()->users()->removeRoles( '__test_user_id__', [ '__test_role_id__' ] );
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals(
@@ -660,7 +660,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->addRoles( '', [] );
+            $api->call()->users()->addRoles( '', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -681,7 +681,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->addRoles( '__test_user_id__', [] );
+            $api->call()->users()->addRoles( '__test_user_id__', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -701,7 +701,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->addRoles( '__test_user_id__', [ '__test_role_id__' ] );
+        $api->call()->users()->addRoles( '__test_user_id__', [ '__test_role_id__' ] );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals(
@@ -732,7 +732,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->getEnrollments( '' );
+            $api->call()->users()->getEnrollments( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -752,7 +752,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getEnrollments( '__test_user_id__' );
+        $api->call()->users()->getEnrollments( '__test_user_id__' );
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertEquals(
@@ -777,7 +777,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->getPermissions( '' );
+            $api->call()->users()->getPermissions( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -797,7 +797,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getPermissions(
+        $api->call()->users()->getPermissions(
             '__test_user_id__',
             [ 'per_page' => 3, 'page' => 2, 'include_totals' => 0 ]
         );
@@ -830,7 +830,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->removePermissions( '', [] );
+            $api->call()->users()->removePermissions( '', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -851,7 +851,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->removePermissions( '__test_user_id__', [] );
+            $api->call()->users()->removePermissions( '__test_user_id__', [] );
             $caught_exception = false;
         } catch (InvalidPermissionsArrayException $e) {
             $caught_exception = true;
@@ -871,7 +871,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->removePermissions(
+        $api->call()->users()->removePermissions(
             '__test_user_id__',
             [
                 [
@@ -912,7 +912,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->addPermissions( '', [] );
+            $api->call()->users()->addPermissions( '', [] );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -933,7 +933,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->addPermissions( '__test_user_id__', [] );
+            $api->call()->users()->addPermissions( '__test_user_id__', [] );
             $caught_exception = false;
         } catch (InvalidPermissionsArrayException $e) {
             $caught_exception = true;
@@ -953,7 +953,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->addPermissions(
+        $api->call()->users()->addPermissions(
             '__test_user_id__',
             [
                 [
@@ -995,7 +995,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->getLogs( '' );
+            $api->call()->users()->getLogs( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -1015,7 +1015,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->getLogs(
+        $api->call()->users()->getLogs(
             '__test_user_id__',
             [ 'per_page' => 3, 'page' => 2, 'include_totals' => 0, 'fields' => 'date,type,ip' ]
         );
@@ -1049,7 +1049,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->generateRecoveryCode( '' );
+            $api->call()->users()->generateRecoveryCode( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -1069,7 +1069,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->generateRecoveryCode( '__test_user_id__' );
+        $api->call()->users()->generateRecoveryCode( '__test_user_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals(
@@ -1094,7 +1094,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $api = new MockManagementApi();
 
         try {
-            $api->call()->users->invalidateBrowsers( '' );
+            $api->call()->users()->invalidateBrowsers( '' );
             $caught_message = '';
         } catch (EmptyOrInvalidParameterException $e) {
             $caught_message = $e->getMessage();
@@ -1114,7 +1114,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->users->invalidateBrowsers( '__test_user_id__' );
+        $api->call()->users()->invalidateBrowsers( '__test_user_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals(


### PR DESCRIPTION
### Changes

- Add lazy-load methods for Management API class.
- Deprecate public Management properties.

**Note:** These methods are being added to support switching over to methods instead of properties in 7.0.0. These do not currently lazy-load but allow developers to start upgrading their implementations before the upgrade. 
### Testing

- [x] This change adds test coverage
- [x] This change was developed in PHP 7.1