### PR TITLE
Add Jobs endpoint tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     }
   },
   "scripts": {
-    "test": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --colors=always --coverage-text --verbose ",
-    "test-ci": "\"vendor/bin/phpunit\" --colors=always --coverage-clover=build/coverage.xml",
+    "test": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text ",
+    "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=build/coverage.xml",
     "phpcs": "\"vendor/bin/phpcs\"",
     "phpcbf": "\"vendor/bin/phpcbf\"",
     "sniffs": "\"vendor/bin/phpcs\" -e",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <phpunit
   coverage-text="true"
+  colors="always"
+  verbose="true"
   bootstrap="./tests/bootstrap.php">
   <testsuites>
     <testsuite name="Auth0 PHP SDK Test Suite">

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -49,7 +49,7 @@ class ApiTests extends \PHPUnit_Framework_TestCase
             'API_TOKEN' => getenv('API_TOKEN'),
         ];
 
-        if (!$env['API_TOKEN'] && $env['APP_CLIENT_SECRET']) {
+        if (! $env['API_TOKEN'] && $env['APP_CLIENT_SECRET']) {
             $auth_api         = new Authentication( $env['DOMAIN'], $env['APP_CLIENT_ID'], $env['APP_CLIENT_SECRET'] );
             $response         = $auth_api->client_credentials( [ 'audience' => 'https://'.$env['DOMAIN'].'/api/v2/' ] );
             $env['API_TOKEN'] = $response['access_token'];

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -1,0 +1,228 @@
+<?php
+namespace Auth0\Tests\API\Management;
+
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Management;
+use Auth0\Tests\API\ApiTests;
+use GuzzleHttp\Psr7\Response;
+
+class JobsTest extends ApiTests
+{
+
+    const FORM_DATA_VALUE_KEY_OFFSET = 3;
+
+    const TEST_IMPORT_USERS_JSON_PATH = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
+
+    /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $expectedTelemetry;
+
+    /**
+     * Default request headers.
+     *
+     * @var array
+     */
+    protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs before test suite starts.
+     */
+    public static function setUpBeforeClass()
+    {
+        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData->setCorePackage();
+        self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs->get( '__test_id__' );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/jobs/__test_id__', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatGetErrorsIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs->getErrors( '__test_id__' );
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/jobs/__test_id__/errors', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatImportUsersRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs->importUsers(
+            self::TEST_IMPORT_USERS_JSON_PATH,
+            '__test_conn_id__',
+            [
+                'upsert' => true,
+                'send_completion_email' => true,
+                'external_id' => '__test_ext_id__',
+            ]
+        );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/jobs/users-imports', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertStringStartsWith( 'multipart/form-data', $headers['Content-Type'][0] );
+
+        $form_body     = $api->getHistoryBodyAsString();
+        $form_body_arr = explode( "\r\n", $form_body );
+
+        // Test that the form data contains our import file content.
+        $import_content = file_get_contents( self::TEST_IMPORT_USERS_JSON_PATH );
+        $this->assertContains( 'name="users"; filename="test-import-users-file.json"', $form_body );
+        $this->assertContains( $import_content, $form_body );
+
+        $conn_id_key = array_search( 'Content-Disposition: form-data; name="connection_id"', $form_body_arr );
+        $this->assertNotEmpty( $conn_id_key );
+        $this->assertEquals( '__test_conn_id__', $form_body_arr[$conn_id_key + self::FORM_DATA_VALUE_KEY_OFFSET] );
+
+        $upsert_key = array_search( 'Content-Disposition: form-data; name="upsert"', $form_body_arr );
+        $this->assertNotEmpty( $upsert_key );
+        $this->assertEquals( 'true', $form_body_arr[$upsert_key + self::FORM_DATA_VALUE_KEY_OFFSET] );
+
+        $email_key = array_search( 'Content-Disposition: form-data; name="send_completion_email"', $form_body_arr );
+        $this->assertNotEmpty( $email_key );
+        $this->assertEquals( 'true', $form_body_arr[$email_key + self::FORM_DATA_VALUE_KEY_OFFSET] );
+
+        $ext_id_key = array_search( 'Content-Disposition: form-data; name="external_id"', $form_body_arr );
+        $this->assertNotEmpty( $ext_id_key );
+        $this->assertEquals( '__test_ext_id__', $form_body_arr[$ext_id_key + self::FORM_DATA_VALUE_KEY_OFFSET] );
+    }
+
+
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatSendVerificationEmailIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs->sendVerificationEmail( '__test_user_id__' );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/jobs/verification-email', $api->getHistoryUrl() );
+        $this->assertEmpty( $api->getHistoryQuery() );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'user_id', $body );
+        $this->assertEquals( '__test_user_id__', $body['user_id'] );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Exception
+     */
+    public function testIntegrationImportUsersJob()
+    {
+        $env = self::getEnv();
+
+        if (! $env['API_TOKEN']) {
+            $this->markTestSkipped( 'No client secret; integration test skipped' );
+        }
+
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN']);
+
+        // Get a single, active database connection.
+        $default_db_name       = 'Username-Password-Authentication';
+        $get_connection_result = $api->connections->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
+        sleep(0.2);
+
+        $conn_id            = $get_connection_result[0]['id'];
+        $import_user_params = [
+            'upsert' => true,
+            'send_completion_email' => false,
+            'external_id' => '__test_ext_id__',
+        ];
+
+        $import_job_result = $api->jobs->importUsers(self::TEST_IMPORT_USERS_JSON_PATH, $conn_id, $import_user_params);
+        sleep(0.2);
+
+        $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
+        $this->assertEquals( $default_db_name, $import_job_result['connection'] );
+        $this->assertEquals( '__test_ext_id__', $import_job_result['external_id'] );
+        $this->assertEquals( 'users_import', $import_job_result['type'] );
+
+        $get_job_result = $api->jobs->get($import_job_result['id']);
+        sleep(0.2);
+
+        $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
+        $this->assertEquals( $default_db_name, $get_job_result['connection'] );
+        $this->assertEquals( '__test_ext_id__', $get_job_result['external_id'] );
+        $this->assertEquals( 'users_import', $get_job_result['type'] );
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Exception
+     */
+    public function testIntegrationSendEmailVerificationJob()
+    {
+        $env = self::getEnv();
+
+        if (! $env['API_TOKEN']) {
+            $this->markTestSkipped( 'No client secret; integration test skipped' );
+        }
+
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN']);
+
+        $create_user_data   = [
+            'connection' => 'Username-Password-Authentication',
+            'email' => 'php-sdk-test-email-verification-job-' . uniqid() . '@auth0.com',
+            'password' => uniqid().uniqid().uniqid(),
+        ];
+        $create_user_result = $api->users->create( $create_user_data );
+        sleep(0.2);
+
+        $user_id = $create_user_result['user_id'];
+
+        $email_job_result = $api->jobs->sendVerificationEmail($user_id);
+        sleep(0.2);
+
+        $this->assertEquals( 'verification_email', $email_job_result['type'] );
+
+        $get_job_result = $api->jobs->get($email_job_result['id']);
+        sleep(0.2);
+
+        $this->assertEquals( 'verification_email', $get_job_result['type'] );
+
+        $api->users->delete( $user_id );
+        sleep(0.2);
+    }
+}

--- a/tests/MockApi.php
+++ b/tests/MockApi.php
@@ -91,6 +91,16 @@ class MockApi
     }
 
     /**
+     * Get the form body from a mocked request.
+     *
+     * @return string
+     */
+    public function getHistoryBodyAsString()
+    {
+        return $this->getHistory()->getBody()->getContents();
+    }
+
+    /**
      * Get the headers from a mocked request.
      *
      * @return array

--- a/tests/json/test-import-users-file.json
+++ b/tests/json/test-import-users-file.json
@@ -1,0 +1,13 @@
+[
+  {
+    "email": "php-sdk-test-import-user-job@auth0.com",
+    "email_verified": true,
+    "app_metadata": {
+        "roles": ["admin", "super"],
+        "plan": "premium"
+    },
+    "user_metadata": {
+        "theme": "dark"
+    }
+  }
+]


### PR DESCRIPTION
### Changes

Add tests for the [Management API Jobs endpoint ](https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id). This SDK does not yet cover all Jobs endpoints, hence the limited tests.

### References

Tests for #354 

### Testing

- [x] This change adds integration and mock test coverage

