### PR TITLE
Deprecate magic __call method on RequestBuilder class

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -283,10 +283,9 @@ class Authentication
             $data['authParams'] = $authParams;
         }
 
-        return $this->apiClient->post()
-        ->passwordless()
-        ->start()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+        ->addPath('passwordless')
+        ->addPath('start')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -308,10 +307,9 @@ class Authentication
             'phone_number' => $phone_number,
         ];
 
-        return $this->apiClient->post()
-        ->passwordless()
-        ->start()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+        ->addPath('passwordless')
+        ->addPath('start')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -327,9 +325,8 @@ class Authentication
      */
     public function userinfo($access_token)
     {
-        return $this->apiClient->get()
-        ->userinfo()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('get')
+        ->addPath('userinfo')
         ->withHeader(new AuthorizationBearer($access_token))
         ->call();
     }
@@ -573,10 +570,9 @@ class Authentication
             'connection' => $connection,
         ];
 
-        return $this->apiClient->post()
-        ->dbconnections()
-        ->signup()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+        ->addPath('dbconnections')
+        ->addPath('signup')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -612,10 +608,9 @@ class Authentication
             $data['password'] = $password;
         }
 
-        return $this->apiClient->post()
-        ->dbconnections()
-        ->change_password()
-        ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+        ->addPath('dbconnections')
+        ->addPath('change_password')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -724,10 +719,9 @@ class Authentication
             'additionalParameters' => $additionalParameters,
         ];
 
-        return $this->apiClient->post()
-            ->users($user_id)
-            ->impersonate()
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+            ->addPath('users', $user_id)
+            ->addPath('impersonate')
             ->withHeader(new AuthorizationBearer($access_token))
             ->withBody(json_encode($data))
             ->call();
@@ -770,10 +764,9 @@ class Authentication
             ]
         );
 
-        return $this->apiClient->post()
-            ->oauth()
-            ->access_token()
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+            ->addPath('oauth')
+            ->addPath('access_token')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -835,10 +828,9 @@ class Authentication
             $data['connection'] = $connection;
         }
 
-        return $this->apiClient->post()
-            ->oauth()
-            ->ro()
-            ->withHeader(new ContentType('application/json'))
+        return $this->apiClient->method('post')
+            ->addPath('oauth')
+            ->addPath('ro')
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -125,6 +125,8 @@ class RequestBuilder
     /**
      * Magic method to overload method calls to paths.
      *
+     * @deprecated 5.6.0, use $this->addPath() to add paths.
+     *
      * @param string     $name      Method invoked.
      * @param array|null $arguments Arguments to add to the path.
      *

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -11,8 +11,8 @@ class Jobs extends GenericResource
      */
     public function get($id)
     {
-        return $this->apiClient->get()
-        ->jobs($id)
+        return $this->apiClient->method('get')
+        ->addPath('jobs', $id)
         ->call();
     }
 
@@ -23,9 +23,9 @@ class Jobs extends GenericResource
      */
     public function getErrors($id)
     {
-        return $this->apiClient->get()
-        ->jobs($id)
-        ->errors()
+        return $this->apiClient->method('get')
+        ->addPath('jobs', $id)
+        ->addPath('errors')
         ->call();
     }
 

--- a/tests/API/Helpers/RequestBuilderTest.php
+++ b/tests/API/Helpers/RequestBuilderTest.php
@@ -35,11 +35,11 @@ class RequestBuilderTest extends ApiTests
 
         $this->assertEquals('', $builder->getUrl());
 
-        $builder->path1();
+        $builder->addPath('path1');
 
         $this->assertEquals('path1', $builder->getUrl());
 
-        $builder->path2(3);
+        $builder->addPath('path2', 3);
 
         $this->assertEquals('path1/path2/3', $builder->getUrl());
     }
@@ -154,8 +154,8 @@ class RequestBuilderTest extends ApiTests
     {
         $builder = self::getUrlBuilder('/api');
 
-        $builder->path(2)
-            ->subpath()
+        $builder->addPath('path', 2)
+            ->addPath('subpath')
             ->withParams(
                 [
                     ['key' => 'param1', 'value' => 'value1'],

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -11,7 +11,12 @@ class JobsTest extends ApiTests
 
     const FORM_DATA_VALUE_KEY_OFFSET = 3;
 
-    const TEST_IMPORT_USERS_JSON_PATH = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
+    /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $testImportUsersJsonPath;
 
     /**
      * Expected telemetry value.
@@ -32,6 +37,7 @@ class JobsTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
+        self::$testImportUsersJsonPath = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
         self::$expectedTelemetry = $infoHeadersData->build();
@@ -88,7 +94,7 @@ class JobsTest extends ApiTests
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
         $api->call()->jobs()->importUsers(
-            self::TEST_IMPORT_USERS_JSON_PATH,
+            self::$testImportUsersJsonPath,
             '__test_conn_id__',
             [
                 'upsert' => true,
@@ -109,7 +115,7 @@ class JobsTest extends ApiTests
         $form_body_arr = explode( "\r\n", $form_body );
 
         // Test that the form data contains our import file content.
-        $import_content = file_get_contents( self::TEST_IMPORT_USERS_JSON_PATH );
+        $import_content = file_get_contents( self::$testImportUsersJsonPath );
         $this->assertContains( 'name="users"; filename="test-import-users-file.json"', $form_body );
         $this->assertContains( $import_content, $form_body );
 
@@ -180,7 +186,7 @@ class JobsTest extends ApiTests
             'external_id' => '__test_ext_id__',
         ];
 
-        $import_job_result = $api->jobs()->importUsers(self::TEST_IMPORT_USERS_JSON_PATH, $conn_id, $import_user_params);
+        $import_job_result = $api->jobs()->importUsers(self::$testImportUsersJsonPath, $conn_id, $import_user_params);
         sleep(0.2);
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );


### PR DESCRIPTION
### Changes

- Deprecate magic __call method on RequestBuilder class
- Remove remaining references to this method
