### PR TITLE
Adjust sleep time; mock tests that do not need integration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <phpunit
   colors="true"
   verbose="true"
+  stopOnFailure="true"
   bootstrap="./tests/bootstrap.php">
   <testsuites>
     <testsuite name="Auth0 PHP SDK Test Suite">

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -58,34 +58,4 @@ class ApiTests extends \PHPUnit_Framework_TestCase
         self::$env = $env;
         return self::$env;
     }
-
-    /**
-     * Get a Management API token for specific scopes.
-     *
-     * @param array $env    Environment variables.
-     *
-     * @return string
-     */
-    protected static function getToken(array $env)
-    {
-        return $env['API_TOKEN'];
-    }
-
-    /**
-     * Return an API client used during self::setUpBeforeClass().
-     *
-     * @param string $endpoint   Endpoint name used for token generation.
-     *
-     * @return mixed
-     *
-     * @throws \Auth0\SDK\Exception\ApiException
-     */
-    protected static function getApi($endpoint)
-    {
-        sleep(2);
-        self::getEnv();
-        $token      = self::getToken(self::$env);
-        $api_client = new Management($token, self::$env['DOMAIN']);
-        return $api_client->$endpoint;
-    }
 }

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -101,10 +101,10 @@ class BlacklistsTest extends ApiTests
         $test_jti = uniqid().uniqid().uniqid();
 
         $api->blacklists()->blacklist($env['APP_CLIENT_ID'], $test_jti);
-        sleep(0.2);
+        usleep(700000);
 
         $blacklisted = $api->blacklists()->getAll($env['APP_CLIENT_ID']);
-        sleep(0.2);
+        usleep(700000);
 
         $this->assertGreaterThan( 0, count( $blacklisted ) );
         $this->assertEquals( $env['APP_CLIENT_ID'], $blacklisted[0]['aud'] );

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -37,13 +37,15 @@ class ClientGrantsTest extends ApiTests
     protected static $scopes = ['test:scope1', 'test:scope2'];
 
     /**
-     * Sets up API client for the testing class.
-     *
+     * @throws CoreException
      * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Exception
      */
     public static function setUpBeforeClass()
     {
-        self::$api = self::getApi( 'client_grants' );
+        self::getEnv();
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        self::$api = $api->clientGrants();
 
         $create_data = [
             'name' => 'TEST_PHP_SDK_CREATE_'.uniqid(),
@@ -51,9 +53,9 @@ class ClientGrantsTest extends ApiTests
             'signing_alg' => 'RS256'
         ];
 
-        $rs_api              = self::getApi( 'resource_servers' );
         self::$apiIdentifier = 'TEST_PHP_SDK_CLIENT_GRANT_API_'.uniqid();
-        $rs_api->create(self::$apiIdentifier, $create_data);
+        $api->resourceServers()->create(self::$apiIdentifier, $create_data);
+        usleep(700000);
     }
 
     public function setUp()
@@ -72,13 +74,15 @@ class ClientGrantsTest extends ApiTests
 
 
     /**
-     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws CoreException
+     * @throws \Exception
      */
     public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
-        $rs_api = self::getApi( 'resource_servers' );
-        $rs_api->delete( self::$apiIdentifier );
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        $api->resourceServers()->delete( self::$apiIdentifier );
+        usleep(700000);
     }
 
     /**
@@ -92,6 +96,7 @@ class ClientGrantsTest extends ApiTests
     public function testGet()
     {
         $all_results = self::$api->getAll();
+        usleep(700000);
         $this->assertNotEmpty($all_results);
 
         $expected_client_id = $all_results[0]['client_id'] ?: null;
@@ -101,10 +106,12 @@ class ClientGrantsTest extends ApiTests
         $this->assertNotNull($expected_audience);
 
         $audience_results = self::$api->getByAudience($expected_audience);
+        usleep(700000);
         $this->assertNotEmpty($audience_results);
         $this->assertEquals($expected_audience, $audience_results[0]['audience']);
 
         $client_id_results = self::$api->getByClientId($expected_client_id);
+        usleep(700000);
         $this->assertNotEmpty($client_id_results);
         $this->assertEquals($expected_client_id, $client_id_results[0]['client_id']);
     }
@@ -121,10 +128,12 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results_1 = self::$api->getAll([], 0, $expected_count);
+        usleep(700000);
         $this->assertCount($expected_count, $results_1);
 
         $expected_page = 1;
         $results_2     = self::$api->getAll([], $expected_page, 1);
+        usleep(700000);
         $this->assertCount(1, $results_2);
         $this->assertEquals($results_1[$expected_page]['client_id'], $results_2[0]['client_id']);
         $this->assertEquals($results_1[$expected_page]['audience'], $results_2[0]['audience']);
@@ -143,6 +152,7 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);
+        usleep(700000);
         $this->assertArrayHasKey('total', $results);
         $this->assertEquals($expected_page * $expected_count, $results['start']);
         $this->assertEquals($expected_count, $results['limit']);
@@ -164,6 +174,7 @@ class ClientGrantsTest extends ApiTests
 
         // Create a Client Grant with just one of the testing scopes.
         $create_result = self::$api->create($client_id, $audience, [self::$scopes[0]]);
+        usleep(700000);
         $this->assertArrayHasKey('id', $create_result);
         $this->assertEquals($client_id, $create_result['client_id']);
         $this->assertEquals($audience, $create_result['audience']);
@@ -173,10 +184,12 @@ class ClientGrantsTest extends ApiTests
 
         // Test patching the created Client Grant.
         $update_result = self::$api->update($grant_id, self::$scopes);
+        usleep(700000);
         $this->assertEquals(self::$scopes, $update_result['scope']);
 
         // Test deleting the created Client Grant.
         $delete_result = self::$api->delete($grant_id);
+        usleep(700000);
         $this->assertNull($delete_result);
     }
 

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -211,7 +211,7 @@ class ClientsTest extends ApiTests
         ];
 
         $created_client = $api->clients()->create($create_body);
-        sleep(0.3);
+        usleep(700000);
 
         $this->assertNotEmpty($created_client['client_id']);
         $this->assertEquals($create_body['name'], $created_client['name']);
@@ -219,7 +219,7 @@ class ClientsTest extends ApiTests
 
         $created_client_id = $created_client['client_id'];
         $got_entity        = $api->clients()->get($created_client_id);
-        sleep(0.3);
+        usleep(700000);
 
         // Make sure what we got matches what we created.
         $this->assertEquals($created_client_id, $got_entity['client_id']);
@@ -230,14 +230,14 @@ class ClientsTest extends ApiTests
         ];
 
         $updated_client = $api->clients()->update($created_client_id, $update_body );
-        sleep(0.3);
+        usleep(700000);
 
         $this->assertEquals($created_client_id, $updated_client['client_id']);
         $this->assertEquals($update_body['name'], $updated_client['name']);
         $this->assertEquals($update_body['app_type'], $updated_client['app_type']);
 
         $api->clients()->delete($created_client_id);
-        sleep(0.3);
+        usleep(700000);
     }
 
     /**
@@ -257,7 +257,7 @@ class ClientsTest extends ApiTests
 
         // Get the second page of Clients with 1 per page (second result).
         $paged_results = $api->clients()->getAll($fields, true, $page_num, 1);
-        sleep(0.3);
+        usleep(700000);
 
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
@@ -268,7 +268,7 @@ class ClientsTest extends ApiTests
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;
         $many_results          = $api->clients()->getAll($fields, true, 0, $many_results_per_page);
-        sleep(0.3);
+        usleep(700000);
 
         // Make sure we have at least as many results as we requested.
         $this->assertLessThanOrEqual($many_results_per_page, count($many_results));

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -177,7 +177,7 @@ class JobsTest extends ApiTests
         // Get a single, active database connection.
         $default_db_name       = 'Username-Password-Authentication';
         $get_connection_result = $api->connections->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
-        sleep(0.2);
+        usleep(700000);
 
         $conn_id            = $get_connection_result[0]['id'];
         $import_user_params = [
@@ -187,7 +187,7 @@ class JobsTest extends ApiTests
         ];
 
         $import_job_result = $api->jobs()->importUsers(self::$testImportUsersJsonPath, $conn_id, $import_user_params);
-        sleep(0.2);
+        usleep(700000);
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $import_job_result['connection'] );
@@ -195,7 +195,7 @@ class JobsTest extends ApiTests
         $this->assertEquals( 'users_import', $import_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($import_job_result['id']);
-        sleep(0.2);
+        usleep(700000);
 
         $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $get_job_result['connection'] );
@@ -223,21 +223,21 @@ class JobsTest extends ApiTests
             'password' => uniqid().uniqid().uniqid(),
         ];
         $create_user_result = $api->users->create( $create_user_data );
-        sleep(0.2);
+        usleep(700000);
 
         $user_id = $create_user_result['user_id'];
 
         $email_job_result = $api->jobs()->sendVerificationEmail($user_id);
-        sleep(0.2);
+        usleep(700000);
 
         $this->assertEquals( 'verification_email', $email_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($email_job_result['id']);
-        sleep(0.2);
+        usleep(700000);
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );
 
         $api->users->delete( $user_id );
-        sleep(0.2);
+        usleep(700000);
     }
 }

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -35,11 +35,6 @@ class LogsTest extends ApiTests
         self::$api = $api->logs();
     }
 
-    public function setUp()
-    {
-        parent::setUp();
-        sleep(1);
-    }
 
     public function testThatMethodAndPropertyReturnSameClass()
     {
@@ -61,6 +56,7 @@ class LogsTest extends ApiTests
             'fields' => '_id,log_id,date',
             'include_fields' => true,
         ]);
+        usleep(700000);
         $this->assertNotEmpty($search_results);
         $this->assertNotEmpty($search_results[0]['_id']);
         $this->assertNotEmpty($search_results[0]['log_id']);
@@ -69,6 +65,7 @@ class LogsTest extends ApiTests
 
         // Test getting a single log result with a valid ID from above.
         $one_log = self::$api->get($search_results[0]['log_id']);
+        usleep(700000);
         $this->assertNotEmpty($one_log);
         $this->assertEquals($search_results[0]['log_id'], $one_log['log_id']);
     }
@@ -93,6 +90,7 @@ class LogsTest extends ApiTests
             // Include totals to check pagination.
             'include_totals' => true,
         ]);
+        usleep(700000);
 
         $this->assertCount($expected_count, $search_results['logs']);
         $this->assertEquals($expected_count, $search_results['length']);

--- a/tests/API/Management/MockManagementApi.php
+++ b/tests/API/Management/MockManagementApi.php
@@ -26,10 +26,10 @@ class MockManagementApi extends MockApi
 
     /**
      * MockManagementApi constructor.
-     *
      * @param array $responses Responses to be loaded, an array of GuzzleHttp\Psr7\Response objects.
+     * @param string $returnType
      */
-    public function __construct(array $responses = [])
+    public function __construct(array $responses = [], $returnType = 'object')
     {
         $guzzleOptions = [];
         if (count( $responses )) {
@@ -39,6 +39,6 @@ class MockManagementApi extends MockApi
             $guzzleOptions['handler'] = $handler;
         }
 
-        $this->client = new Management('__api_token__', 'api.test.local', $guzzleOptions, 'object');
+        $this->client = new Management('__api_token__', 'api.test.local', $guzzleOptions, $returnType);
     }
 }

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -55,17 +55,10 @@ class ResourceServersTest extends ApiTests
     public static function setUpBeforeClass()
     {
         $env   = self::getEnv();
-        $token = self::getToken($env);
-        $api   = new Management($token, $env['DOMAIN'], ['timeout' => 30]);
+        $api   = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
 
         self::$api              = $api->resourceServers();
         self::$serverIdentifier = 'TEST_PHP_SDK_ID_'.uniqid();
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-        sleep(1);
     }
 
     public function testThatMethodAndPropertyReturnSameClass()
@@ -96,6 +89,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->create(self::$serverIdentifier, $create_data);
+        usleep(700000);
 
         $this->assertNotEmpty($response);
         $this->assertNotEmpty($response['id']);
@@ -117,6 +111,7 @@ class ResourceServersTest extends ApiTests
     public function testGet()
     {
         $response = self::$api->get(self::$serverIdentifier);
+        usleep(700000);
         $this->assertNotEmpty($response);
         $this->assertEquals(self::$serverIdentifier, $response['identifier']);
     }
@@ -131,6 +126,7 @@ class ResourceServersTest extends ApiTests
     public function testGetAll()
     {
         $response = self::$api->getAll();
+        usleep(700000);
 
         // Should have at least the one we created and the management API.
         $this->assertGreaterThanOrEqual(2, count($response));
@@ -148,6 +144,7 @@ class ResourceServersTest extends ApiTests
 
         // Test pagination.
         $response_paged = self::$api->getAll(1, 1);
+        usleep(700000);
         $this->assertNotEmpty($response_paged);
         $this->assertEquals($response[1]['id'], $response_paged[0]['id']);
     }
@@ -170,6 +167,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->update(self::$serverIdentifier, $update_data);
+        usleep(700000);
 
         $this->assertEquals($update_data['name'], $response['name']);
         $this->assertEquals($update_data['token_lifetime'], $response['token_lifetime']);
@@ -188,11 +186,13 @@ class ResourceServersTest extends ApiTests
     public function testDelete()
     {
         $response = self::$api->delete(self::$serverIdentifier);
+        usleep(700000);
 
         // Look for the resource server we just deleted.
         $get_server_throws_error = false;
         try {
             self::$api->get(self::$serverIdentifier);
+            usleep(700000);
         } catch (ClientException $e) {
             $get_server_throws_error = (404 === $e->getCode());
         }
@@ -214,6 +214,7 @@ class ResourceServersTest extends ApiTests
         $caught_get_no_id_exception = false;
         try {
             self::$api->get(null);
+            usleep(700000);
         } catch (CoreException $e) {
             $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -224,6 +225,7 @@ class ResourceServersTest extends ApiTests
         $caught_delete_no_id_exception = false;
         try {
             self::$api->delete(null);
+            usleep(700000);
         } catch (CoreException $e) {
             $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -234,6 +236,7 @@ class ResourceServersTest extends ApiTests
         $caught_update_no_id_exception = false;
         try {
             self::$api->update(null, []);
+            usleep(700000);
         } catch (CoreException $e) {
             $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -244,6 +247,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_empty_identifier_param_exception = false;
         try {
             self::$api->create(null, []);
+            usleep(700000);
         } catch (CoreException $e) {
             $caught_create_empty_identifier_param_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }
@@ -253,6 +257,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_invalid_identifier_field_exception = false;
         try {
             self::$api->create('identifier', ['identifier' => 1234]);
+            usleep(700000);
         } catch (CoreException $e) {
             $caught_create_invalid_identifier_field_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -30,16 +30,7 @@ class RulesTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
-        $env = self::getEnv();
-        $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
-
-        self::$api = $api->rules();
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-        sleep(2);
+        self::getEnv();
     }
 
     public function testThatMethodAndPropertyReturnSameClass()
@@ -61,12 +52,16 @@ class RulesTest extends ApiTests
      */
     public function testGet()
     {
-        $results = self::$api->getAll();
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+
+        $results = $api->rules()->getAll();
+        usleep(700000);
         $this->assertNotEmpty($results);
 
         // Check getting a single rule by a known ID.
         $get_rule_id = $results[0]['id'];
-        $result      = self::$api->get($get_rule_id);
+        $result      = $api->rules()->get($get_rule_id);
+        usleep(700000);
         $this->assertNotEmpty($result);
         $this->assertEquals($results[0]['id'], $get_rule_id);
 
@@ -82,7 +77,8 @@ class RulesTest extends ApiTests
         }
 
         // Check enabled rules.
-        $enabled_results = self::$api->getAll(true);
+        $enabled_results = $api->rules()->getAll(true);
+        usleep(700000);
         if ($has_enabled) {
             $this->assertNotEmpty($enabled_results);
         } else {
@@ -90,7 +86,8 @@ class RulesTest extends ApiTests
         }
 
         // Check disabled rules.
-        $disabled_results = self::$api->getAll(false);
+        $disabled_results = $api->rules()->getAll(false);
+        usleep(700000);
         if ($has_disabled) {
             $this->assertNotEmpty($disabled_results);
         } else {
@@ -108,14 +105,18 @@ class RulesTest extends ApiTests
      */
     public function testGetWithFields()
     {
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+
         $fields = ['id', 'name'];
 
-        $fields_results = self::$api->getAll(null, $fields, true);
+        $fields_results = $api->rules()->getAll(null, $fields, true);
+        usleep(700000);
         $this->assertNotEmpty($fields_results);
         $this->assertCount(count($fields), $fields_results[0]);
 
         $get_rule_id   = $fields_results[0]['id'];
-        $fields_result = self::$api->get($get_rule_id, $fields, true);
+        $fields_result = $api->rules()->get($get_rule_id, $fields, true);
+        usleep(700000);
         $this->assertNotEmpty($fields_result);
         $this->assertCount(count($fields), $fields_result);
     }
@@ -129,11 +130,14 @@ class RulesTest extends ApiTests
      */
     public function testGetAllPagination()
     {
-        $paged_results = self::$api->getAll(null, null, null, 0, 2);
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        $paged_results = $api->rules()->getAll(null, null, null, 0, 2);
+        usleep(700000);
         $this->assertCount(2, $paged_results);
 
         // Second page of 1 result.
-        $paged_results_2 = self::$api->getAll(null, null, null, 1, 1);
+        $paged_results_2 = $api->rules()->getAll(null, null, null, 1, 1);
+        usleep(700000);
         $this->assertCount(1, $paged_results_2);
         $this->assertEquals($paged_results[1]['id'], $paged_results_2[0]['id']);
     }
@@ -148,13 +152,15 @@ class RulesTest extends ApiTests
      */
     public function testCreateUpdateDelete()
     {
+        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $create_data = [
             'name' => 'test-create-rule-'.rand(),
             'script' => 'function (user, context, callback) { callback(null, user, context); }',
             'enabled' => true,
         ];
 
-        $create_result = self::$api->create($create_data);
+        $create_result = $api->rules()->create($create_data);
+        usleep(700000);
         $this->assertNotEmpty($create_result['id']);
         $this->assertEquals($create_data['enabled'], $create_result['enabled']);
         $this->assertEquals($create_data['name'], $create_result['name']);
@@ -167,12 +173,14 @@ class RulesTest extends ApiTests
             'enabled' => false,
         ];
 
-        $update_result = self::$api->update($test_rule_id, $update_data);
+        $update_result = $api->rules()->update($test_rule_id, $update_data);
+        usleep(700000);
         $this->assertEquals($update_data['enabled'], $update_result['enabled']);
         $this->assertEquals($update_data['name'], $update_result['name']);
         $this->assertEquals($update_data['script'], $update_result['script']);
 
-        $delete_result = self::$api->delete($test_rule_id);
+        $delete_result = $api->rules()->delete($test_rule_id);
+        usleep(700000);
         $this->assertNull($delete_result);
     }
 
@@ -185,10 +193,12 @@ class RulesTest extends ApiTests
      */
     public function testExceptions()
     {
+        $api = new Management(uniqid(), uniqid());
+
         // Test that the get method throws an exception if the $id parameter is empty.
         $caught_get_no_id_exception = false;
         try {
-            self::$api->get(null);
+            $api->rules()->get(null);
         } catch (CoreException $e) {
             $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -198,7 +208,7 @@ class RulesTest extends ApiTests
         // Test that the delete method throws an exception if the $id parameter is empty.
         $caught_delete_no_id_exception = false;
         try {
-            self::$api->delete(null);
+            $api->rules()->delete(null);
         } catch (CoreException $e) {
             $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -208,7 +218,7 @@ class RulesTest extends ApiTests
         // Test that the create method throws an exception if no "name" field is passed.
         $caught_create_no_name_exception = false;
         try {
-            self::$api->create(['script' => 'function(){}']);
+            $api->rules()->create(['script' => 'function(){}']);
         } catch (CoreException $e) {
             $caught_create_no_name_exception = $this->errorHasString($e, 'Missing required "name" field');
         }
@@ -218,7 +228,7 @@ class RulesTest extends ApiTests
         // Test that the create method throws an exception if no "script" field is passed.
         $caught_create_no_script_exception = false;
         try {
-            self::$api->create(['name' => 'test-create-rule-'.rand()]);
+            $api->rules()->create(['name' => 'test-create-rule-'.rand()]);
         } catch (CoreException $e) {
             $caught_create_no_script_exception = $this->errorHasString($e, 'Missing required "script" field');
         }
@@ -228,7 +238,7 @@ class RulesTest extends ApiTests
         // Test that the update method throws an exception if the $id parameter is empty.
         $caught_update_no_id_exception = false;
         try {
-            self::$api->update(null, []);
+            $api->rules()->update(null, []);
         } catch (CoreException $e) {
             $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }


### PR DESCRIPTION
### Changes

- Adjust sleep time to 0.5 seconds for all integration test calls
- Remove `getToken()` and `getApi()` methods from `ApiTests` test suite class
- Switch to mocked tests for return type testing

