### PR TITLE
Add JWKFetcher::getFormatted() method and switch validator to use

### DIFF
--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -63,7 +63,42 @@ class JWKFetcher
     }
 
     /**
+     * Get a JWKS from a URL and format for JWT::decode().
+     *
+     * @param string $jwks_url Full URL to the JWKS.
+     *
+     * @return array
+     */
+    public function getFormatted($jwks_url)
+    {
+        $keys = $this->cache->get($jwks_url);
+        if (is_array($keys) && ! empty($keys)) {
+            return $keys;
+        }
+
+        $jwks = $this->requestJwks($jwks_url);
+
+        if (empty( $jwks ) || empty( $jwks['keys'] )) {
+            return [];
+        }
+
+        $keys = [];
+        foreach ($jwks['keys'] as $key) {
+            if (empty( $key['kid'] ) || empty( $key['x5c'] ) || empty( $key['x5c'][0] )) {
+                continue;
+            }
+
+            $keys[$key['kid']] = $this->convertCertToPem( $key['x5c'][0] );
+        }
+
+        $this->cache->set($jwks_url, $keys);
+        return $keys;
+    }
+
+    /**
      * Fetch x509 cert for RS256 token decoding.
+     *
+     * TODO: Deprecate, use $this->getFormatted()
      *
      * @param string      $jwks_url URL to the JWKS.
      * @param string|null $kid      Key ID to use; returns first JWK if $kid is null or empty.
@@ -116,6 +151,8 @@ class JWKFetcher
     /**
      * Get a JWK from a JWKS using a key ID, if provided.
      *
+     * TODO: Deprecate
+     *
      * @param array       $jwks JWKS to parse.
      * @param null|string $kid  Key ID to return; returns first JWK if $kid is null or empty.
      *
@@ -144,6 +181,8 @@ class JWKFetcher
 
     /**
      * Check if an array within an array has a non-empty first item.
+     *
+     * TODO: Deprecate
      *
      * @param array|null $array Main array to check.
      * @param string     $key   Key pointing to a sub-array.

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -63,13 +63,13 @@ class JWKFetcher
     }
 
     /**
-     * Get a JWKS from a URL and format for JWT::decode().
+     * Gets an array of keys from the JWKS as kid => x5c.
      *
      * @param string $jwks_url Full URL to the JWKS.
      *
      * @return array
      */
-    public function getFormatted($jwks_url)
+    public function getKeys($jwks_url)
     {
         $keys = $this->cache->get($jwks_url);
         if (is_array($keys) && ! empty($keys)) {

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -217,7 +217,7 @@ class JWTVerifier
             }
 
             $jwks_url = $body_decoded->iss.$this->jwks_path;
-            $secret   = $this->JWKFetcher->getFormatted($jwks_url);
+            $secret   = $this->JWKFetcher->getKeys($jwks_url);
         }
 
         try {

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -216,8 +216,8 @@ class JWTVerifier
                 throw new CoreException('We cannot trust on a token issued by `'.$body_decoded->iss.'`');
             }
 
-            $jwks_url                   = $body_decoded->iss.$this->jwks_path;
-            $secret[$head_decoded->kid] = $this->JWKFetcher->requestJwkX5c($jwks_url, $head_decoded->kid);
+            $jwks_url = $body_decoded->iss.$this->jwks_path;
+            $secret   = $this->JWKFetcher->getFormatted($jwks_url);
         }
 
         try {

--- a/tests/API/Authentication/MockAuthenticationApi.php
+++ b/tests/API/Authentication/MockAuthenticationApi.php
@@ -1,13 +1,8 @@
 <?php
 namespace Auth0\Tests\API\Authentication;
 
-use Auth0\Tests\MockApi;
-
 use Auth0\SDK\API\Authentication;
-
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use Auth0\Tests\MockApi;
 
 /**
  * Class MockAuthenticationApi
@@ -18,27 +13,16 @@ class MockAuthenticationApi extends MockApi
 {
 
     /**
-     * Authentication API object.
-     *
      * @var Authentication
      */
     protected $client;
 
     /**
-     * MockAuthenticationApi constructor.
-     *
-     * @param array $responses Responses to be loaded, an array of GuzzleHttp\Psr7\Response objects.
+     * @param array $guzzleOptions
+     * @param array $config
      */
-    public function __construct(array $responses = [])
+    public function setClient(array $guzzleOptions, array $config = [])
     {
-        $guzzleOptions = [];
-        if (count( $responses )) {
-            $mock    = new MockHandler($responses);
-            $handler = HandlerStack::create($mock);
-            $handler->push( Middleware::history($this->requestHistory) );
-            $guzzleOptions['handler'] = $handler;
-        }
-
         $this->client = new Authentication(
             'test-domain.auth0.com',
             '__test_client_id__',

--- a/tests/API/Helpers/RequestBuilderTest.php
+++ b/tests/API/Helpers/RequestBuilderTest.php
@@ -188,30 +188,30 @@ class RequestBuilderTest extends ApiTests
         $response = [ new Response( 200, [ 'Content-Type' => 'application/json' ], '{"key":"__test_value__"}' ) ];
 
         // Test default return type matches "body".
-        $api = new MockManagementApi( $response, null );
+        $api             = new MockManagementApi( $response, [ 'return_type' => null ] );
         $results_default = $api->call()->tenants()->get();
         $this->assertTrue( is_array( $results_default ) );
         $this->assertArrayHasKey( 'key', $results_default );
         $this->assertEquals( '__test_value__', $results_default['key'] );
 
         // Test that "body" return type gives us the same result.
-        $api = new MockManagementApi( $response, 'body' );
+        $api          = new MockManagementApi( $response, [ 'return_type' => 'body' ] );
         $results_body = $api->call()->tenants()->get();
         $this->assertEquals( $results_default, $results_body );
 
         // Test that "headers" return type contains expected keys.
-        $api = new MockManagementApi( $response, 'headers' );
+        $api             = new MockManagementApi( $response, [ 'return_type' => 'headers' ] );
         $results_headers = $api->call()->tenants()->get();
         $this->assertArrayHasKey( 'Content-Type', $results_headers );
         $this->assertEquals( 'application/json', $results_headers['Content-Type'][0] );
 
         // Test that "object" return type returns the correct object type.
-        $api = new MockManagementApi( $response, 'object' );
+        $api            = new MockManagementApi( $response, [ 'return_type' => 'object' ] );
         $results_object = $api->call()->tenants()->get();
         $this->assertInstanceOf( 'GuzzleHttp\Psr7\Response', $results_object );
 
         // Test that an invalid return type throws an error.
-        $api = new MockManagementApi( $response, '__invalid_return_type__' );
+        $api = new MockManagementApi( $response, [ 'return_type' => '__invalid_return_type__' ] );
         try {
             $api->call()->tenants()->get();
             $error_msg = 'No exception caught';

--- a/tests/API/Helpers/TokenGeneratorTest.php
+++ b/tests/API/Helpers/TokenGeneratorTest.php
@@ -385,9 +385,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         // Mock the JWKFetcher object.
         $mocked_jwks = $this
             ->getMockBuilder( JWKFetcher::class )
-            ->setMethods( [ 'requestJwkX5c' ] )
+            ->setMethods( [ 'getFormatted' ] )
             ->getMock();
-        $mocked_jwks->method( 'requestJwkX5c' )->willReturn( uniqid() );
+        $mocked_jwks->method( 'getFormatted' )->willReturn( uniqid() );
 
         // Mock the JWT object.
         $expected_sub  = uniqid();

--- a/tests/API/Helpers/TokenGeneratorTest.php
+++ b/tests/API/Helpers/TokenGeneratorTest.php
@@ -385,9 +385,9 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         // Mock the JWKFetcher object.
         $mocked_jwks = $this
             ->getMockBuilder( JWKFetcher::class )
-            ->setMethods( [ 'getFormatted' ] )
+            ->setMethods( [ 'getKeys' ] )
             ->getMock();
-        $mocked_jwks->method( 'getFormatted' )->willReturn( uniqid() );
+        $mocked_jwks->method( 'getKeys' )->willReturn( uniqid() );
 
         // Mock the JWT object.
         $expected_sub  = uniqid();

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -44,7 +44,7 @@ class ClientGrantsTest extends ApiTests
     public static function setUpBeforeClass()
     {
         self::getEnv();
-        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        $api       = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         self::$api = $api->clientGrants();
 
         $create_data = [

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -38,7 +38,7 @@ class JobsTest extends ApiTests
     public static function setUpBeforeClass()
     {
         self::$testImportUsersJsonPath = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
-        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData               = new InformationHeaders;
         $infoHeadersData->setCorePackage();
         self::$expectedTelemetry = $infoHeadersData->build();
     }

--- a/tests/API/Management/MockManagementApi.php
+++ b/tests/API/Management/MockManagementApi.php
@@ -25,20 +25,12 @@ class MockManagementApi extends MockApi
     protected $client;
 
     /**
-     * MockManagementApi constructor.
-     * @param array $responses Responses to be loaded, an array of GuzzleHttp\Psr7\Response objects.
-     * @param string $returnType
+     * @param array $guzzleOptions
+     * @param array $config
      */
-    public function __construct(array $responses = [], $returnType = 'object')
+    public function setClient(array $guzzleOptions, array $config = [])
     {
-        $guzzleOptions = [];
-        if (count( $responses )) {
-            $mock    = new MockHandler($responses);
-            $handler = HandlerStack::create($mock);
-            $handler->push( Middleware::history($this->requestHistory) );
-            $guzzleOptions['handler'] = $handler;
-        }
-
+        $returnType   = isset( $config['return_type'] ) ? $config['return_type'] : null;
         $this->client = new Management('__api_token__', 'api.test.local', $guzzleOptions, $returnType);
     }
 }

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -54,8 +54,8 @@ class ResourceServersTest extends ApiTests
      */
     public static function setUpBeforeClass()
     {
-        $env   = self::getEnv();
-        $api   = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
+        $env = self::getEnv();
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);
 
         self::$api              = $api->resourceServers();
         self::$serverIdentifier = 'TEST_PHP_SDK_ID_'.uniqid();

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -130,7 +130,7 @@ class RulesTest extends ApiTests
      */
     public function testGetAllPagination()
     {
-        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        $api           = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $paged_results = $api->rules()->getAll(null, null, null, 0, 2);
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertCount(2, $paged_results);
@@ -152,7 +152,7 @@ class RulesTest extends ApiTests
      */
     public function testCreateUpdateDelete()
     {
-        $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
+        $api         = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $create_data = [
             'name' => 'test-create-rule-'.rand(),
             'script' => 'function (user, context, callback) { callback(null, user, context); }',

--- a/tests/Helpers/JWKFetcherTest.php
+++ b/tests/Helpers/JWKFetcherTest.php
@@ -19,7 +19,7 @@ class JWKFetcherTest extends \PHPUnit_Framework_TestCase
         $test_jwks = file_get_contents( AUTH0_PHP_TEST_JSON_DIR.'localhost--well-known-jwks-json.json' );
         $jwks      = new MockJwks( [ new Response( 200, [ 'Content-Type' => 'application/json' ], $test_jwks ) ] );
 
-        $jwks_formatted = $jwks->call()->getFormatted( uniqid() );
+        $jwks_formatted = $jwks->call()->getKeys( uniqid() );
 
         $this->assertCount( 2, $jwks_formatted );
         $this->assertArrayHasKey( '__test_kid_1__', $jwks_formatted );
@@ -44,10 +44,10 @@ class JWKFetcherTest extends \PHPUnit_Framework_TestCase
             new Response( 200, [ 'Content-Type' => 'application/json' ], '{keys:[]}' ),
         ] );
 
-        $jwks_formatted = $jwks->call()->getFormatted( uniqid() );
+        $jwks_formatted = $jwks->call()->getKeys( uniqid() );
         $this->assertEquals( [], $jwks_formatted );
 
-        $jwks_formatted = $jwks->call()->getFormatted( uniqid() );
+        $jwks_formatted = $jwks->call()->getKeys( uniqid() );
         $this->assertEquals( [], $jwks_formatted );
     }
 
@@ -65,11 +65,11 @@ class JWKFetcherTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $jwks_formatted_1 = $jwks->call()->getFormatted( '__test_url__' );
+        $jwks_formatted_1 = $jwks->call()->getKeys( '__test_url__' );
         $this->assertArrayHasKey( 'abc', $jwks_formatted_1 );
         $this->assertContains( '123', $jwks_formatted_1['abc'] );
 
-        $jwks_formatted_2 = $jwks->call()->getFormatted( '__test_url__' );
+        $jwks_formatted_2 = $jwks->call()->getKeys( '__test_url__' );
         $this->assertEquals( $jwks_formatted_1, $jwks_formatted_2 );
     }
 

--- a/tests/Helpers/MockJwks.php
+++ b/tests/Helpers/MockJwks.php
@@ -1,0 +1,31 @@
+<?php
+namespace Auth0\Tests\Helpers;
+
+use Auth0\SDK\Helpers\Cache\CacheHandler;
+use Auth0\SDK\Helpers\JWKFetcher;
+use Auth0\Tests\MockApi;
+
+
+/**
+ * Class MockJwks
+ *
+ * @package Auth0\SDK\Helpers\JWKFetcher
+ */
+class MockJwks extends MockApi
+{
+
+    /**
+     * @var JWKFetcher
+     */
+    protected $client;
+
+    /**
+     * @param array $guzzleOptions
+     * @param array $config
+     */
+    public function setClient(array $guzzleOptions, array $config = [])
+    {
+        $cache        = isset( $config['cache'] ) && $config['cache'] instanceof CacheHandler ? $config['cache'] : null;
+        $this->client = new JWKFetcher( $cache, $guzzleOptions );
+    }
+}

--- a/tests/MockApi.php
+++ b/tests/MockApi.php
@@ -3,6 +3,10 @@ namespace Auth0\Tests;
 
 use Auth0\SDK\API\Authentication;
 use Auth0\SDK\API\Management;
+use Auth0\SDK\Helpers\JWKFetcher;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 
 /**
@@ -10,7 +14,7 @@ use GuzzleHttp\Psr7\Request;
  *
  * @package Auth0\Tests
  */
-class MockApi
+abstract class MockApi
 {
 
     /**
@@ -30,14 +34,41 @@ class MockApi
     /**
      * Management API object.
      *
-     * @var Management|Authentication
+     * @var Management|Authentication|JWKFetcher
      */
     protected $client;
 
     /**
+     * MockApi constructor.
+     *
+     * @param array $responses Array of GuzzleHttp\Psr7\Response objects.
+     * @param array $config Additional optional configuration needed for mocked class.
+     */
+    public function __construct(array $responses = [], array $config = [])
+    {
+        $guzzleOptions = [];
+        if (count( $responses )) {
+            $mock    = new MockHandler($responses);
+            $handler = HandlerStack::create($mock);
+            $handler->push( Middleware::history($this->requestHistory) );
+            $guzzleOptions['handler'] = $handler;
+        }
+
+        $this->setClient( $guzzleOptions, $config );
+    }
+
+    /**
+     * @param array $guzzleOptions
+     * @param array $config
+     *
+     * @return mixed
+     */
+    abstract public function setClient(array $guzzleOptions, array $config = []);
+
+    /**
      * Return the endpoint being used.
      *
-     * @return Management|Authentication
+     * @return Management|Authentication|JWKFetcher
      */
     public function call()
     {


### PR DESCRIPTION
### Changes

- Add `JWKFetcher::getFormatted()` method to pull entire JWKS instead of specific keys. This makes for more clear caching and allows us to deprecate several unnecessary methods in this class.
- Refactor the `MockApi` class used in test suites to allow new mocked API responses to be added more easily.

### Testing

- [x] This change adds test coverage
- [x] This change has been developed on PHP 7.1
