### PR TITLE
Reduce sleep time during integration tests; run CI tests in series

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             - vendor
   run-tests:
     steps:
-      - run: ./vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml
+      - run: composer test-ci
       - store_artifacts:
           path:  build/coverage.xml
 
@@ -58,17 +58,14 @@ jobs:
             fi
           when: always
 
-#Each workflow represents a Github check
+# Each workflow represents a Github check
 workflows:
-  build_php_5:
+  build-and-test:
     jobs:
       - php_5
-  build_php_7:
-    jobs:
-      - php_7
-  snyk:
-    jobs:
-      - php_7
+      - php_7:
+          requires:
+            - php_5
       - snyk:
           # Must define SNYK_TOKEN env
           context: snyk-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
             fi
           when: always
 
-# Each workflow represents a Github check
 workflows:
   build-and-test:
     jobs:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "test": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text ",
-    "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=build/coverage.xml",
+    "test-ci": "\"vendor/bin/phpunit\" --stop-on-failure --coverage-clover=build/coverage.xml",
     "phpcs": "\"vendor/bin/phpcs\"",
     "phpcbf": "\"vendor/bin/phpcbf\"",
     "sniffs": "\"vendor/bin/phpcs\" -e",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <phpunit
   colors="true"
   verbose="true"
-  stopOnFailure="true"
   bootstrap="./tests/bootstrap.php">
   <testsuites>
     <testsuite name="Auth0 PHP SDK Test Suite">

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -101,10 +101,10 @@ class BlacklistsTest extends ApiTests
         $test_jti = uniqid().uniqid().uniqid();
 
         $api->blacklists()->blacklist($env['APP_CLIENT_ID'], $test_jti);
-        usleep(700000);
+        usleep(150000);
 
         $blacklisted = $api->blacklists()->getAll($env['APP_CLIENT_ID']);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertGreaterThan( 0, count( $blacklisted ) );
         $this->assertEquals( $env['APP_CLIENT_ID'], $blacklisted[0]['aud'] );

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -101,10 +101,10 @@ class BlacklistsTest extends ApiTests
         $test_jti = uniqid().uniqid().uniqid();
 
         $api->blacklists()->blacklist($env['APP_CLIENT_ID'], $test_jti);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $blacklisted = $api->blacklists()->getAll($env['APP_CLIENT_ID']);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertGreaterThan( 0, count( $blacklisted ) );
         $this->assertEquals( $env['APP_CLIENT_ID'], $blacklisted[0]['aud'] );

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -55,7 +55,7 @@ class ClientGrantsTest extends ApiTests
 
         self::$apiIdentifier = 'TEST_PHP_SDK_CLIENT_GRANT_API_'.uniqid();
         $api->resourceServers()->create(self::$apiIdentifier, $create_data);
-        usleep(700000);
+        usleep(150000);
     }
 
     public function setUp()
@@ -82,7 +82,7 @@ class ClientGrantsTest extends ApiTests
         parent::tearDownAfterClass();
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $api->resourceServers()->delete( self::$apiIdentifier );
-        usleep(700000);
+        usleep(150000);
     }
 
     /**
@@ -96,7 +96,7 @@ class ClientGrantsTest extends ApiTests
     public function testGet()
     {
         $all_results = self::$api->getAll();
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($all_results);
 
         $expected_client_id = $all_results[0]['client_id'] ?: null;
@@ -106,12 +106,12 @@ class ClientGrantsTest extends ApiTests
         $this->assertNotNull($expected_audience);
 
         $audience_results = self::$api->getByAudience($expected_audience);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($audience_results);
         $this->assertEquals($expected_audience, $audience_results[0]['audience']);
 
         $client_id_results = self::$api->getByClientId($expected_client_id);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($client_id_results);
         $this->assertEquals($expected_client_id, $client_id_results[0]['client_id']);
     }
@@ -128,12 +128,12 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results_1 = self::$api->getAll([], 0, $expected_count);
-        usleep(700000);
+        usleep(150000);
         $this->assertCount($expected_count, $results_1);
 
         $expected_page = 1;
         $results_2     = self::$api->getAll([], $expected_page, 1);
-        usleep(700000);
+        usleep(150000);
         $this->assertCount(1, $results_2);
         $this->assertEquals($results_1[$expected_page]['client_id'], $results_2[0]['client_id']);
         $this->assertEquals($results_1[$expected_page]['audience'], $results_2[0]['audience']);
@@ -152,7 +152,7 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);
-        usleep(700000);
+        usleep(150000);
         $this->assertArrayHasKey('total', $results);
         $this->assertEquals($expected_page * $expected_count, $results['start']);
         $this->assertEquals($expected_count, $results['limit']);
@@ -174,7 +174,7 @@ class ClientGrantsTest extends ApiTests
 
         // Create a Client Grant with just one of the testing scopes.
         $create_result = self::$api->create($client_id, $audience, [self::$scopes[0]]);
-        usleep(700000);
+        usleep(150000);
         $this->assertArrayHasKey('id', $create_result);
         $this->assertEquals($client_id, $create_result['client_id']);
         $this->assertEquals($audience, $create_result['audience']);
@@ -184,12 +184,12 @@ class ClientGrantsTest extends ApiTests
 
         // Test patching the created Client Grant.
         $update_result = self::$api->update($grant_id, self::$scopes);
-        usleep(700000);
+        usleep(150000);
         $this->assertEquals(self::$scopes, $update_result['scope']);
 
         // Test deleting the created Client Grant.
         $delete_result = self::$api->delete($grant_id);
-        usleep(700000);
+        usleep(150000);
         $this->assertNull($delete_result);
     }
 

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -55,7 +55,7 @@ class ClientGrantsTest extends ApiTests
 
         self::$apiIdentifier = 'TEST_PHP_SDK_CLIENT_GRANT_API_'.uniqid();
         $api->resourceServers()->create(self::$apiIdentifier, $create_data);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 
     public function setUp()
@@ -82,7 +82,7 @@ class ClientGrantsTest extends ApiTests
         parent::tearDownAfterClass();
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $api->resourceServers()->delete( self::$apiIdentifier );
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 
     /**
@@ -96,7 +96,7 @@ class ClientGrantsTest extends ApiTests
     public function testGet()
     {
         $all_results = self::$api->getAll();
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($all_results);
 
         $expected_client_id = $all_results[0]['client_id'] ?: null;
@@ -106,12 +106,12 @@ class ClientGrantsTest extends ApiTests
         $this->assertNotNull($expected_audience);
 
         $audience_results = self::$api->getByAudience($expected_audience);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($audience_results);
         $this->assertEquals($expected_audience, $audience_results[0]['audience']);
 
         $client_id_results = self::$api->getByClientId($expected_client_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($client_id_results);
         $this->assertEquals($expected_client_id, $client_id_results[0]['client_id']);
     }
@@ -128,12 +128,12 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results_1 = self::$api->getAll([], 0, $expected_count);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertCount($expected_count, $results_1);
 
         $expected_page = 1;
         $results_2     = self::$api->getAll([], $expected_page, 1);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertCount(1, $results_2);
         $this->assertEquals($results_1[$expected_page]['client_id'], $results_2[0]['client_id']);
         $this->assertEquals($results_1[$expected_page]['audience'], $results_2[0]['audience']);
@@ -152,7 +152,7 @@ class ClientGrantsTest extends ApiTests
         $expected_count = 2;
 
         $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertArrayHasKey('total', $results);
         $this->assertEquals($expected_page * $expected_count, $results['start']);
         $this->assertEquals($expected_count, $results['limit']);
@@ -174,7 +174,7 @@ class ClientGrantsTest extends ApiTests
 
         // Create a Client Grant with just one of the testing scopes.
         $create_result = self::$api->create($client_id, $audience, [self::$scopes[0]]);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertArrayHasKey('id', $create_result);
         $this->assertEquals($client_id, $create_result['client_id']);
         $this->assertEquals($audience, $create_result['audience']);
@@ -184,12 +184,12 @@ class ClientGrantsTest extends ApiTests
 
         // Test patching the created Client Grant.
         $update_result = self::$api->update($grant_id, self::$scopes);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertEquals(self::$scopes, $update_result['scope']);
 
         // Test deleting the created Client Grant.
         $delete_result = self::$api->delete($grant_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNull($delete_result);
     }
 

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -211,7 +211,7 @@ class ClientsTest extends ApiTests
         ];
 
         $created_client = $api->clients()->create($create_body);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertNotEmpty($created_client['client_id']);
         $this->assertEquals($create_body['name'], $created_client['name']);
@@ -219,7 +219,7 @@ class ClientsTest extends ApiTests
 
         $created_client_id = $created_client['client_id'];
         $got_entity        = $api->clients()->get($created_client_id);
-        usleep(700000);
+        usleep(150000);
 
         // Make sure what we got matches what we created.
         $this->assertEquals($created_client_id, $got_entity['client_id']);
@@ -230,14 +230,14 @@ class ClientsTest extends ApiTests
         ];
 
         $updated_client = $api->clients()->update($created_client_id, $update_body );
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals($created_client_id, $updated_client['client_id']);
         $this->assertEquals($update_body['name'], $updated_client['name']);
         $this->assertEquals($update_body['app_type'], $updated_client['app_type']);
 
         $api->clients()->delete($created_client_id);
-        usleep(700000);
+        usleep(150000);
     }
 
     /**
@@ -257,7 +257,7 @@ class ClientsTest extends ApiTests
 
         // Get the second page of Clients with 1 per page (second result).
         $paged_results = $api->clients()->getAll($fields, true, $page_num, 1);
-        usleep(700000);
+        usleep(150000);
 
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
@@ -268,7 +268,7 @@ class ClientsTest extends ApiTests
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;
         $many_results          = $api->clients()->getAll($fields, true, 0, $many_results_per_page);
-        usleep(700000);
+        usleep(150000);
 
         // Make sure we have at least as many results as we requested.
         $this->assertLessThanOrEqual($many_results_per_page, count($many_results));

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -211,7 +211,7 @@ class ClientsTest extends ApiTests
         ];
 
         $created_client = $api->clients()->create($create_body);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertNotEmpty($created_client['client_id']);
         $this->assertEquals($create_body['name'], $created_client['name']);
@@ -219,7 +219,7 @@ class ClientsTest extends ApiTests
 
         $created_client_id = $created_client['client_id'];
         $got_entity        = $api->clients()->get($created_client_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         // Make sure what we got matches what we created.
         $this->assertEquals($created_client_id, $got_entity['client_id']);
@@ -230,14 +230,14 @@ class ClientsTest extends ApiTests
         ];
 
         $updated_client = $api->clients()->update($created_client_id, $update_body );
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals($created_client_id, $updated_client['client_id']);
         $this->assertEquals($update_body['name'], $updated_client['name']);
         $this->assertEquals($update_body['app_type'], $updated_client['app_type']);
 
         $api->clients()->delete($created_client_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 
     /**
@@ -257,7 +257,7 @@ class ClientsTest extends ApiTests
 
         // Get the second page of Clients with 1 per page (second result).
         $paged_results = $api->clients()->getAll($fields, true, $page_num, 1);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
@@ -268,7 +268,7 @@ class ClientsTest extends ApiTests
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;
         $many_results          = $api->clients()->getAll($fields, true, 0, $many_results_per_page);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         // Make sure we have at least as many results as we requested.
         $this->assertLessThanOrEqual($many_results_per_page, count($many_results));

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -177,7 +177,7 @@ class JobsTest extends ApiTests
         // Get a single, active database connection.
         $default_db_name       = 'Username-Password-Authentication';
         $get_connection_result = $api->connections->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $conn_id            = $get_connection_result[0]['id'];
         $import_user_params = [
@@ -187,7 +187,7 @@ class JobsTest extends ApiTests
         ];
 
         $import_job_result = $api->jobs()->importUsers(self::$testImportUsersJsonPath, $conn_id, $import_user_params);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $import_job_result['connection'] );
@@ -195,7 +195,7 @@ class JobsTest extends ApiTests
         $this->assertEquals( 'users_import', $import_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($import_job_result['id']);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $get_job_result['connection'] );
@@ -223,21 +223,21 @@ class JobsTest extends ApiTests
             'password' => uniqid().uniqid().uniqid(),
         ];
         $create_user_result = $api->users->create( $create_user_data );
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $user_id = $create_user_result['user_id'];
 
         $email_job_result = $api->jobs()->sendVerificationEmail($user_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals( 'verification_email', $email_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($email_job_result['id']);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );
 
         $api->users->delete( $user_id );
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 }

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -177,7 +177,7 @@ class JobsTest extends ApiTests
         // Get a single, active database connection.
         $default_db_name       = 'Username-Password-Authentication';
         $get_connection_result = $api->connections->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
-        usleep(700000);
+        usleep(150000);
 
         $conn_id            = $get_connection_result[0]['id'];
         $import_user_params = [
@@ -187,7 +187,7 @@ class JobsTest extends ApiTests
         ];
 
         $import_job_result = $api->jobs()->importUsers(self::$testImportUsersJsonPath, $conn_id, $import_user_params);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $import_job_result['connection'] );
@@ -195,7 +195,7 @@ class JobsTest extends ApiTests
         $this->assertEquals( 'users_import', $import_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($import_job_result['id']);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $get_job_result['connection'] );
@@ -223,21 +223,21 @@ class JobsTest extends ApiTests
             'password' => uniqid().uniqid().uniqid(),
         ];
         $create_user_result = $api->users->create( $create_user_data );
-        usleep(700000);
+        usleep(150000);
 
         $user_id = $create_user_result['user_id'];
 
         $email_job_result = $api->jobs()->sendVerificationEmail($user_id);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals( 'verification_email', $email_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($email_job_result['id']);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );
 
         $api->users->delete( $user_id );
-        usleep(700000);
+        usleep(150000);
     }
 }

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -56,7 +56,7 @@ class LogsTest extends ApiTests
             'fields' => '_id,log_id,date',
             'include_fields' => true,
         ]);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($search_results);
         $this->assertNotEmpty($search_results[0]['_id']);
         $this->assertNotEmpty($search_results[0]['log_id']);
@@ -65,7 +65,7 @@ class LogsTest extends ApiTests
 
         // Test getting a single log result with a valid ID from above.
         $one_log = self::$api->get($search_results[0]['log_id']);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($one_log);
         $this->assertEquals($search_results[0]['log_id'], $one_log['log_id']);
     }
@@ -90,7 +90,7 @@ class LogsTest extends ApiTests
             // Include totals to check pagination.
             'include_totals' => true,
         ]);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertCount($expected_count, $search_results['logs']);
         $this->assertEquals($expected_count, $search_results['length']);

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -56,7 +56,7 @@ class LogsTest extends ApiTests
             'fields' => '_id,log_id,date',
             'include_fields' => true,
         ]);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($search_results);
         $this->assertNotEmpty($search_results[0]['_id']);
         $this->assertNotEmpty($search_results[0]['log_id']);
@@ -65,7 +65,7 @@ class LogsTest extends ApiTests
 
         // Test getting a single log result with a valid ID from above.
         $one_log = self::$api->get($search_results[0]['log_id']);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($one_log);
         $this->assertEquals($search_results[0]['log_id'], $one_log['log_id']);
     }
@@ -90,7 +90,7 @@ class LogsTest extends ApiTests
             // Include totals to check pagination.
             'include_totals' => true,
         ]);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertCount($expected_count, $search_results['logs']);
         $this->assertEquals($expected_count, $search_results['length']);

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -89,7 +89,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->create(self::$serverIdentifier, $create_data);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertNotEmpty($response);
         $this->assertNotEmpty($response['id']);
@@ -111,7 +111,7 @@ class ResourceServersTest extends ApiTests
     public function testGet()
     {
         $response = self::$api->get(self::$serverIdentifier);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($response);
         $this->assertEquals(self::$serverIdentifier, $response['identifier']);
     }
@@ -126,7 +126,7 @@ class ResourceServersTest extends ApiTests
     public function testGetAll()
     {
         $response = self::$api->getAll();
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         // Should have at least the one we created and the management API.
         $this->assertGreaterThanOrEqual(2, count($response));
@@ -144,7 +144,7 @@ class ResourceServersTest extends ApiTests
 
         // Test pagination.
         $response_paged = self::$api->getAll(1, 1);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($response_paged);
         $this->assertEquals($response[1]['id'], $response_paged[0]['id']);
     }
@@ -167,7 +167,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->update(self::$serverIdentifier, $update_data);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $this->assertEquals($update_data['name'], $response['name']);
         $this->assertEquals($update_data['token_lifetime'], $response['token_lifetime']);
@@ -186,13 +186,13 @@ class ResourceServersTest extends ApiTests
     public function testDelete()
     {
         $response = self::$api->delete(self::$serverIdentifier);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         // Look for the resource server we just deleted.
         $get_server_throws_error = false;
         try {
             self::$api->get(self::$serverIdentifier);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (ClientException $e) {
             $get_server_throws_error = (404 === $e->getCode());
         }
@@ -214,7 +214,7 @@ class ResourceServersTest extends ApiTests
         $caught_get_no_id_exception = false;
         try {
             self::$api->get(null);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (CoreException $e) {
             $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -225,7 +225,7 @@ class ResourceServersTest extends ApiTests
         $caught_delete_no_id_exception = false;
         try {
             self::$api->delete(null);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (CoreException $e) {
             $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -236,7 +236,7 @@ class ResourceServersTest extends ApiTests
         $caught_update_no_id_exception = false;
         try {
             self::$api->update(null, []);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (CoreException $e) {
             $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -247,7 +247,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_empty_identifier_param_exception = false;
         try {
             self::$api->create(null, []);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (CoreException $e) {
             $caught_create_empty_identifier_param_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }
@@ -257,7 +257,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_invalid_identifier_field_exception = false;
         try {
             self::$api->create('identifier', ['identifier' => 1234]);
-            usleep(150000);
+            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         } catch (CoreException $e) {
             $caught_create_invalid_identifier_field_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -89,7 +89,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->create(self::$serverIdentifier, $create_data);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertNotEmpty($response);
         $this->assertNotEmpty($response['id']);
@@ -111,7 +111,7 @@ class ResourceServersTest extends ApiTests
     public function testGet()
     {
         $response = self::$api->get(self::$serverIdentifier);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($response);
         $this->assertEquals(self::$serverIdentifier, $response['identifier']);
     }
@@ -126,7 +126,7 @@ class ResourceServersTest extends ApiTests
     public function testGetAll()
     {
         $response = self::$api->getAll();
-        usleep(700000);
+        usleep(150000);
 
         // Should have at least the one we created and the management API.
         $this->assertGreaterThanOrEqual(2, count($response));
@@ -144,7 +144,7 @@ class ResourceServersTest extends ApiTests
 
         // Test pagination.
         $response_paged = self::$api->getAll(1, 1);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($response_paged);
         $this->assertEquals($response[1]['id'], $response_paged[0]['id']);
     }
@@ -167,7 +167,7 @@ class ResourceServersTest extends ApiTests
         ];
 
         $response = self::$api->update(self::$serverIdentifier, $update_data);
-        usleep(700000);
+        usleep(150000);
 
         $this->assertEquals($update_data['name'], $response['name']);
         $this->assertEquals($update_data['token_lifetime'], $response['token_lifetime']);
@@ -186,13 +186,13 @@ class ResourceServersTest extends ApiTests
     public function testDelete()
     {
         $response = self::$api->delete(self::$serverIdentifier);
-        usleep(700000);
+        usleep(150000);
 
         // Look for the resource server we just deleted.
         $get_server_throws_error = false;
         try {
             self::$api->get(self::$serverIdentifier);
-            usleep(700000);
+            usleep(150000);
         } catch (ClientException $e) {
             $get_server_throws_error = (404 === $e->getCode());
         }
@@ -214,7 +214,7 @@ class ResourceServersTest extends ApiTests
         $caught_get_no_id_exception = false;
         try {
             self::$api->get(null);
-            usleep(700000);
+            usleep(150000);
         } catch (CoreException $e) {
             $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -225,7 +225,7 @@ class ResourceServersTest extends ApiTests
         $caught_delete_no_id_exception = false;
         try {
             self::$api->delete(null);
-            usleep(700000);
+            usleep(150000);
         } catch (CoreException $e) {
             $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -236,7 +236,7 @@ class ResourceServersTest extends ApiTests
         $caught_update_no_id_exception = false;
         try {
             self::$api->update(null, []);
-            usleep(700000);
+            usleep(150000);
         } catch (CoreException $e) {
             $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -247,7 +247,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_empty_identifier_param_exception = false;
         try {
             self::$api->create(null, []);
-            usleep(700000);
+            usleep(150000);
         } catch (CoreException $e) {
             $caught_create_empty_identifier_param_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }
@@ -257,7 +257,7 @@ class ResourceServersTest extends ApiTests
         $caught_create_invalid_identifier_field_exception = false;
         try {
             self::$api->create('identifier', ['identifier' => 1234]);
-            usleep(700000);
+            usleep(150000);
         } catch (CoreException $e) {
             $caught_create_invalid_identifier_field_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -55,13 +55,13 @@ class RulesTest extends ApiTests
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
 
         $results = $api->rules()->getAll();
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($results);
 
         // Check getting a single rule by a known ID.
         $get_rule_id = $results[0]['id'];
         $result      = $api->rules()->get($get_rule_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($result);
         $this->assertEquals($results[0]['id'], $get_rule_id);
 
@@ -78,7 +78,7 @@ class RulesTest extends ApiTests
 
         // Check enabled rules.
         $enabled_results = $api->rules()->getAll(true);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         if ($has_enabled) {
             $this->assertNotEmpty($enabled_results);
         } else {
@@ -87,7 +87,7 @@ class RulesTest extends ApiTests
 
         // Check disabled rules.
         $disabled_results = $api->rules()->getAll(false);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         if ($has_disabled) {
             $this->assertNotEmpty($disabled_results);
         } else {
@@ -110,13 +110,13 @@ class RulesTest extends ApiTests
         $fields = ['id', 'name'];
 
         $fields_results = $api->rules()->getAll(null, $fields, true);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($fields_results);
         $this->assertCount(count($fields), $fields_results[0]);
 
         $get_rule_id   = $fields_results[0]['id'];
         $fields_result = $api->rules()->get($get_rule_id, $fields, true);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($fields_result);
         $this->assertCount(count($fields), $fields_result);
     }
@@ -132,12 +132,12 @@ class RulesTest extends ApiTests
     {
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $paged_results = $api->rules()->getAll(null, null, null, 0, 2);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertCount(2, $paged_results);
 
         // Second page of 1 result.
         $paged_results_2 = $api->rules()->getAll(null, null, null, 1, 1);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertCount(1, $paged_results_2);
         $this->assertEquals($paged_results[1]['id'], $paged_results_2[0]['id']);
     }
@@ -160,7 +160,7 @@ class RulesTest extends ApiTests
         ];
 
         $create_result = $api->rules()->create($create_data);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNotEmpty($create_result['id']);
         $this->assertEquals($create_data['enabled'], $create_result['enabled']);
         $this->assertEquals($create_data['name'], $create_result['name']);
@@ -174,13 +174,13 @@ class RulesTest extends ApiTests
         ];
 
         $update_result = $api->rules()->update($test_rule_id, $update_data);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertEquals($update_data['enabled'], $update_result['enabled']);
         $this->assertEquals($update_data['name'], $update_result['name']);
         $this->assertEquals($update_data['script'], $update_result['script']);
 
         $delete_result = $api->rules()->delete($test_rule_id);
-        usleep(150000);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
         $this->assertNull($delete_result);
     }
 

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -55,13 +55,13 @@ class RulesTest extends ApiTests
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
 
         $results = $api->rules()->getAll();
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($results);
 
         // Check getting a single rule by a known ID.
         $get_rule_id = $results[0]['id'];
         $result      = $api->rules()->get($get_rule_id);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($result);
         $this->assertEquals($results[0]['id'], $get_rule_id);
 
@@ -78,7 +78,7 @@ class RulesTest extends ApiTests
 
         // Check enabled rules.
         $enabled_results = $api->rules()->getAll(true);
-        usleep(700000);
+        usleep(150000);
         if ($has_enabled) {
             $this->assertNotEmpty($enabled_results);
         } else {
@@ -87,7 +87,7 @@ class RulesTest extends ApiTests
 
         // Check disabled rules.
         $disabled_results = $api->rules()->getAll(false);
-        usleep(700000);
+        usleep(150000);
         if ($has_disabled) {
             $this->assertNotEmpty($disabled_results);
         } else {
@@ -110,13 +110,13 @@ class RulesTest extends ApiTests
         $fields = ['id', 'name'];
 
         $fields_results = $api->rules()->getAll(null, $fields, true);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($fields_results);
         $this->assertCount(count($fields), $fields_results[0]);
 
         $get_rule_id   = $fields_results[0]['id'];
         $fields_result = $api->rules()->get($get_rule_id, $fields, true);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($fields_result);
         $this->assertCount(count($fields), $fields_result);
     }
@@ -132,12 +132,12 @@ class RulesTest extends ApiTests
     {
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $paged_results = $api->rules()->getAll(null, null, null, 0, 2);
-        usleep(700000);
+        usleep(150000);
         $this->assertCount(2, $paged_results);
 
         // Second page of 1 result.
         $paged_results_2 = $api->rules()->getAll(null, null, null, 1, 1);
-        usleep(700000);
+        usleep(150000);
         $this->assertCount(1, $paged_results_2);
         $this->assertEquals($paged_results[1]['id'], $paged_results_2[0]['id']);
     }
@@ -160,7 +160,7 @@ class RulesTest extends ApiTests
         ];
 
         $create_result = $api->rules()->create($create_data);
-        usleep(700000);
+        usleep(150000);
         $this->assertNotEmpty($create_result['id']);
         $this->assertEquals($create_data['enabled'], $create_result['enabled']);
         $this->assertEquals($create_data['name'], $create_result['name']);
@@ -174,13 +174,13 @@ class RulesTest extends ApiTests
         ];
 
         $update_result = $api->rules()->update($test_rule_id, $update_data);
-        usleep(700000);
+        usleep(150000);
         $this->assertEquals($update_data['enabled'], $update_result['enabled']);
         $this->assertEquals($update_data['name'], $update_result['name']);
         $this->assertEquals($update_data['script'], $update_result['script']);
 
         $delete_result = $api->rules()->delete($test_rule_id);
-        usleep(700000);
+        usleep(150000);
         $this->assertNull($delete_result);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,8 @@ $tests_dir = dirname(__FILE__).'/';
 
 require_once $tests_dir.'../vendor/autoload.php';
 
+define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 150000 );
+
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );
 }


### PR DESCRIPTION
### Changes

Running PHP 5 and PHP 7 tests in parallel was causing rate limits to be reached on integration tests. This PR makes the `build_php_7` workflow run after `build_php_5` to avoid this problem. This also reduces the sleep time in between each integration test and stops the testing script after the first failure to reduce CPU time when there is a problem.

No SDK functionality changes in this PR.
