### PR TITLE
Add \Auth0\SDK\Auth0::getLoginUrl() method and switch login() to use it

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -414,7 +414,6 @@ class Auth0
         $params = [];
 
         if ($state) {
-            $this->stateHandler->store($state);
             $params['state'] = $state;
         }
 
@@ -450,12 +449,13 @@ class Auth0
         ];
 
         $auth_params = array_replace( $default_params, $params );
+        $auth_params = array_filter( $auth_params );
 
         if (empty( $auth_params['state'] )) {
             $auth_params['state'] = $this->stateHandler->issue();
+        } else {
+            $this->stateHandler->store($auth_params['state']);
         }
-
-        $auth_params = array_filter( $auth_params );
 
         return $this->authentication->get_authorize_link(
             $auth_params['response_type'],


### PR DESCRIPTION
### Changes

- Add `\Auth0\SDK\Auth0::getLoginUrl()` to expose a way to build out a login URL.
- Change `\Auth0\SDK\Auth0::login()` to use this method.

### References

auth0/laravel-auth0#140

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on PHP 7.1

