### PR TITLE
Set content-type for DELETE method

### DIFF
--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -108,7 +108,7 @@ class ApiClient
         ]);
         $builder->withHeaders($this->headers);
 
-        if ($set_content_type && in_array($method, [ 'patch', 'post', 'put' ])) {
+        if ($set_content_type && in_array($method, [ 'patch', 'post', 'put', 'delete' ])) {
             $builder->withHeader(new ContentType('application/json'));
         }
 

--- a/tests/API/Management/ConnectionsMockedTest.php
+++ b/tests/API/Management/ConnectionsMockedTest.php
@@ -274,6 +274,10 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
         $this->assertEmpty( $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
     }
 
     /**
@@ -294,6 +298,10 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
         $this->assertContains( 'https://api.test.local/api/v2/connections/'.$id.'/users', $api->getHistoryUrl() );
         $this->assertEquals( 'email='.$email, $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
     }
 
     /**
@@ -317,6 +325,11 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
         $this->assertEmpty( $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 
     /**
@@ -369,5 +382,10 @@ class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
         $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
         $this->assertEmpty( $api->getHistoryQuery() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 }

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -102,6 +102,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
 
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'given_name', $body );
@@ -190,6 +191,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
 
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'connection', $body );
@@ -465,6 +467,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
 
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'provider', $body );
@@ -641,6 +644,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
 
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'roles', $body );
@@ -890,6 +894,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
 
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'permissions', $body );
@@ -1080,6 +1085,7 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 
     /**
@@ -1125,5 +1131,6 @@ class UsersMockedTest extends \PHPUnit_Framework_TestCase
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@ $tests_dir = dirname(__FILE__).'/';
 
 require_once $tests_dir.'../vendor/autoload.php';
 
-define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 150000 );
+define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 200000 );
 
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );


### PR DESCRIPTION
### Changes

Reverting an earlier and unreleased `5.6.0` change that removed the `Content-Type` header for `DELETE` HTTP methods (#362) and adding tests to make sure that does not change. `DELETE` requests can include a JSON body so we need that header.
