### PR TITLE
Fix mkdir race condition in FileSystemCacheHandler

### DIFF
--- a/src/Helpers/Cache/FileSystemCacheHandler.php
+++ b/src/Helpers/Cache/FileSystemCacheHandler.php
@@ -19,7 +19,10 @@ class FileSystemCacheHandler implements CacheHandler
     public function __construct($temp_directory_prefix = 'auth0-php')
     {
         $this->tmp_dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.$temp_directory_prefix.DIRECTORY_SEPARATOR;
-        if (! is_dir($this->tmp_dir) && ! @mkdir($this->tmp_dir, 0777, true) && ! is_dir($this->tmp_dir) ) {
+        if (! is_dir($this->tmp_dir)
+            && ! @mkdir($this->tmp_dir, 0777, true)
+            && ! is_dir($this->tmp_dir) // If mkdir failed it means that another process created it in between
+        ) {
             throw new \RuntimeException("Cache Handler was not able to create directory '$this->tmp_dir'");
         }
     }

--- a/src/Helpers/Cache/FileSystemCacheHandler.php
+++ b/src/Helpers/Cache/FileSystemCacheHandler.php
@@ -19,8 +19,8 @@ class FileSystemCacheHandler implements CacheHandler
     public function __construct($temp_directory_prefix = 'auth0-php')
     {
         $this->tmp_dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.$temp_directory_prefix.DIRECTORY_SEPARATOR;
-        if (! file_exists($this->tmp_dir)) {
-            mkdir($this->tmp_dir);
+        if (! is_dir($this->tmp_dir) && ! @mkdir($this->tmp_dir, 0777, true) && ! is_dir($this->tmp_dir) ) {
+            throw new \RuntimeException("Cache Handler was not able to create directory '$this->tmp_dir'");
         }
     }
 

--- a/src/Helpers/Cache/FileSystemCacheHandler.php
+++ b/src/Helpers/Cache/FileSystemCacheHandler.php
@@ -21,9 +21,9 @@ class FileSystemCacheHandler implements CacheHandler
         $this->tmp_dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.$temp_directory_prefix.DIRECTORY_SEPARATOR;
         if (! is_dir($this->tmp_dir)
             && ! @mkdir($this->tmp_dir, 0777, true)
-            && ! is_dir($this->tmp_dir) // If mkdir failed it means that another process created it in between
+            && ! is_dir($this->tmp_dir) // If mkdir failed it means that another process created it in between or the directory is not writeable
         ) {
-            throw new \RuntimeException("Cache Handler was not able to create directory '$this->tmp_dir'");
+            trigger_error("Cache Handler was not able to create directory '$this->tmp_dir'", E_USER_WARNING);
         }
     }
 


### PR DESCRIPTION
### Changes

From time I am having errors such as `Warning: mkdir(): File exists` coming from `FileSystemCacheHandler`.

Not a big a deal but it's creating false positive alerts.

### References

- https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#mkdir-race-condition

### Testing

Quite hard to test but it's a known issue. Most framework for example are using that approach.

- [ ] This change adds test coverage

- [x] This change has been tested on the latest version of PHP

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

- [x] All existing and new tests complete without errors.

- [x] The correct base branch is being used.
