### PR TITLE
Update minimum PHP from 5.5 to 71; fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,6 @@ commands:
 
 
 jobs:
-  php_5:
-    docker:
-      - image: circleci/php:5.6
-    steps:
-      - prepare
-      - run-tests
   php_7:
     docker:
       - image: circleci/php:7.1
@@ -61,10 +55,7 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - php_5
-      - php_7:
-          requires:
-            - php_5
+      - php_7
       - snyk:
           # Must define SNYK_TOKEN env
           context: snyk-env

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -23,7 +23,7 @@
     PHPCompatibility sniffs to check for PHP cross-version incompatible code.
     https://github.com/PHPCompatibility/PHPCompatibility
     -->
-    <config name="testVersion" value="5.5-"/>
+    <config name="testVersion" value="7.1-"/>
     <rule ref="PHPCompatibility"/>
 
     <!--

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     }
   ],
   "require": {
-    "php": "^5.5 || ^7.0",
+    "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0",
     "ext-json": "*",
     "firebase/php-jwt" : "^5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.7",
+    "phpunit/phpunit": "^7.0",
     "josegonzalez/dotenv": "^2.0",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -3,8 +3,8 @@ namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Authentication;
 use Auth0\Tests\Traits\ErrorHelpers;
-use Auth0\SDK\API\Management;
 use josegonzalez\Dotenv\Loader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ApiTests.
@@ -12,7 +12,7 @@ use josegonzalez\Dotenv\Loader;
  *
  * @package Auth0\Tests\API
  */
-class ApiTests extends \PHPUnit_Framework_TestCase
+class ApiTests extends TestCase
 {
     use ErrorHelpers;
 

--- a/tests/API/Authentication/UrlBuildersTest.php
+++ b/tests/API/Authentication/UrlBuildersTest.php
@@ -2,9 +2,9 @@
 namespace Auth0\Tests\API\Authentication;
 
 use Auth0\SDK\API\Authentication;
-use Auth0\SDK\API\Helpers\InformationHeaders;
+use PHPUnit\Framework\TestCase;
 
-class UrlBuildersTest extends \PHPUnit_Framework_TestCase
+class UrlBuildersTest extends TestCase
 {
 
     public function testThatBasicAuthorizeLinkIsBuiltCorrectly()

--- a/tests/API/Header/HeaderTest.php
+++ b/tests/API/Header/HeaderTest.php
@@ -4,11 +4,12 @@ namespace Auth0\Tests;
 
 use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
+use Auth0\SDK\API\Header\ForwardedFor;
 use Auth0\SDK\API\Header\Header;
 use Auth0\SDK\API\Header\Telemetry;
-use Auth0\SDK\API\Header\ForwardedFor;
+use PHPUnit\Framework\TestCase;
 
-class HeaderTest extends \PHPUnit_Framework_TestCase
+class HeaderTest extends TestCase
 {
 
     public function testHeader()

--- a/tests/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/API/Helpers/InformationHeadersExtendTest.php
@@ -1,18 +1,19 @@
 <?php
 namespace Auth0\Tests\Api\Helpers;
 
-use Auth0\Tests\API\Management\MockManagementApi;
-use Auth0\Tests\API\Authentication\MockAuthenticationApi;
-use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Helpers\ApiClient;
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\Tests\API\Authentication\MockAuthenticationApi;
+use Auth0\Tests\API\Management\MockManagementApi;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InformationHeadersExtendTest
  *
  * @package Auth0\Tests\Api\Helpers
  */
-class InformationHeadersExtendTest extends \PHPUnit_Framework_TestCase
+class InformationHeadersExtendTest extends TestCase
 {
 
     public static function tearDownAfterClass()

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -3,13 +3,14 @@ namespace Auth0\Tests\Api\Helpers;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Helpers\ApiClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InformationHeadersTest
  *
  * @package Auth0\Tests\Api\Helpers
  */
-class InformationHeadersTest extends \PHPUnit_Framework_TestCase
+class InformationHeadersTest extends TestCase
 {
 
     /**

--- a/tests/API/Helpers/State/DummyStateHandlerTest.php
+++ b/tests/API/Helpers/State/DummyStateHandlerTest.php
@@ -2,13 +2,14 @@
 namespace Auth0\Tests\Api\Helpers\State;
 
 use Auth0\SDK\API\Helpers\State\DummyStateHandler;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DummyStateHandlerTest
  *
  * @package Auth0\Tests\Api\Helpers\State
  */
-class DummyStateHandlerTest extends \PHPUnit_Framework_TestCase
+class DummyStateHandlerTest extends TestCase
 {
 
     /**

--- a/tests/API/Helpers/State/SessionStateHandlerTest.php
+++ b/tests/API/Helpers/State/SessionStateHandlerTest.php
@@ -3,13 +3,14 @@ namespace Auth0\Tests\Api\Helpers\State;
 
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\Store\SessionStore;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SessionStateHandlerTest
  *
  * @package Auth0\Tests\Api\Helpers\State
  */
-class SessionStateHandlerTest extends \PHPUnit_Framework_TestCase
+class SessionStateHandlerTest extends TestCase
 {
 
     /**

--- a/tests/API/Helpers/TokenGeneratorTest.php
+++ b/tests/API/Helpers/TokenGeneratorTest.php
@@ -1,21 +1,22 @@
 <?php
 namespace Auth0\Tests\Api\Helpers;
 
-use Auth0\SDK\API\Helpers\TokenGenerator;
-use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Auth0JWT;
+use Auth0\SDK\API\Helpers\TokenGenerator;
 use Auth0\SDK\Exception\CoreException;
 use Auth0\SDK\Exception\InvalidTokenException;
-use Auth0\Tests\Traits\ErrorHelpers;
 use Auth0\SDK\Helpers\JWKFetcher;
+use Auth0\SDK\JWTVerifier;
+use Auth0\Tests\Traits\ErrorHelpers;
 use Firebase\JWT\JWT;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TokenTest
  *
  * @package Auth0\Tests\Api\Helpers
  */
-class TokenTest extends \PHPUnit_Framework_TestCase
+class TokenTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/ConnectionsMockedTest.php
+++ b/tests/API/Management/ConnectionsMockedTest.php
@@ -1,17 +1,18 @@
 <?php
 namespace Auth0\Tests\API\Management;
 
-use Auth0\Tests\Traits\ErrorHelpers;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
+use Auth0\Tests\Traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConnectionsTestMocked.
  *
  * @package Auth0\Tests\API\Management
  */
-class ConnectionsTestMocked extends \PHPUnit_Framework_TestCase
+class ConnectionsTestMocked extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/API/Management/EmailTemplatesMockedTest.php
@@ -2,17 +2,18 @@
 
 namespace Auth0\Tests\API\Management;
 
-use Auth0\Tests\Traits\ErrorHelpers;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
+use Auth0\Tests\Traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class EmailTemplatesMockedTest
  *
  * @package Auth0\Tests\API\Management
  */
-class EmailTemplatesMockedTest extends \PHPUnit_Framework_TestCase
+class EmailTemplatesMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/EmailsMockedTest.php
+++ b/tests/API/Management/EmailsMockedTest.php
@@ -2,17 +2,18 @@
 
 namespace Auth0\Tests\API\Management;
 
-use Auth0\Tests\Traits\ErrorHelpers;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
+use Auth0\Tests\Traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class EmailsMockedTest
  *
  * @package Auth0\Tests\API\Management
  */
-class EmailsMockedTest extends \PHPUnit_Framework_TestCase
+class EmailsMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/GrantsMockedTest.php
+++ b/tests/API/Management/GrantsMockedTest.php
@@ -1,20 +1,19 @@
 <?php
 namespace Auth0\Tests\API\Management;
 
-use Auth0\SDK\API\Management;
 use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Management;
 use Auth0\SDK\Exception\CoreException;
-
 use Auth0\Tests\Traits\ErrorHelpers;
-
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GrantsTestMocked.
  *
  * @package Auth0\Tests\API\Management
  */
-class GrantsTestMocked extends \PHPUnit_Framework_TestCase
+class GrantsTestMocked extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/RolesMockedTest.php
+++ b/tests/API/Management/RolesMockedTest.php
@@ -7,13 +7,14 @@ use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 use Auth0\SDK\Exception\InvalidPermissionsArrayException;
 use Auth0\Tests\Traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RolesTestMocked.
  *
  * @package Auth0\Tests\API\Management
  */
-class RolesTestMocked extends \PHPUnit_Framework_TestCase
+class RolesTestMocked extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -1,22 +1,20 @@
 <?php
 namespace Auth0\Tests\API\Management;
 
+use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
-use Auth0\SDK\Exception\CoreException;
 use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 use Auth0\SDK\Exception\InvalidPermissionsArrayException;
 use Auth0\Tests\Traits\ErrorHelpers;
-
-use Auth0\SDK\API\Helpers\InformationHeaders;
-
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class UsersMockedTest.
  *
  * @package Auth0\Tests\API\Management
  */
-class UsersMockedTest extends \PHPUnit_Framework_TestCase
+class UsersMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -4,20 +4,19 @@ namespace Auth0\Tests;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Exception\ApiException;
 use Auth0\SDK\Exception\CoreException;
-
 use Auth0\Tests\Traits\ErrorHelpers;
-
 use Firebase\JWT\JWT;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Auth0Test
  *
  * @package Auth0\Tests
  */
-class Auth0Test extends \PHPUnit_Framework_TestCase
+class Auth0Test extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/Helpers/Cache/CacheTest.php
+++ b/tests/Helpers/Cache/CacheTest.php
@@ -3,8 +3,9 @@ namespace Auth0\Tests\Helpers\Cache;
 
 use Auth0\SDK\Helpers\Cache\NoCacheHandler;
 use Auth0\SDK\Helpers\Cache\FileSystemCacheHandler;
+use PHPUnit\Framework\TestCase;
 
-class CacheTest extends \PHPUnit_Framework_TestCase
+class CacheTest extends TestCase
 {
     public function testNoCache()
     {

--- a/tests/Helpers/JWKFetcherTest.php
+++ b/tests/Helpers/JWKFetcherTest.php
@@ -1,17 +1,18 @@
 <?php
 namespace Auth0\Tests\Helpers;
 
-use \Auth0\SDK\Helpers\Cache\CacheHandler;
+use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\Helpers\Cache\FileSystemCacheHandler;
-use \Auth0\SDK\Helpers\JWKFetcher;
-use \GuzzleHttp\Psr7\Response;
+use Auth0\SDK\Helpers\JWKFetcher;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class JWKFetcherTest.
  *
  * @package Auth0\Tests\Helpers\Cache
  */
-class JWKFetcherTest extends \PHPUnit_Framework_TestCase
+class JWKFetcherTest extends TestCase
 {
 
     public function testThatGetFormattedReturnsKeys()
@@ -217,8 +218,8 @@ class JWKFetcherTest extends \PHPUnit_Framework_TestCase
 
         // Test that the set method was called with the correct parameters.
         $set_invocations = $set_spy->getInvocations();
-        $this->assertEquals( $jwks_url.'|'.$kid, $set_invocations[0]->parameters[0] );
-        $this->assertEquals( $pem_not_cached, $set_invocations[0]->parameters[1] );
+        $this->assertEquals( $jwks_url.'|'.$kid, $set_invocations[0]->getParameters()[0] );
+        $this->assertEquals( $pem_not_cached, $set_invocations[0]->getParameters()[1] );
 
         // Test that the get method was only called twice.
         $this->assertEquals( 2, $get_spy->getInvocationCount() );

--- a/tests/Store/SessionStoreTest.php
+++ b/tests/Store/SessionStoreTest.php
@@ -1,12 +1,14 @@
 <?php
+namespace Auth0\Tests\Store;
 
 use Auth0\SDK\Store\SessionStore;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SessionStoreTest.
  * Tests the SessionStore class.
  */
-class SessionStoreTest extends PHPUnit_Framework_TestCase
+class SessionStoreTest extends TestCase
 {
     /**
      * Session key for test values.
@@ -88,7 +90,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
     public function testSet()
     {
         // Make sure this key does not exist yet so we can test that it was set.
-        $this->assertFalse(isset($_SESSION[self::$sessionKey]));
+        $_SESSION = [];
 
         // Suppressing "headers already sent" warning related to cookies.
         // phpcs:ignore

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@ $tests_dir = dirname(__FILE__).'/';
 
 require_once $tests_dir.'../vendor/autoload.php';
 
-define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 200000 );
+define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 140000 );
 
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );


### PR DESCRIPTION
### Changes

- Updates the minimum version of PHP from 5.5 to 7.1
- Fixes failing tests from updates to the testing suite
- Remove PHP 5.5 from CI testing

### References

A quick note on the PHP version we're using ... while we'd like to bump this to 7.2, it was clear to us that not enough applications using this SDK were 7.2 or higher. We're going to gauge the impact this release has on the lowest PHP version used and, if we're able to prompt applications to update, we'll consider another bump in the next major version of this SDK.

### Testing

- [x] This change has been tested on PHP 7.1

### Checklist

- [x] All existing and new tests complete without errors
- [x] The correct base branch is being used - `7.0.0-dev`
