### PR TITLE
Update management props

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 The Auth0 PHP SDK provides straight-forward and tested methods for accessing Authentication and Management API endpoints. This README describes how to get started and provides simple examples of how to use the SDK.
 
-For more details about how to install this SDK into an existing project or how to download a preconfigured seed project, see:
+**Branches**
+
+- `master` - Work in progress for minor and patch releases
+- `7.0.0-dev` - Work in progress for upcoming major release
+- **All other branches are not maintained and will be removed**
 
 ## Table of Contents
 
@@ -49,7 +53,7 @@ $auth0 = new Auth0([
 	'domain' => 'your-tenant.auth0.com',
 	'client_id' => 'application_client_id',
 	'client_secret' => 'application_client_secret',
-	
+
 	// This is your application URL that will be used to process the login.
 	// Save this URL in the "Allowed Callback URLs" field on the Application settings tab
 	'redirect_uri' => 'https://yourdomain.com/auth/callback',
@@ -70,7 +74,7 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 - Use [Community](https://community.auth0.com/) for usage, questions, specific cases
 - Use [Issues](https://github.com/auth0/auth0-PHP/issues) here for code-level support and bug reports
-- Customers with a paid Auth0 subscription can use the [Support Center](https://support.auth0.com/) to submit a ticket to our support specialists. 
+- Customers with a paid Auth0 subscription can use the [Support Center](https://support.auth0.com/) to submit a ticket to our support specialists.
 
 ## Vulnerability Reporting
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Auth0 PHP SDK provides straight-forward and tested methods for accessing Aut
 **Branches**
 
 - `master` - Work in progress for minor and patch releases
-- `7.0.0-dev` - Work in progress for upcoming major release
+- [`7.0.0-dev`](https://github.com/auth0/auth0-PHP/tree/7.0.0-dev) - Work in progress for upcoming major release
 - **All other branches are not maintained and will be removed**
 
 ## Table of Contents

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -1,6 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Auth0\SDK\API;
 
+use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
+use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\API\Management\Blacklists;
 use Auth0\SDK\API\Management\Clients;
 use Auth0\SDK\API\Management\ClientGrants;
@@ -21,108 +25,150 @@ use Auth0\SDK\API\Management\UserBlocks;
 use Auth0\SDK\API\Management\Users;
 use Auth0\SDK\API\Management\UsersByEmail;
 
-use Auth0\SDK\API\Helpers\ApiClient;
-use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
-
+/**
+ * Class Management
+ *
+ * @package Auth0\SDK\API
+ */
 class Management
 {
 
     /**
+     * Instance of Auth0\SDK\API\Helpers\ApiClient
+     *
      * @var ApiClient
      */
     private $apiClient;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Blacklists
+     *
      * @var Blacklists
      */
     private $blacklists;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Clients
+     *
      * @var Clients
      */
     private $clients;
 
     /**
+     * Instance of Auth0\SDK\API\Management\ClientGrants
+     *
      * @var ClientGrants
      */
-    private $client_grants;
+    private $clientGrants;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Connections
+     *
      * @var Connections
      */
     private $connections;
 
     /**
+     * Instance of Auth0\SDK\API\Management\DeviceCredentials
+     *
      * @var DeviceCredentials
      */
     private $deviceCredentials;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Emails
+     *
      * @var Emails
      */
     private $emails;
 
     /**
+     * Instance of Auth0\SDK\API\Management\EmailTemplates
+     *
      * @var EmailTemplates
      */
     private $emailTemplates;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Jobs
+     *
      * @var Jobs
      */
     private $jobs;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Grants
+     *
      * @var Grants
      */
     private $grants;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Logs
+     *
      * @var Logs
      */
     private $logs;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Roles
+     *
      * @var Roles
      */
     private $roles;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Rules
+     *
      * @var Rules
      */
     private $rules;
 
     /**
+     * Instance of Auth0\SDK\API\Management\ResourceServers
+     *
      * @var ResourceServers
      */
-    private $resource_servers;
+    private $resourceServers;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Stats
+     *
      * @var Stats
      */
     private $stats;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Tenants
+     *
      * @var Tenants
      */
     private $tenants;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Tickets
+     *
      * @var Tickets
      */
     private $tickets;
 
     /**
+     * Instance of Auth0\SDK\API\Management\UserBlocks
+     *
      * @var UserBlocks
      */
     private $userBlocks;
 
     /**
+     * Instance of Auth0\SDK\API\Management\Users
+     *
      * @var Users
      */
     private $users;
 
     /**
+     * Instance of Auth0\SDK\API\Management\UsersByEmail
+     *
      * @var UsersByEmail
      */
     private $usersByEmail;
@@ -130,10 +176,13 @@ class Management
     /**
      * Management constructor.
      *
-     * @param string      $token
-     * @param string      $domain
-     * @param array       $guzzleOptions
-     * @param string|null $returnType
+     * @param string      $token         Access token for the Management API.
+     * @param string      $domain        Management API domain.
+     * @param array       $guzzleOptions Options for the Guzzle HTTP library.
+     * @param null|string $returnType    Return type for the HTTP request. Can be one of:
+     *         - `headers` to return only the response headers.
+     *         - `body` (default) to return only the response body.
+     *         - `object` to return the entire Reponse object.
      */
     public function __construct(string $token, string $domain, array $guzzleOptions = [], ?string $returnType = null)
     {
@@ -183,11 +232,11 @@ class Management
      */
     public function clientGrants() : ClientGrants
     {
-        if (! $this->client_grants instanceof ClientGrants) {
-            $this->client_grants = new ClientGrants($this->apiClient);
+        if (! $this->clientGrants instanceof ClientGrants) {
+            $this->clientGrants = new ClientGrants($this->apiClient);
         }
 
-        return $this->client_grants;
+        return $this->clientGrants;
     }
 
     /**
@@ -323,11 +372,11 @@ class Management
      */
     public function resourceServers() : ResourceServers
     {
-        if (! $this->resource_servers instanceof ResourceServers) {
-            $this->resource_servers = new ResourceServers($this->apiClient);
+        if (! $this->resourceServers instanceof ResourceServers) {
+            $this->resourceServers = new ResourceServers($this->apiClient);
         }
 
-        return $this->resource_servers;
+        return $this->resourceServers;
     }
 
     /**

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -28,167 +28,104 @@ class Management
 {
 
     /**
-     *
-     * @var string
-     */
-    private $token;
-
-    /**
-     *
-     * @var string
-     */
-    private $domain;
-
-    /**
-     *
      * @var ApiClient
      */
     private $apiClient;
 
     /**
-     *
-     * @var array
-     */
-    private $guzzleOptions;
-
-    /**
-     *
-     * @var string
-     */
-    private $returnType;
-
-    /**
-     * @deprecated 5.6.0, will lose public access; use $this->blacklists() instead.
-     *
      * @var Blacklists
      */
-    public $blacklists;
+    private $blacklists;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->clients() instead.
-     *
      * @var Clients
      */
-    public $clients;
+    private $clients;
 
     /**
-     * @deprecated 5.6.0, will be renamed and lose public access; use $this->clientGrants() instead.
-     *
      * @var ClientGrants
      */
-    public $client_grants;
+    private $client_grants;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->connections() instead.
-     *
      * @var Connections
      */
-    public $connections;
+    private $connections;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->deviceCredentials() instead.
-     *
      * @var DeviceCredentials
      */
-    public $deviceCredentials;
+    private $deviceCredentials;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->emails() instead.
-     *
      * @var Emails
      */
-    public $emails;
+    private $emails;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->emailTemplates() instead.
-     *
      * @var EmailTemplates
      */
-    public $emailTemplates;
+    private $emailTemplates;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->jobs() instead.
-     *
      * @var Jobs
      */
-    public $jobs;
+    private $jobs;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->grants() instead.
-     *
      * @var Grants
      */
-    public $grants;
+    private $grants;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->logs() instead.
-     *
      * @var Logs
      */
-    public $logs;
+    private $logs;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->roles() instead.
-     *
      * @var Roles
      */
-    public $roles;
+    private $roles;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->rules() instead.
-     *
      * @var Rules
      */
-    public $rules;
+    private $rules;
 
     /**
-     * @deprecated 5.6.0, will be renamed and lose public access; use $this->resourceServers() instead.
-     *
      * @var ResourceServers
      */
-    public $resource_servers;
+    private $resource_servers;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->stats() instead.
-     *
      * @var Stats
      */
-    public $stats;
+    private $stats;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->tenants() instead.
-     *
      * @var Tenants
      */
-    public $tenants;
+    private $tenants;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->tickets() instead.
-     *
      * @var Tickets
      */
-    public $tickets;
+    private $tickets;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->userBlocks() instead.
-     *
      * @var UserBlocks
      */
-    public $userBlocks;
+    private $userBlocks;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->users() instead.
-     *
      * @var Users
      */
-    public $users;
+    private $users;
 
     /**
-     * @deprecated 5.6.0, will lose public access; use $this->usersByEmail() instead.
-     *
      * @var UsersByEmail
      */
-    public $usersByEmail;
+    private $usersByEmail;
 
     /**
      * Management constructor.
@@ -198,34 +135,17 @@ class Management
      * @param array       $guzzleOptions
      * @param string|null $returnType
      */
-    public function __construct($token, $domain, $guzzleOptions = [], $returnType = null)
+    public function __construct(string $token, string $domain, array $guzzleOptions = [], ?string $returnType = null)
     {
-        $this->token         = $token;
-        $this->domain        = $domain;
-        $this->guzzleOptions = $guzzleOptions;
-        $this->returnType    = $returnType;
-
-        $this->setApiClient();
-
-        $this->blacklists        = new Blacklists($this->apiClient);
-        $this->clients           = new Clients($this->apiClient);
-        $this->client_grants     = new ClientGrants($this->apiClient);
-        $this->connections       = new Connections($this->apiClient);
-        $this->deviceCredentials = new DeviceCredentials($this->apiClient);
-        $this->emails            = new Emails($this->apiClient);
-        $this->emailTemplates    = new EmailTemplates($this->apiClient);
-        $this->grants            = new Grants($this->apiClient);
-        $this->jobs              = new Jobs($this->apiClient);
-        $this->logs              = new Logs($this->apiClient);
-        $this->roles             = new Roles($this->apiClient);
-        $this->rules             = new Rules($this->apiClient);
-        $this->resource_servers  = new ResourceServers($this->apiClient);
-        $this->stats             = new Stats($this->apiClient);
-        $this->tenants           = new Tenants($this->apiClient);
-        $this->tickets           = new Tickets($this->apiClient);
-        $this->userBlocks        = new UserBlocks($this->apiClient);
-        $this->users             = new Users($this->apiClient);
-        $this->usersByEmail      = new UsersByEmail($this->apiClient);
+        $this->apiClient = new ApiClient([
+            'domain' => 'https://'.$domain,
+            'basePath' => '/api/v2/',
+            'guzzleOptions' => $guzzleOptions,
+            'returnType' => $returnType,
+            'headers' => [
+                new AuthorizationBearer($token)
+            ]
+        ]);
     }
 
     /**
@@ -233,7 +153,7 @@ class Management
      *
      * @return Blacklists
      */
-    public function blacklists()
+    public function blacklists() : Blacklists
     {
         if (! $this->blacklists instanceof Blacklists) {
             $this->blacklists = new Blacklists($this->apiClient);
@@ -247,7 +167,7 @@ class Management
      *
      * @return Clients
      */
-    public function clients()
+    public function clients() : Clients
     {
         if (! $this->clients instanceof Clients) {
             $this->clients = new Clients($this->apiClient);
@@ -261,7 +181,7 @@ class Management
      *
      * @return ClientGrants
      */
-    public function clientGrants()
+    public function clientGrants() : ClientGrants
     {
         if (! $this->client_grants instanceof ClientGrants) {
             $this->client_grants = new ClientGrants($this->apiClient);
@@ -275,7 +195,7 @@ class Management
      *
      * @return Connections
      */
-    public function connections()
+    public function connections() : Connections
     {
         if (! $this->connections instanceof Connections) {
             $this->connections = new Connections($this->apiClient);
@@ -289,7 +209,7 @@ class Management
      *
      * @return DeviceCredentials
      */
-    public function deviceCredentials()
+    public function deviceCredentials() : DeviceCredentials
     {
         if (! $this->deviceCredentials instanceof DeviceCredentials) {
             $this->deviceCredentials = new DeviceCredentials($this->apiClient);
@@ -303,7 +223,7 @@ class Management
      *
      * @return Emails
      */
-    public function emails()
+    public function emails() : Emails
     {
         if (! $this->emails instanceof Emails) {
             $this->emails = new Emails($this->apiClient);
@@ -317,7 +237,7 @@ class Management
      *
      * @return EmailTemplates
      */
-    public function emailTemplates()
+    public function emailTemplates() : EmailTemplates
     {
         if (! $this->emailTemplates instanceof EmailTemplates) {
             $this->emailTemplates = new EmailTemplates($this->apiClient);
@@ -331,7 +251,7 @@ class Management
      *
      * @return Grants
      */
-    public function grants()
+    public function grants() : Grants
     {
         if (! $this->grants instanceof Grants) {
             $this->grants = new Grants($this->apiClient);
@@ -345,7 +265,7 @@ class Management
      *
      * @return Jobs
      */
-    public function jobs()
+    public function jobs() : Jobs
     {
         if (! $this->jobs instanceof Jobs) {
             $this->jobs = new Jobs($this->apiClient);
@@ -359,7 +279,7 @@ class Management
      *
      * @return Logs
      */
-    public function logs()
+    public function logs() : Logs
     {
         if (! $this->logs instanceof Logs) {
             $this->logs = new Logs($this->apiClient);
@@ -373,7 +293,7 @@ class Management
      *
      * @return Roles
      */
-    public function roles()
+    public function roles() : Roles
     {
         if (! $this->roles instanceof Roles) {
             $this->roles = new Roles($this->apiClient);
@@ -387,7 +307,7 @@ class Management
      *
      * @return Rules
      */
-    public function rules()
+    public function rules() : Rules
     {
         if (! $this->rules instanceof Rules) {
             $this->rules = new Rules($this->apiClient);
@@ -401,7 +321,7 @@ class Management
      *
      * @return ResourceServers
      */
-    public function resourceServers()
+    public function resourceServers() : ResourceServers
     {
         if (! $this->resource_servers instanceof ResourceServers) {
             $this->resource_servers = new ResourceServers($this->apiClient);
@@ -415,7 +335,7 @@ class Management
      *
      * @return Stats
      */
-    public function stats()
+    public function stats() : Stats
     {
         if (! $this->stats instanceof Stats) {
             $this->stats = new Stats($this->apiClient);
@@ -429,7 +349,7 @@ class Management
      *
      * @return Tenants
      */
-    public function tenants()
+    public function tenants() : Tenants
     {
         if (! $this->tenants instanceof Tenants) {
             $this->tenants = new Tenants($this->apiClient);
@@ -443,7 +363,7 @@ class Management
      *
      * @return Tickets
      */
-    public function tickets()
+    public function tickets() : Tickets
     {
         if (! $this->tickets instanceof Tickets) {
             $this->tickets = new Tickets($this->apiClient);
@@ -457,7 +377,7 @@ class Management
      *
      * @return UserBlocks
      */
-    public function userBlocks()
+    public function userBlocks() : UserBlocks
     {
         if (! $this->userBlocks instanceof UserBlocks) {
             $this->userBlocks = new UserBlocks($this->apiClient);
@@ -471,7 +391,7 @@ class Management
      *
      * @return Users
      */
-    public function users()
+    public function users() : Users
     {
         if (! $this->users instanceof Users) {
             $this->users = new Users($this->apiClient);
@@ -485,29 +405,12 @@ class Management
      *
      * @return UsersByEmail
      */
-    public function usersByEmail()
+    public function usersByEmail() : UsersByEmail
     {
         if (! $this->usersByEmail instanceof UsersByEmail) {
             $this->usersByEmail = new UsersByEmail($this->apiClient);
         }
 
         return $this->usersByEmail;
-    }
-
-    protected function setApiClient()
-    {
-        $apiDomain = "https://{$this->domain}";
-
-        $client = new ApiClient([
-            'domain' => $apiDomain,
-            'basePath' => '/api/v2/',
-            'guzzleOptions' => $this->guzzleOptions,
-            'returnType' => $this->returnType,
-            'headers' => [
-                new AuthorizationBearer($this->token)
-            ]
-        ]);
-
-        $this->apiClient = $client;
     }
 }

--- a/tests/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/API/Helpers/InformationHeadersExtendTest.php
@@ -65,7 +65,7 @@ class InformationHeadersExtendTest extends TestCase
         $new_headers = self::setExtendedHeaders('test-extend-sdk-2', '2.3.4');
 
         $api = new MockManagementApi( [ new Response( 200 ) ] );
-        $api->call()->connections->getAll();
+        $api->call()->connections()->getAll();
         $headers = $api->getHistoryHeaders();
 
         $this->assertEquals( $new_headers->build(), $headers['Auth0-Client'][0] );

--- a/tests/API/Management/BlacklistsTest.php
+++ b/tests/API/Management/BlacklistsTest.php
@@ -77,15 +77,6 @@ class BlacklistsTest extends ApiTests
         $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists );
-        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists() );
-        $api->blacklists = null;
-        $this->assertInstanceOf( Management\Blacklists::class, $api->blacklists() );
-    }
-
     /**
      * @throws \Auth0\SDK\Exception\ApiException
      */

--- a/tests/API/Management/ClientGrantsTest.php
+++ b/tests/API/Management/ClientGrantsTest.php
@@ -63,16 +63,6 @@ class ClientGrantsTest extends ApiTests
         parent::setUp();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\ClientGrants::class, $api->client_grants );
-        $this->assertInstanceOf( Management\ClientGrants::class, $api->clientGrants() );
-        $api->client_grants = null;
-        $this->assertInstanceOf( Management\ClientGrants::class, $api->clientGrants() );
-    }
-
-
     /**
      * @throws CoreException
      * @throws \Exception

--- a/tests/API/Management/ClientsTest.php
+++ b/tests/API/Management/ClientsTest.php
@@ -39,15 +39,6 @@ class ClientsTest extends ApiTests
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Clients::class, $api->clients );
-        $this->assertInstanceOf( Management\Clients::class, $api->clients() );
-        $api->clients = null;
-        $this->assertInstanceOf( Management\Clients::class, $api->clients() );
-    }
-
     /**
      * @throws \Exception
      */

--- a/tests/API/Management/ConnectionsMockedTest.php
+++ b/tests/API/Management/ConnectionsMockedTest.php
@@ -41,15 +41,6 @@ class ConnectionsTestMocked extends TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Connections::class, $api->connections );
-        $this->assertInstanceOf( Management\Connections::class, $api->connections() );
-        $api->connections = null;
-        $this->assertInstanceOf( Management\Connections::class, $api->connections() );
-    }
-
     /**
      * Test a basic getAll connection call.
      *

--- a/tests/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/API/Management/EmailTemplatesMockedTest.php
@@ -42,15 +42,6 @@ class EmailTemplatesMockedTest extends TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates );
-        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates() );
-        $api->emailTemplates = null;
-        $this->assertInstanceOf( Management\EmailTemplates::class, $api->emailTemplates() );
-    }
-
     /**
      * @throws \Exception Should not be thrown in this test.
      */

--- a/tests/API/Management/EmailsMockedTest.php
+++ b/tests/API/Management/EmailsMockedTest.php
@@ -42,15 +42,6 @@ class EmailsMockedTest extends TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Emails::class, $api->emails );
-        $this->assertInstanceOf( Management\Emails::class, $api->emails() );
-        $api->emails = null;
-        $this->assertInstanceOf( Management\Emails::class, $api->emails() );
-    }
-
     /**
      * @throws \Exception Should not be thrown in this test.
      */

--- a/tests/API/Management/GrantsMockedTest.php
+++ b/tests/API/Management/GrantsMockedTest.php
@@ -35,15 +35,6 @@ class GrantsTestMocked extends TestCase
         self::$telemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Grants::class, $api->grants );
-        $this->assertInstanceOf( Management\Grants::class, $api->grants() );
-        $api->grants = null;
-        $this->assertInstanceOf( Management\Grants::class, $api->grants() );
-    }
-
     /**
      * Test that getAll requests properly.
      *

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -43,15 +43,6 @@ class JobsTest extends ApiTests
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Jobs::class, $api->jobs );
-        $this->assertInstanceOf( Management\Jobs::class, $api->jobs() );
-        $api->jobs = null;
-        $this->assertInstanceOf( Management\Jobs::class, $api->jobs() );
-    }
-
     /**
      * @throws \Exception Should not be thrown in this test.
      */
@@ -176,7 +167,7 @@ class JobsTest extends ApiTests
 
         // Get a single, active database connection.
         $default_db_name       = 'Username-Password-Authentication';
-        $get_connection_result = $api->connections->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
+        $get_connection_result = $api->connections()->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $conn_id            = $get_connection_result[0]['id'];
@@ -222,7 +213,7 @@ class JobsTest extends ApiTests
             'email' => 'php-sdk-test-email-verification-job-'.uniqid().'@auth0.com',
             'password' => uniqid().uniqid().uniqid(),
         ];
-        $create_user_result = $api->users->create( $create_user_data );
+        $create_user_result = $api->users()->create( $create_user_data );
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 
         $user_id = $create_user_result['user_id'];
@@ -237,7 +228,7 @@ class JobsTest extends ApiTests
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );
 
-        $api->users->delete( $user_id );
+        $api->users()->delete( $user_id );
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 }

--- a/tests/API/Management/LogsTest.php
+++ b/tests/API/Management/LogsTest.php
@@ -35,16 +35,6 @@ class LogsTest extends ApiTests
         self::$api = $api->logs();
     }
 
-
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Logs::class, $api->logs );
-        $this->assertInstanceOf( Management\Logs::class, $api->logs() );
-        $api->logs = null;
-        $this->assertInstanceOf( Management\Logs::class, $api->logs() );
-    }
-
     /**
      * Test a general search.
      *

--- a/tests/API/Management/ResourceServersTest.php
+++ b/tests/API/Management/ResourceServersTest.php
@@ -61,15 +61,6 @@ class ResourceServersTest extends ApiTests
         self::$serverIdentifier = 'TEST_PHP_SDK_ID_'.uniqid();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\ResourceServers::class, $api->resource_servers );
-        $this->assertInstanceOf( Management\ResourceServers::class, $api->resourceServers() );
-        $api->resource_servers = null;
-        $this->assertInstanceOf( Management\ResourceServers::class, $api->resourceServers() );
-    }
-
     /**
      * Test creating a Resource Server.
      *

--- a/tests/API/Management/RolesMockedTest.php
+++ b/tests/API/Management/RolesMockedTest.php
@@ -43,15 +43,6 @@ class RolesTestMocked extends TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Roles::class, $api->roles );
-        $this->assertInstanceOf( Management\Roles::class, $api->roles() );
-        $api->roles = null;
-        $this->assertInstanceOf( Management\Roles::class, $api->roles() );
-    }
-
     /**
      * Test a basic getAll roles call.
      *

--- a/tests/API/Management/RulesTest.php
+++ b/tests/API/Management/RulesTest.php
@@ -33,15 +33,6 @@ class RulesTest extends ApiTests
         self::getEnv();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Rules::class, $api->rules );
-        $this->assertInstanceOf( Management\Rules::class, $api->rules() );
-        $api->rules = null;
-        $this->assertInstanceOf( Management\Rules::class, $api->rules() );
-    }
-
     /**
      * Test that get methods work as expected.
      *

--- a/tests/API/Management/UsersMockedTest.php
+++ b/tests/API/Management/UsersMockedTest.php
@@ -43,15 +43,6 @@ class UsersMockedTest extends TestCase
         self::$expectedTelemetry = $infoHeadersData->build();
     }
 
-    public function testThatMethodAndPropertyReturnSameClass()
-    {
-        $api = new Management(uniqid(), uniqid());
-        $this->assertInstanceOf( Management\Users::class, $api->users );
-        $this->assertInstanceOf( Management\Users::class, $api->users() );
-        $api->users = null;
-        $this->assertInstanceOf( Management\Users::class, $api->users() );
-    }
-
     /**
      * Test a get user call.
      *


### PR DESCRIPTION
### Changes

**This is a breaking change for Management API functionality.**

`Management` class properties have been changed from `public` to `private` access. Instead of using the class property to access the endpoint functionality, you'll now use a method with the same (or very similar) name as the property.

You can see these changes in some of the tests below but, for clarity, if you were getting users like so:

```php
$m_api = new Management( $api_token, $domain );
$results = $m_api->users->getAll();
```

... it would now be:

```php
$m_api = new Management( $api_token, $domain );
$results = $m_api->users()->getAll();
```

Other changes:

- `Management` constructor declares parameter types
- Endpoint methods declare return types
- Removed unused `protected setApiClient()` method

### References

#363 - Deprecation PR for properties

### Testing

- [x] This change modifies test coverage (removes the property type check)
- [x] This change has been tested on PHP 7.1

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
