### PR TITLE
Remove deprecated methods and add types to RequestBuilder

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -36,7 +36,9 @@
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.CodeAnalysis"/>
     <rule ref="Generic.Commenting"/>
-    <rule ref="Generic.ControlStructures"/>
+    <rule ref="Generic.ControlStructures">
+        <exclude name="Generic.ControlStructures.DisallowYodaConditions"/>
+    </rule>
     <rule ref="Generic.Files">
         <exclude name="Generic.Files.EndFileNoNewline"/>
         <exclude name="Generic.Files.LowercasedFilename"/>

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -284,8 +284,7 @@ class Authentication
         }
 
         return $this->apiClient->method('post')
-        ->addPath('passwordless')
-        ->addPath('start')
+        ->addPath('passwordless', 'start')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -308,8 +307,7 @@ class Authentication
         ];
 
         return $this->apiClient->method('post')
-        ->addPath('passwordless')
-        ->addPath('start')
+        ->addPath('passwordless', 'start')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -360,7 +358,7 @@ class Authentication
         }
 
         $request = $this->apiClient->method('post')
-            ->addPath( 'oauth/token' )
+            ->addPath( 'oauth', 'token' )
             ->withBody(json_encode($options));
 
         if (isset($options['auth0_forwarded_for'])) {
@@ -571,8 +569,7 @@ class Authentication
         ];
 
         return $this->apiClient->method('post')
-        ->addPath('dbconnections')
-        ->addPath('signup')
+        ->addPath('dbconnections', 'signup')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -609,8 +606,7 @@ class Authentication
         }
 
         return $this->apiClient->method('post')
-        ->addPath('dbconnections')
-        ->addPath('change_password')
+        ->addPath('dbconnections', 'change_password')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -720,8 +716,7 @@ class Authentication
         ];
 
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('impersonate')
+            ->addPath('users', $user_id, 'impersonate')
             ->withHeader(new AuthorizationBearer($access_token))
             ->withBody(json_encode($data))
             ->call();
@@ -765,8 +760,7 @@ class Authentication
         );
 
         return $this->apiClient->method('post')
-            ->addPath('oauth')
-            ->addPath('access_token')
+            ->addPath('oauth', 'access_token')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -829,8 +823,7 @@ class Authentication
         }
 
         return $this->apiClient->method('post')
-            ->addPath('oauth')
-            ->addPath('ro')
+            ->addPath('oauth', 'ro')
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/Blacklists.php
+++ b/src/API/Management/Blacklists.php
@@ -12,8 +12,7 @@ class Blacklists extends GenericResource
     public function getAll($aud)
     {
         return $this->apiClient->method('get')
-            ->addPath('blacklists')
-            ->addPath('tokens')
+            ->addPath('blacklists', 'tokens')
             ->withParam('aud', $aud)
             ->call();
     }
@@ -27,8 +26,7 @@ class Blacklists extends GenericResource
     public function blacklist($aud, $jti)
     {
         return $this->apiClient->method('post')
-            ->addPath('blacklists')
-            ->addPath('tokens')
+            ->addPath('blacklists', 'tokens')
             ->withBody(json_encode([
                 'aud' => $aud,
                 'jti' => $jti

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -137,8 +137,7 @@ class Connections extends GenericResource
     public function deleteUser($id, $email)
     {
         return $this->apiClient->method('delete')
-            ->addPath('connections', $id)
-            ->addPath('users')
+            ->addPath('connections', $id, 'users')
             ->withParam('email', $email)
             ->call();
     }

--- a/src/API/Management/Emails.php
+++ b/src/API/Management/Emails.php
@@ -13,8 +13,7 @@ class Emails extends GenericResource
     public function getEmailProvider($fields = null, $include_fields = null)
     {
         $request = $this->apiClient->method('get')
-        ->addPath('emails')
-        ->addPath('provider');
+        ->addPath('emails', 'provider');
 
         if ($fields !== null) {
             if (is_array($fields)) {
@@ -39,8 +38,7 @@ class Emails extends GenericResource
     public function configureEmailProvider($data)
     {
         return $this->apiClient->method('post')
-        ->addPath('emails')
-        ->addPath('provider')
+        ->addPath('emails', 'provider')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -53,8 +51,7 @@ class Emails extends GenericResource
     public function updateEmailProvider($data)
     {
         return $this->apiClient->method('patch')
-        ->addPath('emails')
-        ->addPath('provider')
+        ->addPath('emails', 'provider')
         ->withBody(json_encode($data))
         ->call();
     }
@@ -66,8 +63,7 @@ class Emails extends GenericResource
     public function deleteEmailProvider()
     {
         return $this->apiClient->method('delete')
-        ->addPath('emails')
-        ->addPath('provider')
+        ->addPath('emails', 'provider')
         ->call();
     }
 }

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -24,8 +24,7 @@ class Jobs extends GenericResource
     public function getErrors($id)
     {
         return $this->apiClient->method('get')
-        ->addPath('jobs', $id)
-        ->addPath('errors')
+        ->addPath('jobs', $id, 'errors')
         ->call();
     }
 
@@ -39,8 +38,7 @@ class Jobs extends GenericResource
     public function importUsers($file_path, $connection_id, $params = [])
     {
         $request = $this->apiClient->method('post', false)
-        ->addPath('jobs')
-        ->addPath('users-imports')
+        ->addPath('jobs', 'users-imports')
         ->addFile('users', $file_path)
         ->addFormParam('connection_id', $connection_id);
 
@@ -67,8 +65,7 @@ class Jobs extends GenericResource
     public function sendVerificationEmail($user_id)
     {
         return $this->apiClient->method('post')
-        ->addPath('jobs')
-        ->addPath('verification-email')
+        ->addPath('jobs', 'verification-email')
         ->withBody(json_encode([
             'user_id' => $user_id
         ]))

--- a/src/API/Management/Roles.php
+++ b/src/API/Management/Roles.php
@@ -150,8 +150,7 @@ class Roles extends GenericResource
         $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
-            ->addPath('roles', $role_id)
-            ->addPath('permissions')
+            ->addPath('roles', $role_id, 'permissions')
             ->withDictParams($params)
             ->call();
     }
@@ -179,8 +178,7 @@ class Roles extends GenericResource
         $data = [ 'permissions' => $permissions ];
 
         return $this->apiClient->method('post')
-            ->addPath('roles', $role_id)
-            ->addPath('permissions')
+            ->addPath('roles', $role_id, 'permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -208,8 +206,7 @@ class Roles extends GenericResource
         $data = [ 'permissions' => $permissions ];
 
         return $this->apiClient->method('delete')
-            ->addPath('roles', $role_id)
-            ->addPath('permissions')
+            ->addPath('roles', $role_id, 'permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -238,8 +235,7 @@ class Roles extends GenericResource
         $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
-            ->addPath('roles', $role_id)
-            ->addPath('users')
+            ->addPath('roles', $role_id, 'users')
             ->withDictParams($params)
             ->call();
     }
@@ -270,8 +266,7 @@ class Roles extends GenericResource
         $data = [ 'users' => array_unique( $users ) ];
 
         return $this->apiClient->method('post')
-            ->addPath('roles', $role_id)
-            ->addPath('users')
+            ->addPath('roles', $role_id, 'users')
             ->withBody(json_encode($data))
             ->call();
     }

--- a/src/API/Management/Stats.php
+++ b/src/API/Management/Stats.php
@@ -11,8 +11,7 @@ class Stats extends GenericResource
     public function getActiveUsersCount()
     {
         return $this->apiClient->method('get')
-        ->addPath('stats')
-        ->addPath('active-users')
+        ->addPath('stats', 'active-users')
         ->call();
     }
 
@@ -25,8 +24,7 @@ class Stats extends GenericResource
     public function getDailyStats($from, $to)
     {
         return $this->apiClient->method('get')
-        ->addPath('stats')
-        ->addPath('daily')
+        ->addPath('stats', 'daily')
         ->withParam('from', $from)
         ->withParam('to', $to)
         ->call();

--- a/src/API/Management/Tenants.php
+++ b/src/API/Management/Tenants.php
@@ -13,8 +13,7 @@ class Tenants extends GenericResource
     public function get($fields = null, $include_fields = null)
     {
         $request = $this->apiClient->method('get')
-        ->addPath('tenants')
-        ->addPath('settings');
+        ->addPath('tenants', 'settings');
 
         if ($fields !== null) {
             if (is_array($fields)) {
@@ -39,8 +38,7 @@ class Tenants extends GenericResource
     public function update($data)
     {
         return $this->apiClient->method('patch')
-        ->addPath('tenants')
-        ->addPath('settings')
+        ->addPath('tenants', 'settings')
         ->withBody(json_encode($data))
         ->call();
     }

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -18,8 +18,7 @@ class Tickets extends GenericResource
         }
 
         $request = $this->apiClient->method('post')
-            ->addPath('tickets')
-            ->addPath('email-verification')
+            ->addPath('tickets', 'email-verification')
             ->withBody(json_encode($body));
 
         return $request->call();
@@ -101,8 +100,7 @@ class Tickets extends GenericResource
         }
 
         return $this->apiClient->method('post')
-            ->addPath('tickets')
-            ->addPath('password-change')
+            ->addPath('tickets', 'password-change')
             ->withBody(json_encode($body))
             ->call();
     }

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -187,8 +187,7 @@ class Users extends GenericResource
     public function linkAccount($user_id, array $data)
     {
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('identities')
+            ->addPath('users', $user_id, 'identities')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -210,9 +209,7 @@ class Users extends GenericResource
     public function unlinkAccount($user_id, $provider, $identity_id)
     {
         return $this->apiClient->method('delete')
-            ->addPath('users', $user_id)
-            ->addPath('identities', $provider)
-            ->addPath($identity_id)
+            ->addPath('users', $user_id, 'identities', $provider, $identity_id)
             ->call();
     }
 
@@ -233,8 +230,7 @@ class Users extends GenericResource
     public function deleteMultifactorProvider($user_id, $mfa_provider)
     {
         return $this->apiClient->method('delete')
-            ->addPath('users', $user_id)
-            ->addPath('multifactor', $mfa_provider)
+            ->addPath('users', $user_id, 'multifactor', $mfa_provider)
             ->call();
     }
 
@@ -262,8 +258,7 @@ class Users extends GenericResource
         $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
-            ->addPath('users', $user_id)
-            ->addPath('roles')
+            ->addPath('users', $user_id, 'roles')
             ->withDictParams($params)
             ->call();
     }
@@ -294,8 +289,7 @@ class Users extends GenericResource
         $data = [ 'roles' => $roles ];
 
         return $this->apiClient->method('delete')
-            ->addPath('users', $user_id)
-            ->addPath('roles')
+            ->addPath('users', $user_id, 'roles')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -328,8 +322,7 @@ class Users extends GenericResource
         $data = [ 'roles' => $roles ];
 
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('roles')
+            ->addPath('users', $user_id, 'roles')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -352,8 +345,7 @@ class Users extends GenericResource
         $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('get')
-            ->addPath('users', $user_id)
-            ->addPath('enrollments')
+            ->addPath('users', $user_id, 'enrollments')
             ->call();
     }
 
@@ -379,8 +371,7 @@ class Users extends GenericResource
         $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
-            ->addPath('users', $user_id)
-            ->addPath('permissions')
+            ->addPath('users', $user_id, 'permissions')
             ->withDictParams($params)
             ->call();
     }
@@ -408,8 +399,7 @@ class Users extends GenericResource
         $data = [ 'permissions' => $permissions ];
 
         return $this->apiClient->method('delete')
-            ->addPath('users', $user_id)
-            ->addPath('permissions')
+            ->addPath('users', $user_id, 'permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -437,8 +427,7 @@ class Users extends GenericResource
         $data = [ 'permissions' => $permissions ];
 
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('permissions')
+            ->addPath('users', $user_id, 'permissions')
             ->withBody(json_encode($data))
             ->call();
     }
@@ -465,8 +454,7 @@ class Users extends GenericResource
         $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
-            ->addPath('users', $user_id)
-            ->addPath('logs')
+            ->addPath('users', $user_id, 'logs')
             ->withDictParams($params)
             ->call();
     }
@@ -489,8 +477,7 @@ class Users extends GenericResource
         $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('recovery-code-regeneration')
+            ->addPath('users', $user_id, 'recovery-code-regeneration')
             ->call();
     }
 
@@ -512,8 +499,7 @@ class Users extends GenericResource
         $this->checkEmptyOrInvalidString($user_id, 'user_id');
 
         return $this->apiClient->method('post')
-            ->addPath('users', $user_id)
-            ->addPath('multifactor/actions/invalidate-remember-browser')
+            ->addPath('users', $user_id, 'multifactor', 'actions', 'invalidate-remember-browser')
             ->call();
     }
 

--- a/tests/API/Helpers/RequestBuilderTest.php
+++ b/tests/API/Helpers/RequestBuilderTest.php
@@ -137,34 +137,9 @@ class RequestBuilderTest extends ApiTests
     {
         $builder = self::getUrlBuilder('/api');
 
-        // Adding a parameter array should be reflected in the RequestBuilder object.
-        $builder->withParams(
-            [
-                ['key' => 'param1','value' => 'value4'],
-                ['key' => 'param3','value' => 'value3'],
-            ]
-        );
-        $this->assertEquals('?param1=value4&param3=value3', $builder->getParams());
-
         // Adding a parameter dictionary should be reflected in the RequestBuilder object.
         $builder->withDictParams([ 'param4' => 'value4', 'param2' => 'value5']);
-        $this->assertEquals('?param1=value4&param3=value3&param4=value4&param2=value5', $builder->getParams());
-    }
-
-    public function testFullUrl()
-    {
-        $builder = self::getUrlBuilder('/api');
-
-        $builder->addPath('path', 2)
-            ->addPath('subpath')
-            ->withParams(
-                [
-                    ['key' => 'param1', 'value' => 'value1'],
-                    ['key' => 'param2', 'value' => 'value2'],
-                ]
-            );
-
-        $this->assertEquals('path/2/subpath?param1=value1&param2=value2', $builder->getUrl());
+        $this->assertEquals('?param4=value4&param2=value5', $builder->getParams());
     }
 
     public function testGetGuzzleOptions()
@@ -209,16 +184,5 @@ class RequestBuilderTest extends ApiTests
         $api            = new MockManagementApi( $response, [ 'return_type' => 'object' ] );
         $results_object = $api->call()->tenants()->get();
         $this->assertInstanceOf( 'GuzzleHttp\Psr7\Response', $results_object );
-
-        // Test that an invalid return type throws an error.
-        $api = new MockManagementApi( $response, [ 'return_type' => '__invalid_return_type__' ] );
-        try {
-            $api->call()->tenants()->get();
-            $error_msg = 'No exception caught';
-        } catch (CoreException $e) {
-            $error_msg = $e->getMessage();
-        }
-
-        $this->assertStringStartsWith( 'Invalid returnType', $error_msg );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@ $tests_dir = dirname(__FILE__).'/';
 
 require_once $tests_dir.'../vendor/autoload.php';
 
-define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 140000 );
+define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 150000 );
 
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );


### PR DESCRIPTION
### Changes

**Breaking changes:**

- Remove magic `__call()` method from `RequestBuilder` class
- Remove deprecated `addPathVariable()` method from `RequestBuilder` class (use `addPath()` instead)
- Remove deprecated `dump()` method from `RequestBuilder` class (no replacement provided)
- Remove unused `withParams()` method from `RequestBuilder` class (use `withDictParams()` instead)
- `RequestBuilder::withHeader()` now only accepts a `Header` instance as an argument.

**Other changes:**

- `RequestBuilder::addPath()` now accepts an unlimited number of parameters to build a URL path.
- Argument and return type hints 
- Docblocks

### Testing

- [x] This change modifies test coverage
- [x] This change has been tested on PHP 7.1

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
