### PR TITLE
Remove deprecated InformationHeaders methods and add types

### DIFF
--- a/src/API/Helpers/InformationHeaders.php
+++ b/src/API/Helpers/InformationHeaders.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Auth0\SDK\API\Helpers;
 
@@ -26,7 +27,7 @@ class InformationHeaders
      *
      * @return void
      */
-    public function setPackage($name, $version)
+    public function setPackage(string $name, $version) : void
     {
         $this->data['name']    = $name;
         $this->data['version'] = $version;
@@ -37,7 +38,7 @@ class InformationHeaders
      *
      * @return void
      */
-    public function setCorePackage()
+    public function setCorePackage() : void
     {
         $this->setPackage('auth0-php', ApiClient::API_VERSION);
         $this->setEnvProperty('php', phpversion());
@@ -51,7 +52,7 @@ class InformationHeaders
      *
      * @return void
      */
-    public function setEnvProperty($name, $version)
+    public function setEnvProperty(string $name, $version) : void
     {
         if (! isset($this->data['env']) || ! is_array($this->data['env'])) {
             $this->data['env'] = [];
@@ -67,7 +68,7 @@ class InformationHeaders
      *
      * @return void
      */
-    public function setEnvironmentData(array $data)
+    public function setEnvironmentData(array $data) : void
     {
         $this->data['env'] = $data;
     }
@@ -77,7 +78,7 @@ class InformationHeaders
      *
      * @return array
      */
-    public function get()
+    public function get() : array
     {
         return $this->data;
     }
@@ -87,7 +88,7 @@ class InformationHeaders
      *
      * @return string
      */
-    public function build()
+    public function build() : string
     {
         return base64_encode(json_encode($this->get()));
     }
@@ -100,7 +101,7 @@ class InformationHeaders
      *
      * @return InformationHeaders
      */
-    public static function Extend(InformationHeaders $headers)
+    public static function Extend(InformationHeaders $headers) : InformationHeaders
     {
         $new_headers = new InformationHeaders;
         $old_headers = $headers->get();
@@ -113,56 +114,4 @@ class InformationHeaders
 
         return $new_headers;
     }
-
-    /*
-     * Deprecated
-     */
-
-    // phpcs:disable
-
-    /**
-     * @deprecated 5.4.0, use $this->setEnvProperty() instead.
-     *
-     * @param string $name    Dependency or platform name.
-     * @param string $version Dependency or platform version.
-     *
-     * @return void
-     *
-     * @codeCoverageIgnore - Deprecated
-     */
-    public function setEnvironment($name, $version)
-    {
-        $this->setEnvProperty($name, $version);
-    }
-
-    /**
-     * @deprecated 5.4.0, use $this->setEnvProperty() instead.
-     *
-     * @param string $name    Dependency name.
-     * @param string $version Dependency version.
-     *
-     * @return void
-     *
-     * @codeCoverageIgnore - Deprecated
-     */
-    public function setDependency($name, $version)
-    {
-        $this->setEnvProperty($name, $version);
-    }
-
-    /**
-     * @deprecated 5.4.0, use $this->setEnvProperty() instead.
-     *
-     * @param array $data Dependency data to store.
-     *
-     * @return void
-     *
-     * @codeCoverageIgnore - Deprecated
-     */
-    public function setDependencyData(array $data)
-    {
-        $this->data['dependencies'] = $data;
-    }
-
-    // phpcs:enable
 }

--- a/tests/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/API/Helpers/InformationHeadersExtendTest.php
@@ -25,37 +25,6 @@ class InformationHeadersExtendTest extends TestCase
     }
 
     /**
-     * Extend existing headers and make sure existing data stays intact.
-     *
-     * @link https://github.com/auth0/jwt-auth-bundle/blob/master/src/JWTAuthBundle.php
-     * @link https://github.com/auth0/laravel-auth0/blob/master/src/Auth0/Login/LoginServiceProvider.php
-     *
-     * @return void
-     */
-    public function testThatExtendedHeadersBuildCorrectly()
-    {
-        $new_headers = self::setExtendedHeaders('test-extend-sdk-1', '1.2.3');
-        $new_headers->setEnvironment('test-extend-env', '2.3.4');
-
-        $new_header_data = $new_headers->get();
-
-        // Look for new SDK name and version.
-        $this->assertEquals( 'test-extend-sdk-1', $new_header_data['name'] );
-        $this->assertEquals( '1.2.3', $new_header_data['version'] );
-
-        // Look for original env data.
-        $this->assertArrayHasKey('env', $new_header_data);
-        $this->assertArrayHasKey('php', $new_header_data['env']);
-        $this->assertEquals( phpversion(), $new_header_data['env']['php'] );
-        $this->assertArrayHasKey('auth0-php', $new_header_data['env']);
-        $this->assertEquals(ApiClient::API_VERSION, $new_header_data['env']['auth0-php']);
-
-        // Look for extended env data.
-        $this->assertArrayHasKey('test-extend-env', $new_header_data['env']);
-        $this->assertEquals('2.3.4', $new_header_data['env']['test-extend-env']);
-    }
-
-    /**
      * Test that extending the headers works for Management API calls.
      *
      * @throws \Exception Unsuccessful HTTP call or empty mock history queue.

--- a/tests/API/Helpers/InformationHeadersTest.php
+++ b/tests/API/Helpers/InformationHeadersTest.php
@@ -57,31 +57,6 @@ class InformationHeadersTest extends TestCase
     }
 
     /**
-     * Set and override an env property with the deprecated method and make sure it's returned correctly.
-     *
-     * @return void
-     */
-    public function testThatSetEnvironmentSetsDataCorrectly()
-    {
-        $header = new InformationHeaders();
-        $header->setEnvironment( 'test_env_name', '2.3.4' );
-        $header_data = $header->get();
-
-        $this->assertArrayHasKey('env', $header_data);
-        $this->assertCount(1, $header_data['env']);
-        $this->assertArrayHasKey('test_env_name', $header_data['env']);
-        $this->assertEquals('2.3.4', $header_data['env']['test_env_name']);
-
-        $header->setEnvironment( 'test_env_name', '3.4.5' );
-        $header_data = $header->get();
-        $this->assertEquals('3.4.5', $header_data['env']['test_env_name']);
-
-        $header->setEnvironment( 'test_env_name_2', '4.5.6' );
-        $header_data = $header->get();
-        $this->assertEquals('4.5.6', $header_data['env']['test_env_name_2']);
-    }
-
-    /**
      * Set the package and env and make sure it's built correctly.
      *
      * @return void


### PR DESCRIPTION
### Changes

**Breaking Changes:**

- Remove deprecated `InformationHeaders::setEnvironment()` method
- Remove deprecated `InformationHeaders:: setDependency()` method
- Remove deprecated `InformationHeaders:: setDependencyData()` method

**Other Changes:**

- Add parameter and return types

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
