### PR TITLE
Make sure we do not generate a new state id

### DIFF
--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -35,14 +35,14 @@ class SessionStateHandler implements StateHandler
 
     /**
      * Generate state value to be used for the state param value during authorization 
-     * if one does not already exist.
+     * if one does not already exist or we want to force the generation of one.
      *
      * @return string
      */
-    public function issue()
+    public function issue($force = false)
     {
         $state = $this->store->get(self::STATE_NAME);
-        if ($state === null) {
+        if ($state === null || $force) {
             $state = uniqid('', true);
             $this->store($state);
         }

--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -34,14 +34,19 @@ class SessionStateHandler implements StateHandler
     }
 
     /**
-     * Generate state value to be used for the state param value during authorization.
+     * Generate state value to be used for the state param value during authorization 
+     * if one does not already exist.
      *
      * @return string
      */
     public function issue()
     {
-        $state = uniqid('', true);
-        $this->store($state);
+        $state = $this->store->get(self::STATE_NAME);
+        if ($state === null) {
+            $state = uniqid('', true);
+            $this->store($state);
+        }
+        
         return $state;
     }
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -803,4 +803,25 @@ class Auth0
     {
         $this->debugger = $debugger;
     }
+    
+    /**
+     * Gets the store interface
+     *
+     * @return StoreInterface
+     */
+    public function getStore(): StoreInterface 
+    {
+        return $this->store;
+    }
+    
+    /**
+     * Gets the State Handler
+     *
+     * @return StateHandler
+     */
+    public function getStateHandler(): StateHandler
+    {
+        return $this->stateHandler; 
+    }
+        
 }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -809,7 +809,7 @@ class Auth0
      *
      * @return StoreInterface
      */
-    public function getStore(): StoreInterface 
+    public function getStore() 
     {
         return $this->store;
     }
@@ -819,7 +819,7 @@ class Auth0
      *
      * @return StateHandler
      */
-    public function getStateHandler(): StateHandler
+    public function getStateHandler()
     {
         return $this->stateHandler; 
     }


### PR DESCRIPTION
If we already have state id, we should not be generating one, can lead to Invalid state error in laravel.

### Changes
- SessionStateHandler class - In the issue method, we check if there is already one created to avoid an invalid state exception in laravel.

### References

https://github.com/auth0/laravel-auth0/issues/141#issuecomment-544586139

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

This can be validated by following the tutorial on laravel integration and adding the fix.

[ ] This change adds test coverage

[x] This change has been tested on the latest version of PHP

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

[x] All existing and new tests complete without errors.

[x] The correct base branch is being used.
