### PR TITLE
add redis state handler using the predis library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php": "^5.5 || ^7.0",
     "guzzlehttp/guzzle": "~6.0",
     "ext-json": "*",
-    "firebase/php-jwt" : "^5.0"
+    "firebase/php-jwt" : "^5.0",
+    "predis/predis": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.7",

--- a/src/API/Helpers/State/RedisStateHandler.php
+++ b/src/API/Helpers/State/RedisStateHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Auth0\SDK\API\Helpers\State;
+
+use Predis\Client;
+use Auth0\SDK\API\Helpers\State\StateHandler;
+
+/*
+ * This file is part of Auth0-PHP package.
+ *
+ * (c) Auth0
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+/**
+ * Redis based implementation of StateHandler.
+ *
+ * @author Auth0
+ */
+class RedisStateHandler implements StateHandler
+{
+    const STATE_NAME = 'webauth_state';
+
+    private $cache;
+
+    /**
+     * Auth0RedisStateHandler constructor.
+     *
+     * @param Client $cache
+     */
+    public function __construct(Client $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Generate state value to be used for the state param value during authorization.
+     *
+     * @return string
+     */
+    public function issue()
+    {
+        $state = uniqid('', true);
+        $this->store($state);
+        return $state;
+    }
+
+    /**
+     * Store a given state value to be used for the state param value during authorization.
+     *
+     * @param string $state
+     *
+     * @return mixed|void
+     */
+    public function store($state)
+    {
+        $this->cache->sadd(self::STATE_NAME, $state);
+    }
+
+    /**
+     * Perform validation of the returned state with the previously generated state.
+     *
+     * @param string $state
+     *
+     * @return boolean
+     */
+    public function validate($state)
+    {
+        $valid = $this->cache->sismember(self::STATE_NAME, $state) > 0;
+        $this->cache->srem(self::STATE_NAME, $state);
+        return $valid;
+    }
+}

--- a/src/API/Helpers/State/RedisStateHandler.php
+++ b/src/API/Helpers/State/RedisStateHandler.php
@@ -5,34 +5,25 @@ namespace Auth0\SDK\API\Helpers\State;
 use Predis\Client;
 use Auth0\SDK\API\Helpers\State\StateHandler;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- */
-
 /**
  * Redis based implementation of StateHandler.
  *
- * @author Auth0
+ * @author Brian Anderson
  */
 class RedisStateHandler implements StateHandler
 {
     const STATE_NAME = 'webauth_state';
 
-    private $cache;
+    private $redis;
 
     /**
-     * Auth0RedisStateHandler constructor.
+     * RedisStateHandler constructor.
      *
-     * @param Client $cache
+     * @param Client $redis
      */
-    public function __construct(Client $cache)
+    public function __construct(Client $redis)
     {
-        $this->cache = $cache;
+        $this->redis = $redis;
     }
 
     /**
@@ -56,7 +47,7 @@ class RedisStateHandler implements StateHandler
      */
     public function store($state)
     {
-        $this->cache->sadd(self::STATE_NAME, $state);
+        $this->redis->sadd(self::STATE_NAME, $state);
     }
 
     /**
@@ -68,8 +59,8 @@ class RedisStateHandler implements StateHandler
      */
     public function validate($state)
     {
-        $valid = $this->cache->sismember(self::STATE_NAME, $state) > 0;
-        $this->cache->srem(self::STATE_NAME, $state);
+        $valid = $this->redis->sismember(self::STATE_NAME, $state) > 0;
+        $this->redis->srem(self::STATE_NAME, $state);
         return $valid;
     }
 }

--- a/tests/API/Helpers/State/RedisStateHandlerTest.php
+++ b/tests/API/Helpers/State/RedisStateHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+namespace Auth0\Tests\Api\Helpers\State;
+
+use Auth0\SDK\API\Helpers\State\RedisStateHandler;
+use Predis\Client;
+
+/**
+ * Class RedisStateHandlerTest
+ *
+ * @package Auth0\Tests\Api\Helpers\State
+ */
+class RedisStateHandlerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Storage engine to use.
+     *
+     * @var Client
+     */
+    private $cache;
+
+    /**
+     * State handler to use.
+     *
+     * @var RedisStateHandler
+     */
+    private $stateHandler;
+
+    /**
+     * RedisStateHandlerTest constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->cache = new Client();
+        $this->stateHandler = new RedisStateHandler($this->cache);
+    }
+
+    /**
+     * Test that state is stored and retrieved properly.
+     *
+     * @return void
+     */
+    public function testStateStoredCorrectly()
+    {
+        $uniqid = uniqid();
+
+        $this->stateHandler->store($uniqid);
+        $this->assertGreaterThan(0, $this->cache->sismember(RedisStateHandler::STATE_NAME, $uniqid));
+    }
+
+    /**
+     * Test that the state is being issued correctly.
+     *
+     * @return void
+     */
+    public function testStateIssuedCorrectly()
+    {
+        $state_issued = $this->stateHandler->issue();
+        $this->assertGreaterThan(0, $this->cache->sismember(RedisStateHandler::STATE_NAME, $state_issued));
+    }
+
+    /**
+     * Test that state validated properly.
+     *
+     * @return void
+     */
+    public function testStateValidatesCorrectly()
+    {
+        $state_issued = $this->stateHandler->issue();
+        $this->assertTrue($this->stateHandler->validate($state_issued));
+        $this->assertEquals(0, $this->cache->sismember(RedisStateHandler::STATE_NAME, $state_issued));
+
+    }
+
+    /**
+     * Test that state validation fails with an incorrect value.
+     *
+     * @return void
+     */
+    public function testStateFailsWithIncorrectValue()
+    {
+        $state_issued = $this->stateHandler->issue();
+        $this->assertFalse($this->stateHandler->validate($state_issued.'false'));
+    }
+}


### PR DESCRIPTION
### Changes

This change adds the `RedisStateHandler` class to the `Auth0\SDK\API\Helpers\State` namespace. It is similar to the `SessionStateHandler`, but will save state to a redis data store instead of to the session.
In order to connect to redis, the `predis` composer package has been added to the composer requirements as well.

### References

This change is what has been developed while searching for a solution to [this community article](https://community.auth0.com/t/err-too-many-redirects-invalid-state-response-from-php-getuser-function/32768).

### Testing

A unit test has been added.
[x] This change adds test coverage

[x] This change has been tested on the latest version of PHP

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

[x] All existing and new tests complete without errors.

[x] The correct base branch is being used (I left the default).
