### PR TITLE
Remove session cookie expiration option

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -334,8 +334,6 @@ class Auth0
 
         $session_base_name = ! empty( $config['session_base_name'] ) ? $config['session_base_name'] : SessionStore::BASE_NAME;
 
-        $session_cookie_expires = isset( $config['session_cookie_expires'] ) ? $config['session_cookie_expires'] : SessionStore::COOKIE_EXPIRES;
-
         if (isset($config['store'])) {
             if ($config['store'] === false) {
                 $emptyStore = new EmptyStore();
@@ -344,7 +342,7 @@ class Auth0
                 $this->setStore($config['store']);
             }
         } else {
-            $sessionStore = new SessionStore($session_base_name, $session_cookie_expires);
+            $sessionStore = new SessionStore($session_base_name);
             $this->setStore($sessionStore);
         }
 
@@ -355,7 +353,7 @@ class Auth0
                 $this->stateHandler = $config['state_handler'];
             }
         } else {
-            $stateStore         = new SessionStore($session_base_name, $session_cookie_expires);
+            $stateStore         = new SessionStore($session_base_name);
             $this->stateHandler = new SessionStateHandler($stateStore);
         }
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -15,11 +15,6 @@ class SessionStore implements StoreInterface
     const BASE_NAME = 'auth0_';
 
     /**
-     * Default session cookie expiration.
-     */
-    const COOKIE_EXPIRES = 604800;
-
-    /**
      * Session base name, configurable on instantiation.
      *
      * @var string
@@ -27,22 +22,13 @@ class SessionStore implements StoreInterface
     protected $session_base_name = self::BASE_NAME;
 
     /**
-     * Session cookie expiration, configurable on instantiation.
-     *
-     * @var integer
-     */
-    protected $session_cookie_expires;
-
-    /**
      * SessionStore constructor.
      *
-     * @param string  $base_name      Session base name.
-     * @param integer $cookie_expires Session expiration in seconds; default is 1 week.
+     * @param string $base_name Session base name.
      */
-    public function __construct($base_name = self::BASE_NAME, $cookie_expires = self::COOKIE_EXPIRES)
+    public function __construct($base_name = self::BASE_NAME)
     {
-        $this->session_base_name      = (string) $base_name;
-        $this->session_cookie_expires = (int) $cookie_expires;
+        $this->session_base_name = (string) $base_name;
     }
 
     /**
@@ -54,10 +40,6 @@ class SessionStore implements StoreInterface
     private function initSession()
     {
         if (! session_id()) {
-            if (! empty( $this->session_cookie_expires )) {
-                session_set_cookie_params($this->session_cookie_expires);
-            }
-
             session_start();
         }
     }

--- a/tests/Store/SessionStoreTest.php
+++ b/tests/Store/SessionStoreTest.php
@@ -64,9 +64,6 @@ class SessionStoreTest extends TestCase
 
         // Make sure we have a session to check.
         $this->assertNotEmpty(session_id());
-
-        $cookieParams = session_get_cookie_params();
-        $this->assertEquals(self::COOKIE_LIFETIME, $cookieParams['lifetime']);
     }
 
     /**
@@ -150,28 +147,5 @@ class SessionStoreTest extends TestCase
         // phpcs:ignore
         @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE);
         $this->assertEquals(self::TEST_VALUE, self::$sessionStore->get(self::TEST_KEY));
-    }
-
-    /**
-     * Test that custom cookie expires can be set.
-     *
-     * @return void
-     *
-     * @runInSeparateProcess
-     */
-    public function testCustomCookieExpires()
-    {
-        $custom_expires = mt_rand( 11111, 99999 );
-
-        $this->assertEmpty(session_id());
-        self::$sessionStore = new SessionStore( null, $custom_expires );
-
-        // Suppressing "headers already sent" warning related to cookies.
-        // phpcs:ignore
-        @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE);
-
-        $this->assertNotEmpty(session_id());
-        $cookieParams = session_get_cookie_params();
-        $this->assertEquals($custom_expires, $cookieParams['lifetime']);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,9 @@ $tests_dir = dirname(__FILE__).'/';
 
 require_once $tests_dir.'../vendor/autoload.php';
 
+ini_set('session.use_cookies', false);
+ini_set('session.cache_limiter', false);
+
 define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 160000 );
 
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {


### PR DESCRIPTION
### Changes

Remove the session cookie expiration option throughout the SDK. The session cookie expiration should be managed in the application, not in this SDK. If you were using this setting before, see the PHP core function `session_set_cookie_params()` to set this value after upgrading:

https://www.php.net/manual/en/function.session-set-cookie-params.php 

**Breaking changes:**

- Remove `SessionStore::COOKIE_EXPIRES` constant

**Other changes:**

- Remove 2nd argument for `SessionStore` class
- Remove `session_cookie_expires` config option for `Auth0` class

### Testing

- [x] This change modifies test coverage
- [x] This change has been tested on PHP 7.2

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
