### PR TITLE
Change client secret requirements

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -23,6 +23,7 @@ use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\API\Helpers\State\DummyStateHandler;
 
+use Firebase\JWT\JWT;
 use GuzzleHttp\Exception\RequestException;
 
 /**
@@ -78,14 +79,6 @@ class Auth0
      * @var string
      */
     protected $clientSecret;
-
-    /**
-     * True if the client secret is base64 encoded, false if not.
-     * This information can be found in your Auth0 Application settings below the Client Secret field.
-     *
-     * @var boolean
-     */
-    protected $clientSecretEncoded;
 
     /**
      * Response mode
@@ -266,19 +259,18 @@ class Auth0
             throw new CoreException('Invalid client_id');
         }
 
-        if (empty($config['client_secret'])) {
-            throw new CoreException('Invalid client_secret');
-        }
-
         if (empty($config['redirect_uri'])) {
             throw new CoreException('Invalid redirect_uri');
         }
 
-        $this->domain              = $config['domain'];
-        $this->clientId            = $config['client_id'];
-        $this->clientSecret        = $config['client_secret'];
-        $this->clientSecretEncoded = ! empty( $config['secret_base64_encoded'] );
-        $this->redirectUri         = $config['redirect_uri'];
+        $this->domain      = $config['domain'];
+        $this->clientId    = $config['client_id'];
+        $this->redirectUri = $config['redirect_uri'];
+
+        $this->clientSecret = $config['client_secret'] ?? null;
+        if ($config['secret_base64_encoded'] ?? false) {
+            $this->clientSecret = JWT::urlsafeB64Decode($this->clientSecret);
+        }
 
         if (isset($config['audience'])) {
             $this->audience = $config['audience'];

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -268,7 +268,7 @@ class Auth0
         $this->redirectUri = $config['redirect_uri'];
 
         $this->clientSecret = $config['client_secret'] ?? null;
-        if ($config['secret_base64_encoded'] ?? false) {
+        if ($this->clientSecret && ($config['secret_base64_encoded'] ?? false)) {
             $this->clientSecret = JWT::urlsafeB64Decode($this->clientSecret);
         }
 
@@ -349,7 +349,7 @@ class Auth0
             $this->stateHandler = new SessionStateHandler($stateStore);
         }
 
-        if (isset($config['cache_handler']) && $config['cache_handler'] instanceof CacheHandler ) {
+        if (isset($config['cache_handler']) && $config['cache_handler'] instanceof CacheHandler) {
             $this->cacheHandler = $config['cache_handler'];
         } else {
             $this->cacheHandler = new NoCacheHandler();

--- a/src/Helpers/Tokens/SignatureVerifier.php
+++ b/src/Helpers/Tokens/SignatureVerifier.php
@@ -15,6 +15,7 @@ use Lcobucci\JWT\Token;
  */
 abstract class SignatureVerifier
 {
+
     /**
      * Token algorithm value.
      *

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -8,6 +8,7 @@ use Auth0\Tests\Traits\ErrorHelpers;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -375,6 +376,70 @@ class Auth0Test extends TestCase
         $url_query        = explode( '&', $parsed_url_query );
 
         $this->assertContains( 'state='.$_SESSION['auth0__webauth_state'], $url_query );
+    }
+
+    /**
+     * @throws ApiException Should not be thrown in this test.
+     * @throws CoreException Should not be thrown in this test.
+     */
+    public function testThatClientSecretIsNotDecodedByDefault()
+    {
+        $request_history = [];
+        $mock            = new MockHandler([
+            new Response(200, [ 'Content-Type' => 'json' ], '{"access_token":"1.2.3"}'),
+        ]);
+        $handler         = HandlerStack::create($mock);
+        $handler->push( Middleware::history($request_history) );
+
+        $_GET['code']  = uniqid();
+        $custom_config = array_merge(self::$baseConfig, [
+            'skip_userinfo' => true,
+            'guzzle_options' => [
+                'handler' => $handler,
+            ]
+        ]);
+
+        $auth0 = new Auth0( $custom_config );
+        $auth0->exchange();
+
+        $request_body = $request_history[0]['request']->getBody()->getContents();
+        $request_body = json_decode($request_body, true);
+
+        $this->assertArrayHasKey( 'client_secret', $request_body );
+        $this->assertEquals( '__test_client_secret__', $request_body['client_secret'] );
+    }
+
+    /**
+     * @throws ApiException Should not be thrown in this test.
+     * @throws CoreException Should not be thrown in this test.
+     */
+    public function testThatClientSecretIsDecodedBeforeSending()
+    {
+        $request_history = [];
+        $mock            = new MockHandler([
+            new Response(200, [ 'Content-Type' => 'json' ], '{"access_token":"1.2.3"}'),
+        ]);
+        $handler         = HandlerStack::create($mock);
+        $handler->push( Middleware::history($request_history) );
+
+        $_GET['code']  = uniqid();
+        $custom_config = array_merge(self::$baseConfig, [
+            'client_secret' => JWT::urlsafeB64Encode( '__test_encoded_client_secret__' ),
+            'secret_base64_encoded' => true,
+            'skip_userinfo' => true,
+            'guzzle_options' => [
+                'handler' => $handler,
+            ]
+        ]);
+
+        $auth0 = new Auth0( $custom_config );
+        $auth0->exchange();
+
+        $request_body = $request_history[0]['request']->getBody()->getContents();
+        $request_body = json_decode($request_body, true);
+
+        $this->assertArrayHasKey( 'client_secret', $request_body );
+        $this->assertEquals( '__test_encoded_client_secret__', $request_body['client_secret'] );
     }
 
     /*


### PR DESCRIPTION
### Changes

- Remove the requirement for a client secret to be passed to the `Auth0` class
- Decode the secret in the constructor so it's decoded throughout

### Testing

- [x] This change modifies test coverage
- [x] This change has been tested on PHP 7.2

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.