### PR TITLE
Cleanup Auth0 class constructor for clarification and better defaults

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -225,7 +225,6 @@ class Auth0
      *     - guzzle_options         (Object)  Optional. Options passed to Guzzle
      *     - skip_userinfo          (Boolean) Optional. True to use id_token for user, false to call the
      *                                                  userinfo endpoint, default false
-     *     - session_base_name      (String)  Optional. A common prefix for all session keys. Default `auth0_`
      *     - session_cookie_expires (Integer) Optional. Seconds for session cookie to expire (if default store is used).
      *                                                  Default `604800`
      * @throws CoreException If `domain` is not provided.
@@ -235,21 +234,20 @@ class Auth0
      */
     public function __construct(array $config)
     {
-        if (empty($config['domain'])) {
+        $this->domain = $config['domain'] ?? $_ENV['AUTH0_DOMAIN'] ?? null;
+        if (empty($this->domain)) {
             throw new CoreException('Invalid domain');
         }
 
-        if (empty($config['client_id'])) {
+        $this->clientId = $config['client_id'] ?? $_ENV['AUTH0_CLIENT_ID'] ?? null;
+        if (empty($this->clientId)) {
             throw new CoreException('Invalid client_id');
         }
 
-        if (empty($config['redirect_uri'])) {
+        $this->redirectUri = $config['redirect_uri'] ?? $_ENV['AUTH0_REDIRECT_URI'] ?? null;
+        if (empty($this->redirectUri)) {
             throw new CoreException('Invalid redirect_uri');
         }
-
-        $this->domain      = $config['domain'];
-        $this->clientId    = $config['client_id'];
-        $this->redirectUri = $config['redirect_uri'];
 
         $this->clientSecret = $config['client_secret'] ?? null;
         if ($this->clientSecret && ($config['secret_base64_encoded'] ?? false)) {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -85,14 +85,14 @@ class Auth0
      *
      * @var string
      */
-    protected $responseMode = 'query';
+    protected $responseMode;
 
     /**
      * Response type
      *
      * @var string
      */
-    protected $responseType = 'code';
+    protected $responseType;
 
     /**
      * Audience for the API being used
@@ -172,7 +172,7 @@ class Auth0
      *
      * @see http://docs.guzzlephp.org/en/stable/request-options.html
      */
-    protected $guzzleOptions = [];
+    protected $guzzleOptions;
 
     /**
      * Skip the /userinfo endpoint call and use the ID token.
@@ -254,30 +254,12 @@ class Auth0
             $this->clientSecret = JWT::urlsafeB64Decode($this->clientSecret);
         }
 
-        if (isset($config['audience'])) {
-            $this->audience = $config['audience'];
-        }
-
-        if (isset($config['response_mode'])) {
-            $this->responseMode = $config['response_mode'];
-        }
-
-        if (isset($config['response_type'])) {
-            $this->responseType = $config['response_type'];
-        }
-
-        if (isset($config['scope'])) {
-            $this->scope = $config['scope'];
-        }
-
-        if (isset($config['guzzle_options'])) {
-            $this->guzzleOptions = $config['guzzle_options'];
-        }
-
-        $this->skipUserinfo = false;
-        if (isset($config['skip_userinfo']) && is_bool($config['skip_userinfo'])) {
-            $this->skipUserinfo = $config['skip_userinfo'];
-        }
+        $this->audience = $config['audience'] ?? null;
+        $this->responseMode = $config['response_mode'] ?? 'query';
+        $this->responseType = $config['response_type'] ?? 'code';
+        $this->scope = $config['scope'] ?? 'openid profile email';
+        $this->guzzleOptions = $config['guzzle_options'] ?? [];
+        $this->skipUserinfo = $config['skip_userinfo'] ?? true;
 
         $this->idTokenAlg = $config['id_token_alg'] ?? 'RS256';
         if (! in_array( $this->idTokenAlg, ['HS256', 'RS256'] )) {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -123,21 +123,6 @@ class Auth0
     protected $redirectUri;
 
     /**
-     * Debug mode flag.
-     *
-     * @var boolean
-     */
-    protected $debugMode;
-
-    /**
-     * Debugger function.
-     * Will be called only if $debug_mode is true.
-     *
-     * @var \Closure
-     */
-    protected $debugger;
-
-    /**
      * The access token retrieved after authorization.
      * NULL means that there is no authorization yet.
      *
@@ -237,7 +222,6 @@ class Auth0
      *                                                  leave empty to default to SessionStore
      *     - state_handler          (Mixed)   Optional. A class that implements StateHandler of false for none;
      *                                                  leave empty to default to SessionStore SessionStateHandler
-     *     - debug                  (Boolean) Optional. Turn on debug mode, default false
      *     - guzzle_options         (Object)  Optional. Options passed to Guzzle
      *     - skip_userinfo          (Boolean) Optional. True to use id_token for user, false to call the
      *                                                  userinfo endpoint, default false
@@ -301,8 +285,6 @@ class Auth0
         if (! in_array( $this->idTokenAlg, ['HS256', 'RS256'] )) {
             throw new CoreException('Invalid id_token_alg; must be "HS256" or "RS256"');
         }
-
-        $this->debugMode = isset($config['debug']) ? $config['debug'] : false;
 
         // User info is persisted by default.
         if (isset($config['persist_user']) && false === $config['persist_user']) {
@@ -769,17 +751,5 @@ class Auth0
     {
         $this->store = $store;
         return $this;
-    }
-
-    /**
-     * Set the debugger closure
-     *
-     * @param \Closure $debugger - debugger closure to use.
-     *
-     * @return void
-     */
-    public function setDebugger(\Closure $debugger)
-    {
-        $this->debugger = $debugger;
     }
 }

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -84,6 +84,7 @@ class Auth0Test extends TestCase
         ] );
 
         $add_config   = [
+            'skip_userinfo' => false,
             'id_token_alg' => 'HS256',
             'guzzle_options' => [
                 'handler' => HandlerStack::create($mock)
@@ -116,6 +117,7 @@ class Auth0Test extends TestCase
         ] );
 
         $add_config   = [
+            'skip_userinfo' => false,
             'scope' => 'offline_access read:messages',
             'audience' => 'https://api.identifier',
             'guzzle_options' => [ 'handler' => HandlerStack::create($mock) ]

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ require_once $tests_dir.'../vendor/autoload.php';
 ini_set('session.use_cookies', false);
 ini_set('session.cache_limiter', false);
 
-define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 160000 );
+define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 200000 );
 
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );


### PR DESCRIPTION
### Changes

**Potentially breaking changes:**

- Add ENV fallbacks for required settings:
    - `AUTH0_DOMAIN` will be used if the `domain` configuration key is empty
    - `AUTH0_CLIENT_ID ` will be used if the `client_id` configuration key is empty
    - `AUTH0_REDIRECT_URI ` will be used if the `redirect_uri` configuration key is empty
- Change `skip_userinfo` default to `true`. This means that applications no setting this value will get the user identity from the ID token rather than an extra HTTP call to the `/userinfo` endpoint.
- Remove unused debugging mode and public `Auth0->setDebugger()` method
- Base64 decode Client Secret in the constructor to be used as-is within the class

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of PHP

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
