### PR TITLE
Nonce and max_age handling with new CookieStore class

### DIFF
--- a/src/API/Helpers/State/DummyStateHandler.php
+++ b/src/API/Helpers/State/DummyStateHandler.php
@@ -2,19 +2,8 @@
 
 namespace Auth0\SDK\API\Helpers\State;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- */
-
 /**
  * Dummy implementation of the StateHandler
- *
- * @author Auth0
  */
 class DummyStateHandler implements StateHandler
 {

--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -4,19 +4,8 @@ namespace Auth0\SDK\API\Helpers\State;
 
 use Auth0\SDK\Store\StoreInterface;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- */
-
 /**
  * Session based implementation of StateHandler.
- *
- * @author Auth0
  */
 class SessionStateHandler implements StateHandler
 {
@@ -25,7 +14,6 @@ class SessionStateHandler implements StateHandler
     private $store;
 
     /**
-     *
      * @param StoreInterface $store
      */
     public function __construct(StoreInterface $store)

--- a/src/API/Helpers/State/StateHandler.php
+++ b/src/API/Helpers/State/StateHandler.php
@@ -2,19 +2,8 @@
 
 namespace Auth0\SDK\API\Helpers\State;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- */
-
 /**
  * This interface must be implemented by state handlers.
- *
- * @author Auth0
  */
 interface StateHandler
 {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -192,6 +192,13 @@ class Auth0
     protected $idTokenAlg;
 
     /**
+     * Leeway for ID token validation.
+     *
+     * @var int
+     */
+    protected $idTokenLeeway;
+
+    /**
      * State Handler.
      *
      * @var StateHandler
@@ -237,6 +244,7 @@ class Auth0
      *                                                  userinfo endpoint (false)
      *     - max_age                (Integer) Optional. Maximum time allowed between authentication and callback
      *     - id_token_alg           (String)  Optional. ID token algorithm expected; RS256 (default) or HS256 only
+     *     - id_token_leeway        (Integer) Optional. Leeway, in seconds, for ID token validation.
      *     - session_base_name      (String)  Optional. Base name for session keys
      *     - store                  (Mixed)   Optional. StorageInterface for identity and token persistence;
      *                                                  leave empty to default to SessionStore, false for none
@@ -283,6 +291,7 @@ class Auth0
         $this->guzzleOptions = $config['guzzle_options'] ?? [];
         $this->skipUserinfo  = $config['skip_userinfo'] ?? true;
         $this->maxAge        = $config['max_age'] ?? null;
+        $this->idTokenLeeway = $config['id_token_leeway'] ?? null;
 
         $this->idTokenAlg = $config['id_token_alg'] ?? 'RS256';
         if (! in_array( $this->idTokenAlg, ['HS256', 'RS256'] )) {
@@ -654,6 +663,7 @@ class Auth0
         $verifierOptions = [
             'nonce' => $this->authStore->get('nonce'),
             'max_age' => $this->authStore->get('max_age'),
+            'leeway' => $this->idTokenLeeway,
         ];
         $this->authStore->delete('nonce');
         $this->authStore->delete('max_age');

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -194,7 +194,7 @@ class Auth0
     /**
      * Leeway for ID token validation.
      *
-     * @var int
+     * @var integer
      */
     protected $idTokenLeeway;
 
@@ -332,12 +332,10 @@ class Auth0
             $this->setStore($sessionStore);
         }
 
-        $authStore = $config['auth_store'] ?? new CookieStore();
-        if (! $authStore instanceof StoreInterface) {
-            $authStore = new EmptyStore();
+        $this->authStore = $config['auth_store'] ?? null;
+        if (! $this->authStore instanceof StoreInterface) {
+            $this->authStore = new CookieStore();
         }
-
-        $this->authStore = $authStore;
 
         if (isset($config['state_handler'])) {
             if ($config['state_handler'] === false) {
@@ -427,12 +425,18 @@ class Auth0
         $auth_params = array_filter( $auth_params );
 
         if (empty( $auth_params['state'] )) {
+            // No state provided by application so generate, store, and send one.
             $auth_params['state'] = $this->stateHandler->issue();
         } else {
+            // Store the passed-in value.
             $this->stateHandler->store($auth_params['state']);
         }
 
-        $auth_params['nonce'] = self::getNonce();
+        // ID token nonce validation is required so auth params must include one.
+        if (empty( $auth_params['nonce'] )) {
+            $auth_params['nonce'] = self::getNonce();
+        }
+
         $this->authStore->set( 'nonce', $auth_params['nonce'] );
 
         if (isset($auth_params['max_age'])) {
@@ -661,12 +665,18 @@ class Auth0
         }
 
         $verifierOptions = [
-            'nonce' => $this->authStore->get('nonce'),
-            'max_age' => $this->authStore->get('max_age'),
+            // Set a custom leeway if one was passed to the constructor.
             'leeway' => $this->idTokenLeeway,
+            'max_age' => $this->authStore->get('max_age'),
         ];
-        $this->authStore->delete('nonce');
         $this->authStore->delete('max_age');
+
+        $verifierOptions['nonce'] = $this->authStore->get('nonce');
+        if (empty( $verifierOptions['nonce'] )) {
+            throw new InvalidTokenException('Nonce value not found in application store');
+        }
+
+        $this->authStore->delete('nonce');
 
         $idTokenVerifier      = new IdTokenVerifier($idTokenIss, $this->clientId, $sigVerifier);
         $this->idTokenDecoded = $idTokenVerifier->verify($idToken, $verifierOptions);

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -667,7 +667,7 @@ class Auth0
         $verifierOptions = [
             // Set a custom leeway if one was passed to the constructor.
             'leeway' => $this->idTokenLeeway,
-            'max_age' => $this->authStore->get('max_age'),
+            'max_age' => $this->authStore->get('max_age') ?? $this->maxAge,
         ];
         $this->authStore->delete('max_age');
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -286,19 +286,13 @@ class Auth0
             $this->dontPersist('id_token');
         }
 
-        $session_base_name = ! empty( $config['session_base_name'] ) ? $config['session_base_name'] : SessionStore::BASE_NAME;
+        $session_base_name = $config['session_base_name'] ?? SessionStore::BASE_NAME;
 
-        if (isset($config['store'])) {
-            if ($config['store'] === false) {
-                $emptyStore = new EmptyStore();
-                $this->setStore($emptyStore);
-            } else {
-                $this->setStore($config['store']);
-            }
-        } else {
-            $sessionStore = new SessionStore($session_base_name);
-            $this->setStore($sessionStore);
+        $sessionStore = $config['store'] ?? new SessionStore($session_base_name);
+        if (! $sessionStore instanceof StoreInterface) {
+            $sessionStore = new EmptyStore();
         }
+        $this->setStore($sessionStore);
 
         if (isset($config['state_handler'])) {
             if ($config['state_handler'] === false) {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -9,12 +9,14 @@ namespace Auth0\SDK;
 
 use Auth0\SDK\Exception\CoreException;
 use Auth0\SDK\Exception\ApiException;
+use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\Helpers\Cache\NoCacheHandler;
 use Auth0\SDK\Helpers\JWKFetcher;
 use Auth0\SDK\Helpers\Tokens\IdTokenVerifier;
 use Auth0\SDK\Helpers\Tokens\AsymmetricVerifier;
 use Auth0\SDK\Helpers\Tokens\SymmetricVerifier;
+use Auth0\SDK\Store\CookieStore;
 use Auth0\SDK\Store\EmptyStore;
 use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Store\StoreInterface;
@@ -197,6 +199,13 @@ class Auth0
     protected $stateHandler;
 
     /**
+     * Authorization storage used for state, nonce, and max_age.
+     *
+     * @var StoreInterface
+     */
+    protected $authStore;
+
+    /**
      * Cache Handler.
      *
      * @var CacheHandler
@@ -254,12 +263,12 @@ class Auth0
             $this->clientSecret = JWT::urlsafeB64Decode($this->clientSecret);
         }
 
-        $this->audience = $config['audience'] ?? null;
-        $this->responseMode = $config['response_mode'] ?? 'query';
-        $this->responseType = $config['response_type'] ?? 'code';
-        $this->scope = $config['scope'] ?? 'openid profile email';
+        $this->audience      = $config['audience'] ?? null;
+        $this->responseMode  = $config['response_mode'] ?? 'query';
+        $this->responseType  = $config['response_type'] ?? 'code';
+        $this->scope         = $config['scope'] ?? 'openid profile email';
         $this->guzzleOptions = $config['guzzle_options'] ?? [];
-        $this->skipUserinfo = $config['skip_userinfo'] ?? true;
+        $this->skipUserinfo  = $config['skip_userinfo'] ?? true;
 
         $this->idTokenAlg = $config['id_token_alg'] ?? 'RS256';
         if (! in_array( $this->idTokenAlg, ['HS256', 'RS256'] )) {
@@ -288,11 +297,19 @@ class Auth0
 
         $session_base_name = $config['session_base_name'] ?? SessionStore::BASE_NAME;
 
-        $sessionStore = $config['store'] ?? new SessionStore($session_base_name);
-        if (! $sessionStore instanceof StoreInterface) {
-            $sessionStore = new EmptyStore();
+        $userStore = $config['store'] ?? new SessionStore($session_base_name);
+        if (! $userStore instanceof StoreInterface) {
+            $userStore = new EmptyStore();
         }
-        $this->setStore($sessionStore);
+
+        $this->setStore($userStore);
+
+        $authStore = $config['auth_store'] ?? new CookieStore();
+        if (! $authStore instanceof StoreInterface) {
+            $authStore = new EmptyStore();
+        }
+
+        $this->authStore = $authStore;
 
         if (isset($config['state_handler'])) {
             if ($config['state_handler'] === false) {
@@ -385,6 +402,9 @@ class Auth0
         } else {
             $this->stateHandler->store($auth_params['state']);
         }
+
+        $auth_params['nonce'] = self::getNonce();
+        $this->authStore->set( 'nonce', $auth_params['nonce'] );
 
         return $this->authentication->get_authorize_link(
             $auth_params['response_type'],
@@ -593,7 +613,7 @@ class Auth0
      * @return \Auth0\SDK\Auth0
      *
      * @throws CoreException
-     * @throws Exception\InvalidTokenException
+     * @throws InvalidTokenException
      */
     public function setIdToken($idToken)
     {
@@ -725,5 +745,21 @@ class Auth0
     {
         $this->store = $store;
         return $this;
+    }
+
+    /**
+     * @param integer $length
+     *
+     * @return string
+     */
+    public static function getNonce(int $length = 16) : string
+    {
+        try {
+            $random_bytes = random_bytes($length);
+        } catch (\Exception $e) {
+            $random_bytes = openssl_random_pseudo_bytes($length);
+        }
+
+        return bin2hex($random_bytes);
     }
 }

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -93,7 +93,7 @@ class CookieStore implements StoreInterface
     protected function setCookie(string $key_name, ?string $value = null) : bool
     {
         if (is_null($value)) {
-            return setcookie($key_name);
+            return setcookie($key_name, '', 0, '/');
         }
 
         return setcookie($key_name, $value, time() + $this->cookie_expiration, '/', '', false, true);

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -18,17 +18,23 @@ class CookieStore implements StoreInterface
      * @var string
      */
     protected $cookie_base_name;
+
+    /**
+     * Cookie expiration, configurable on instantiation.
+     *
+     * @var integer
+     */
     protected $cookie_expiration;
 
     /**
      * CookieStore constructor.
      *
-     * @param string $base_name Cookie base name.
-     * @param int $expires Cookie expiration length, in seconds.
+     * @param string  $base_name Cookie base name.
+     * @param integer $expires   Cookie expiration length, in seconds.
      */
     public function __construct(?string $base_name = self::BASE_NAME, ?int $expires = 600)
     {
-        $this->cookie_base_name = $base_name;
+        $this->cookie_base_name  = $base_name;
         $this->cookie_expiration = $expires;
     }
 
@@ -79,10 +85,10 @@ class CookieStore implements StoreInterface
     /**
      * Set or delete a cookie.
      *
-     * @param string $key_name Cookie name to set.
-     * @param string|null $value Cookie value; set to null to delete the cookie.
+     * @param string      $key_name Cookie name to set.
+     * @param string|null $value    Cookie value; set to null to delete the cookie.
      *
-     * @return bool
+     * @return boolean
      */
     protected function setCookie(string $key_name, ?string $value = null) : bool
     {

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Auth0\SDK\Store;
+
+/**
+ * This class provides a layer to persist transient auth data using cookies.
+ */
+class CookieStore implements StoreInterface
+{
+    /**
+     * Default cookie base name.
+     */
+    const BASE_NAME = 'auth0';
+
+    /**
+     * Cookie base name, configurable on instantiation.
+     *
+     * @var string
+     */
+    protected $cookie_base_name;
+    protected $cookie_expiration;
+
+    /**
+     * CookieStore constructor.
+     *
+     * @param string $base_name Cookie base name.
+     * @param int $expires Cookie expiration length, in seconds.
+     */
+    public function __construct(?string $base_name = self::BASE_NAME, ?int $expires = 600)
+    {
+        $this->cookie_base_name = $base_name;
+        $this->cookie_expiration = $expires;
+    }
+
+    /**
+     * Persists $value on cookies, identified by $key.
+     *
+     * @param string $key   Cookie to set.
+     * @param mixed  $value Value to use.
+     *
+     * @return void
+     */
+    public function set($key, $value)
+    {
+        $key_name           = $this->getCookieName($key);
+        $_COOKIE[$key_name] = $value;
+        setcookie($key_name, $value, time() + $this->cookie_expiration, '/', '', false, true);
+    }
+
+    /**
+     * Gets persisted values identified by $key.
+     * If the value is not set, returns $default.
+     *
+     * @param string $key     Cookie to set.
+     * @param mixed  $default Default to return if nothing was found.
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        $key_name = $this->getCookieName($key);
+        return $_COOKIE[$key_name] ?? $default;
+    }
+
+    /**
+     * Removes a persisted value identified by $key.
+     *
+     * @param string $key Cookie to delete.
+     *
+     * @return void
+     */
+    public function delete($key)
+    {
+        $key_name = $this->getCookieName($key);
+        unset($_COOKIE[$key_name]);
+        setcookie($key_name);
+    }
+
+    /**
+     * Constructs a cookie name.
+     *
+     * @param string $key Cookie name to prefix and return.
+     *
+     * @return string
+     */
+    public function getCookieName($key)
+    {
+        $key_name = $key;
+        if (! empty( $this->cookie_base_name )) {
+            $key_name = $this->cookie_base_name.'_'.$key_name;
+        }
+
+        return $key_name;
+    }
+}

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -32,7 +32,7 @@ class CookieStore implements StoreInterface
      * @param string  $base_name Cookie base name.
      * @param integer $expires   Cookie expiration length, in seconds.
      */
-    public function __construct(?string $base_name = self::BASE_NAME, ?int $expires = 600)
+    public function __construct(string $base_name = self::BASE_NAME, int $expires = 600)
     {
         $this->cookie_base_name  = $base_name;
         $this->cookie_expiration = $expires;
@@ -50,7 +50,7 @@ class CookieStore implements StoreInterface
     {
         $key_name           = $this->getCookieName($key);
         $_COOKIE[$key_name] = $value;
-        $this->setCookie( $key_name, $value );
+        $this->setCookie( $key_name, $value, $this->cookie_expiration );
     }
 
     /**
@@ -85,18 +85,15 @@ class CookieStore implements StoreInterface
     /**
      * Set or delete a cookie.
      *
-     * @param string      $key_name Cookie name to set.
-     * @param string|null $value    Cookie value; set to null to delete the cookie.
+     * @param string  $name    Cookie name to set.
+     * @param string  $value   Cookie value.
+     * @param integer $expires Cookie expiration.
      *
      * @return boolean
      */
-    protected function setCookie(string $key_name, ?string $value = null) : bool
+    protected function setCookie(string $name, string $value = '', int $expires = 0) : bool
     {
-        if (is_null($value)) {
-            return setcookie($key_name, '', 0, '/');
-        }
-
-        return setcookie($key_name, $value, time() + $this->cookie_expiration, '/', '', false, true);
+        return setcookie($name, $value, time() + $expires, '/', '', false, true);
     }
 
     /**
@@ -106,7 +103,7 @@ class CookieStore implements StoreInterface
      *
      * @return string
      */
-    protected function getCookieName(string $key) : string
+    public function getCookieName(string $key) : string
     {
         $key_name = $key;
         if (! empty( $this->cookie_base_name )) {

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -44,7 +44,7 @@ class CookieStore implements StoreInterface
     {
         $key_name           = $this->getCookieName($key);
         $_COOKIE[$key_name] = $value;
-        setcookie($key_name, $value, time() + $this->cookie_expiration, '/', '', false, true);
+        $this->setCookie( $key_name, $value );
     }
 
     /**
@@ -73,7 +73,24 @@ class CookieStore implements StoreInterface
     {
         $key_name = $this->getCookieName($key);
         unset($_COOKIE[$key_name]);
-        setcookie($key_name);
+        $this->setCookie( $key_name );
+    }
+
+    /**
+     * Set or delete a cookie.
+     *
+     * @param string $key_name Cookie name to set.
+     * @param string|null $value Cookie value; set to null to delete the cookie.
+     *
+     * @return bool
+     */
+    protected function setCookie(string $key_name, ?string $value = null) : bool
+    {
+        if (is_null($value)) {
+            return setcookie($key_name);
+        }
+
+        return setcookie($key_name, $value, time() + $this->cookie_expiration, '/', '', false, true);
     }
 
     /**
@@ -83,7 +100,7 @@ class CookieStore implements StoreInterface
      *
      * @return string
      */
-    public function getCookieName($key)
+    protected function getCookieName(string $key) : string
     {
         $key_name = $key;
         if (! empty( $this->cookie_base_name )) {

--- a/src/Store/EmptyStore.php
+++ b/src/Store/EmptyStore.php
@@ -2,21 +2,8 @@
 
 namespace Auth0\SDK\Store;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- */
-
-
-
 /**
  * This class is a mockup store, that discards the values, its a way of saying no store.
- *
- * @author Auth0
  */
 class EmptyStore implements StoreInterface
 {

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -4,8 +4,6 @@ namespace Auth0\SDK\Store;
 
 /**
  * This class provides a layer to persist user access using PHP Sessions.
- *
- * @author Auth0
  */
 class SessionStore implements StoreInterface
 {
@@ -19,7 +17,7 @@ class SessionStore implements StoreInterface
      *
      * @var string
      */
-    protected $session_base_name = self::BASE_NAME;
+    protected $session_base_name;
 
     /**
      * SessionStore constructor.

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -1,18 +1,6 @@
 <?php
 namespace Auth0\SDK\Store;
 
-/*
- * This file is part of Auth0-PHP package.
- *
- * (c) Auth0
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
- *
- * This interface must be implemented by stores
- *
- * @author Auth0
- */
 interface StoreInterface
 {
     /**

--- a/src/Store/StoreInterface.php
+++ b/src/Store/StoreInterface.php
@@ -10,6 +10,7 @@ interface StoreInterface
      * @param mixed  $value
      */
     public function set($key, $value);
+
     /**
      * Get a value from the store by a given key
      *
@@ -18,6 +19,7 @@ interface StoreInterface
      * @return mixed
      */
     public function get($key, $default = null);
+
     /**
      * Remove a value from the store
      *

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -388,7 +388,9 @@ class Auth0Test extends TestCase
         $parsed_url_query = parse_url( $auth_url, PHP_URL_QUERY );
         $url_query        = explode( '&', $parsed_url_query );
 
+        $this->assertArrayHasKey( 'auth0__webauth_state', $_SESSION );
         $this->assertContains( 'state='.$_SESSION['auth0__webauth_state'], $url_query );
+        $this->assertArrayHasKey( 'auth0__nonce', $_SESSION );
         $this->assertContains( 'nonce='.$_SESSION['auth0__nonce'], $url_query );
     }
 
@@ -454,6 +456,40 @@ class Auth0Test extends TestCase
 
         $this->assertArrayHasKey( 'client_secret', $request_body );
         $this->assertEquals( '__test_encoded_client_secret__', $request_body['client_secret'] );
+    }
+
+    public function testThatMaxAgeIsSetInLoginUrlFromInitialConfig()
+    {
+        $custom_config            = self::$baseConfig;
+        $custom_config['max_age'] = 1000;
+        $auth0                    = new Auth0( $custom_config );
+
+        $auth_url = @$auth0->getLoginUrl();
+
+        $parsed_url_query = parse_url( $auth_url, PHP_URL_QUERY );
+        $url_query        = explode( '&', $parsed_url_query );
+
+        $this->assertContains( 'max_age=1000', $url_query );
+        $this->assertArrayHasKey( 'auth0__max_age', $_SESSION );
+        $this->assertEquals( 1000, $_SESSION['auth0__max_age'] );
+    }
+
+    public function testThatMaxAgeIsOverriddenInLoginUrl()
+    {
+        $custom_config            = self::$baseConfig;
+        $custom_config['max_age'] = 1000;
+        $auth0                    = new Auth0( $custom_config );
+
+        // Ignore cookie error triggered when session is started.
+        // phpcs:ignore
+        $auth_url = @$auth0->getLoginUrl(['max_age' => 1001]);
+
+        $parsed_url_query = parse_url( $auth_url, PHP_URL_QUERY );
+        $url_query        = explode( '&', $parsed_url_query );
+
+        $this->assertContains( 'max_age=1001', $url_query );
+        $this->assertArrayHasKey( 'auth0__max_age', $_SESSION );
+        $this->assertEquals( 1001, $_SESSION['auth0__max_age'] );
     }
 
     /*

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -4,6 +4,7 @@ namespace Auth0\Tests;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Exception\ApiException;
 use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Store\SessionStore;
 use Auth0\Tests\Traits\ErrorHelpers;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Handler\MockHandler;
@@ -27,15 +28,7 @@ class Auth0Test extends TestCase
      *
      * @var array
      */
-    public static $baseConfig = [
-        'domain'        => '__test_domain__',
-        'client_id'     => '__test_client_id__',
-        'client_secret' => '__test_client_secret__',
-        'redirect_uri'  => '__test_redirect_uri__',
-        'store' => false,
-        'state_handler' => false,
-        'scope' => 'openid offline_access',
-    ];
+    public static $baseConfig;
 
     /**
      * Default request headers.
@@ -43,6 +36,24 @@ class Auth0Test extends TestCase
      * @var array
      */
     protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs after each test completes.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        self::$baseConfig = [
+            'domain'        => '__test_domain__',
+            'client_id'     => '__test_client_id__',
+            'client_secret' => '__test_client_secret__',
+            'redirect_uri'  => '__test_redirect_uri__',
+            'store' => false,
+            'auth_store' => new SessionStore(),
+            'state_handler' => false,
+            'scope' => 'openid offline_access',
+        ];
+    }
 
     /**
      * Runs after each test completes.
@@ -363,7 +374,7 @@ class Auth0Test extends TestCase
         $this->assertContains( 'client_id=__test_client_id__', $url_query );
     }
 
-    public function testThatGetLoginUrlGeneratesState()
+    public function testThatGetLoginUrlGeneratesStateAndNonce()
     {
         $custom_config = self::$baseConfig;
         unset( $custom_config['state_handler'] );
@@ -378,6 +389,7 @@ class Auth0Test extends TestCase
         $url_query        = explode( '&', $parsed_url_query );
 
         $this->assertContains( 'state='.$_SESSION['auth0__webauth_state'], $url_query );
+        $this->assertContains( 'nonce='.$_SESSION['auth0__nonce'], $url_query );
     }
 
     /**

--- a/tests/Store/CookieStoreTest.php
+++ b/tests/Store/CookieStoreTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Auth0\Tests\Store;
+
+use Auth0\SDK\Store\CookieStore;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+
+/**
+ * Class CookieStoreTest.
+ * Tests the CookieStore class.
+ */
+class CookieStoreTest extends TestCase
+{
+
+    /**
+     * Mock CookieStore instance to skip setcookie() call.
+     *
+     * @var CookieStore
+     */
+    public static $mockStore;
+
+    /**
+     * Mock spy for calls to setCookie.
+     *
+     * @var AnyInvokedCount
+     */
+    public static $mockSpy;
+
+    /**
+     * Run before all tests in this suite.
+     */
+    public function setUp()
+    {
+        self::$mockStore = $this->getMockBuilder(CookieStore::class)->setMethods(['setCookie'])->getMock();
+        self::$mockStore->expects(self::$mockSpy = $this->any())->method('setCookie')->willReturn(true);
+    }
+
+    /**
+     * Run after each test in this suite.
+     */
+    public function tearDown()
+    {
+        $_COOKIE = [];
+    }
+
+    public function testGetCookieName()
+    {
+        $store = new CookieStore();
+        $this->assertEquals('auth0_test_key', $store->getCookieName('test_key'));
+    }
+
+    public function testCustomBaseName()
+    {
+        $store = new CookieStore('custom_base');
+        $this->assertEquals('custom_base_test_key', $store->getCookieName('test_key'));
+    }
+
+    public function testCustomExpiration()
+    {
+        $mockStore = $this->getMockBuilder(CookieStore::class)
+            ->setConstructorArgs([uniqid(), 1200])
+            ->setMethods(['setCookie'])
+            ->getMock();
+        $mockStore->expects($mockSpy = $this->any())->method('setCookie')->willReturn(true);
+        $mockStore->set(uniqid(), uniqid());
+
+        $setCookieParams = $mockSpy->getInvocations()[0]->getParameters();
+        $this->assertEquals(1200, $setCookieParams[2]);
+    }
+
+    public function testSet()
+    {
+        self::$mockStore->set('test_set_key', '__test_set_value__');
+
+        $this->assertEquals('__test_set_value__', $_COOKIE['auth0_test_set_key']);
+        $this->assertCount(1, (array) self::$mockSpy->getInvocations());
+
+        $setCookieParams = self::$mockSpy->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('auth0_test_set_key', $setCookieParams[0]);
+        $this->assertEquals('__test_set_value__', $setCookieParams[1]);
+        $this->assertEquals(600, $setCookieParams[2]);
+    }
+
+    public function testGet()
+    {
+        $store                         = new CookieStore();
+        $_COOKIE['auth0_test_get_key'] = '__test_get_value__';
+
+        $this->assertEquals('__test_get_value__', $store->get('test_get_key'));
+        $this->assertEquals('__test_default_value__', $store->get('test_empty_key', '__test_default_value__'));
+    }
+
+    public function testDelete()
+    {
+        $_COOKIE['auth0_test_delete_key'] = '__test_delete_value__';
+
+        self::$mockStore->delete('test_delete_key');
+
+        $this->assertNull(self::$mockStore->get('test_delete_key'));
+        $this->assertArrayNotHasKey('auth0_test_delete_key', $_COOKIE);
+        $this->assertCount(1, (array) self::$mockSpy->getInvocations());
+
+        $setCookieParams = self::$mockSpy->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('auth0_test_delete_key', $setCookieParams[0]);
+        $this->assertEquals('', $setCookieParams[1]);
+        $this->assertEquals(0, $setCookieParams[2]);
+    }
+}


### PR DESCRIPTION
### Changes

**Potentially breaking changes:**

- Add enforced nonce checking for ID tokens. Nonce value is stored automatically in cookies (default cookie name `auth0_nonce`) and required to be checked in ID tokens. All checking is handled in the SDK but some managed hosts require whitelisted cookies and/or specific cookie names so this could be breaking.

**Other changes:**

- Add `auth_store` config option for ID token `nonce` handling; defaults to new `CookieStore` class
- Add `max_age` config option for `Auth0` class to set a `max_age` URL parameter on all authorization requests.
- Add `leeway` config option for `Auth0` class to set an ID token time check leeway

### Testing

Also went through a number of manual tests to ensure the default cookie setting and deleting was working. 

- [x] This change adds test coverage
- [x] This change has been developed and tested on PHP 7.1 and 7.2

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
