### PR TITLE
Add SameSite cookie attribute handling

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,10 +2,7 @@
 <ruleset name="Auth0-PHP" namespace="Auth0PHP\CS\Standard">
     <description>A custom coding standard for the Auth0 PHP SDK</description>
 
-    <file>.</file>
-
-    <exclude-pattern>/examples/*</exclude-pattern>
-    <exclude-pattern>/vendor/*</exclude-pattern>
+    <file>./src</file>
 
     <!-- Only check PHP files. -->
     <arg name="extensions" value="php"/>

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -303,6 +303,7 @@ class Auth0
         $transientStore = $config['transient_store'] ?? null;
         if (! $transientStore instanceof StoreInterface) {
             $transientStore = new CookieStore([
+                // Use configuration option or class default.
                 'legacy_samesite_none' => $config['legacy_samesite_none_cookie'] ?? null,
                 'samesite' => 'form_post' === $this->responseMode ? 'None' : 'Lax',
             ]);

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -302,7 +302,10 @@ class Auth0
 
         $transientStore = $config['transient_store'] ?? null;
         if (! $transientStore instanceof StoreInterface) {
-            $transientStore = new CookieStore();
+            $transientStore = new CookieStore([
+                'legacy_samesite_none' => $config['legacy_samesite_none_cookie'] ?? null,
+                'samesite' => 'form_post' === $this->responseMode ? 'None' : 'Lax',
+            ]);
         }
 
         $this->transientHandler = new TransientStoreHandler( $transientStore );

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -13,36 +13,44 @@ class CookieStore implements StoreInterface
     const BASE_NAME = 'auth0_';
 
     /**
-     * Cookie base name, configurable on instantiation.
+     * Cookie base name.
+     * Use config key 'base_name' to set this during instantiation.
      *
      * @var string
      */
     protected $baseName;
 
     /**
-     * Cookie expiration, configurable on instantiation.
+     * Cookie expiration length.
+     * This will be added to current time or $this->now to set cookie expiration time.
+     * Use config key 'expiration' to set this during instantiation.
      *
      * @var integer
      */
     protected $expiration;
 
     /**
-     * SameSite attribute for all cookies.
+     * SameSite attribute for all cookies set with class instance.
+     * Must be one of None, Strict, Lax (default is no SameSite attribute).
+     * Use config key 'samesite' to set this during instantiation.
      *
-     * @var integer
+     * @var null|string
      */
     protected $sameSite;
 
     /**
      * Time to use as "now" in expiration calculations.
-     * Useful for testing.
+     * Used primarily for testing.
+     * Use config key 'now' to set this during instantiation.
      *
      * @var null|integer
      */
     protected $now;
 
     /**
-     * Support legacy browsers for SameSite=None
+     * Support legacy browsers for SameSite=None.
+     * This will set/get/delete a fallback cookie with no SameSite attribute if $this->sameSite is None.
+     * Use config key 'legacy_samesite_none' to set this during instantiation.
      *
      * @var boolean
      */
@@ -51,20 +59,19 @@ class CookieStore implements StoreInterface
     /**
      * CookieStore constructor.
      *
-     * @param array $options Set cookie options.
+     * @param array $options Cookie options. See class properties above for keys and types allowed.
      */
     public function __construct(array $options = [])
     {
         $this->baseName   = $options['base_name'] ?? self::BASE_NAME;
         $this->expiration = $options['expiration'] ?? 600;
 
-        $sameSite = 'Lax';
-        if (isset($options['samesite']) && is_string($options['samesite'])) {
+        if (! empty($options['samesite']) && is_string($options['samesite'])) {
             $sameSite = ucfirst($options['samesite']);
-        }
 
-        if (in_array($sameSite, ['None', 'Strict', 'Lax'])) {
-            $this->sameSite = $sameSite;
+            if (in_array($sameSite, ['None', 'Strict', 'Lax'])) {
+                $this->sameSite = $sameSite;
+            }
         }
 
         $this->now = $options['now'] ?? null;
@@ -84,7 +91,17 @@ class CookieStore implements StoreInterface
     {
         $key_name           = $this->getCookieName($key);
         $_COOKIE[$key_name] = $value;
-        $this->setCookie($key_name, $value);
+
+        if ($this->sameSite) {
+            $this->setCookieHeader($key_name, $value, $this->getExpTimecode());
+        } else {
+            $this->setCookie($key_name, $value, $this->getExpTimecode());
+        }
+
+        if ($this->legacySameSiteNone && 'None' === $this->sameSite) {
+            $_COOKIE['_'.$key_name] = $value;
+            $this->setCookie('_'.$key_name, $value, $this->getExpTimecode());
+        }
     }
 
     /**
@@ -99,7 +116,14 @@ class CookieStore implements StoreInterface
     public function get($key, $default = null)
     {
         $key_name = $this->getCookieName($key);
-        return $_COOKIE[$key_name] ?? $default;
+        $value    = $default;
+
+        // If we're handling legacy browsers, check for fallback value first.
+        if ($this->legacySameSiteNone) {
+            $value = $_COOKIE['_'.$key_name] ?? $value;
+        }
+
+        return $_COOKIE[$key_name] ?? $value;
     }
 
     /**
@@ -113,38 +137,43 @@ class CookieStore implements StoreInterface
     {
         $key_name = $this->getCookieName($key);
         unset($_COOKIE[$key_name]);
-        $this->setCookie( $key_name );
+        $this->setCookie( $key_name, '', 0 );
+
+        if ($this->legacySameSiteNone) {
+            unset($_COOKIE['_'.$key_name]);
+            $this->setCookie( '_'.$key_name, '', 0 );
+        }
     }
 
     /**
-     * @param $name
-     * @param $value
-     * @param $handleSameSite
+     * Build the header to use when setting SameSite cookies.
+     * Core setcookie() function does not handle SameSite before PHP 7.3.
+     *
+     * @param string  $name   Cookie name.
+     * @param string  $value  Cookie value.
+     * @param integer $expire Cookie expiration timecode.
      *
      * @return string
      */
-    public function getSetCookieHeader(string $name, string $value, $handleSameSite = true) : string
+    public function getSameSiteCookieHeader(string $name, string $value, int $expire) : string
     {
         $date = new \Datetime();
-        $date->setTimestamp($this->getExpTimecode());
-        $date->setTimezone(new \DateTimeZone('GMT'));
+        $date->setTimestamp($expire)
+            ->setTimezone(new \DateTimeZone('GMT'));
 
-        $header = sprintf(
-            '%s=%s; path=/; expires=%s; HttpOnly',
+        return sprintf(
+            'Set-Cookie: %s=%s; path=/; expires=%s; HttpOnly; SameSite=%s%s',
             $name,
             $value,
-            $date->format(\DateTime::COOKIE)
+            $date->format($date::COOKIE),
+            $this->sameSite,
+            'None' === $this->sameSite ? '; Secure' : ''
         );
-
-        if ($handleSameSite) {
-            $header .= '; SameSite=' . $this->sameSite;
-            $header .= 'None' === $this->sameSite ? '; Secure' : '';
-        }
-
-        return $header;
     }
 
     /**
+     * Get cookie expiration timecode to use.
+     *
      * @return integer
      */
     private function getExpTimecode() : int
@@ -153,26 +182,35 @@ class CookieStore implements StoreInterface
     }
 
     /**
-     * Set or delete a cookie.
+     * Wrapper around PHP core setcookie() function to assist with testing.
      *
-     * @param string $name  Cookie name to set.
-     * @param string $value Cookie value.
+     * @param string  $name   Complete cookie name to set.
+     * @param string  $value  Value of the cookie to set.
+     * @param integer $expire Expiration time in Unix timecode format.
      *
      * @return boolean
+     *
+     * @codeCoverageIgnore
      */
-    protected function setCookie(string $name, string $value = '') : bool
+    protected function setCookie(string $name, string $value, int $expire) : bool
     {
-        if (! $this->sameSite) {
-            return setcookie($name, $value, $this->getExpTimecode(), '/', '', false, true);
-        }
+        return setcookie($name, $value, $expire, '/', '', false, true);
+    }
 
-        header('Set-Cookie: '.$this->getSetCookieHeader($name, $value), false);
-
-        if ($this->legacySameSiteNone && 'None' === $this->sameSite) {
-            header('Set-Cookie: _'.$this->getSetCookieHeader($name, $value, false), false);
-        }
-
-        return true;
+    /**
+     * Wrapper around PHP core header() function to assist with testing.
+     *
+     * @param string  $name   Complete cookie name to set.
+     * @param string  $value  Value of the cookie to set.
+     * @param integer $expire Expiration time in Unix timecode format.
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected function setCookieHeader(string $name, string $value, int $expire) : void
+    {
+        header($this->getSameSiteCookieHeader($name, $value, $expire), false);
     }
 
     /**

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -4,6 +4,10 @@ namespace Auth0\SDK\Store;
 
 /**
  * This class provides a layer to persist user access using PHP Sessions.
+ *
+ * NOTE: If you are using this storage method for the transient_store option in the Auth0 class along with a
+ * response_mode of form_post, the session cookie MUST be set to SameSite=None and Secure using
+ * session_set_cookie_params() or another method. This combination will be enforced by browsers in early 2020.
  */
 class SessionStore implements StoreInterface
 {

--- a/tests/Store/CookieStoreTest.php
+++ b/tests/Store/CookieStoreTest.php
@@ -51,21 +51,8 @@ class CookieStoreTest extends TestCase
 
     public function testCustomBaseName()
     {
-        $store = new CookieStore('custom_base');
+        $store = new CookieStore(['base_name' => 'custom_base']);
         $this->assertEquals('custom_base_test_key', $store->getCookieName('test_key'));
-    }
-
-    public function testCustomExpiration()
-    {
-        $mockStore = $this->getMockBuilder(CookieStore::class)
-            ->setConstructorArgs([uniqid(), 1200])
-            ->setMethods(['setCookie'])
-            ->getMock();
-        $mockStore->expects($mockSpy = $this->any())->method('setCookie')->willReturn(true);
-        $mockStore->set(uniqid(), uniqid());
-
-        $setCookieParams = $mockSpy->getInvocations()[0]->getParameters();
-        $this->assertEquals(1200, $setCookieParams[2]);
     }
 
     public function testSet()
@@ -79,7 +66,6 @@ class CookieStoreTest extends TestCase
 
         $this->assertEquals('auth0__test_set_key', $setCookieParams[0]);
         $this->assertEquals('__test_set_value__', $setCookieParams[1]);
-        $this->assertEquals(600, $setCookieParams[2]);
     }
 
     public function testGet()
@@ -105,6 +91,38 @@ class CookieStoreTest extends TestCase
 
         $this->assertEquals('auth0__test_delete_key', $setCookieParams[0]);
         $this->assertEquals('', $setCookieParams[1]);
-        $this->assertEquals(0, $setCookieParams[2]);
+    }
+
+    public function testGetSetCookieHeaderDefault()
+    {
+        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0]);
+
+        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
+        $this->assertEquals(
+            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Lax',
+            $header
+        );
+    }
+
+    public function testGetSetCookieHeaderStrict()
+    {
+        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'strict']);
+
+        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
+        $this->assertEquals(
+            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Strict',
+            $header
+        );
+    }
+
+    public function testGetSetCookieHeaderNone()
+    {
+        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'none']);
+
+        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
+        $this->assertEquals(
+            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=None; Secure',
+            $header
+        );
     }
 }

--- a/tests/Store/CookieStoreTest.php
+++ b/tests/Store/CookieStoreTest.php
@@ -202,22 +202,26 @@ class CookieStoreTest extends TestCase
 
     public function testGetSetCookieHeaderStrict()
     {
-        $store = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'lax']);
+        $store  = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'lax']);
+        $method = new \ReflectionMethod(CookieStore::class, 'getSameSiteCookieHeader');
+        $method->setAccessible(true);
+        $header = $method->invokeArgs($store, ['__test_name_1__', '__test_value_1__', 303943620]);
 
-        $header = $store->getSameSiteCookieHeader('__test_name_1__', '__test_value_1__', 303943620);
         $this->assertEquals(
-            'Set-Cookie: __test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Lax',
+            'Set-Cookie: __test_name_1__=__test_value_1__; path=/; '.'expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Lax',
             $header
         );
     }
 
     public function testGetSetCookieHeaderNone()
     {
-        $store = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'none']);
+        $store  = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'none']);
+        $method = new \ReflectionMethod(CookieStore::class, 'getSameSiteCookieHeader');
+        $method->setAccessible(true);
+        $header = $method->invokeArgs($store, ['__test_name_2__', '__test_value_2__', 303943620]);
 
-        $header = $store->getSameSiteCookieHeader('__test_name_1__', '__test_value_1__', 303943620);
         $this->assertEquals(
-            'Set-Cookie: __test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=None; Secure',
+            'Set-Cookie: __test_name_2__=__test_value_2__; path=/; '.'expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=None; Secure',
             $header
         );
     }

--- a/tests/Store/CookieStoreTest.php
+++ b/tests/Store/CookieStoreTest.php
@@ -12,35 +12,40 @@ use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
 class CookieStoreTest extends TestCase
 {
 
-    /**
-     * Mock CookieStore instance to skip setcookie() call.
-     *
-     * @var CookieStore
-     */
-    public static $mockStore;
+    private static $mockSpyCookie;
 
-    /**
-     * Mock spy for calls to setCookie.
-     *
-     * @var AnyInvokedCount
-     */
-    public static $mockSpy;
-
-    /**
-     * Run before all tests in this suite.
-     */
-    public function setUp()
-    {
-        self::$mockStore = $this->getMockBuilder(CookieStore::class)->setMethods(['setCookie'])->getMock();
-        self::$mockStore->expects(self::$mockSpy = $this->any())->method('setCookie')->willReturn(true);
-    }
+    private static $mockSpyHeader;
 
     /**
      * Run after each test in this suite.
      */
     public function tearDown()
     {
-        $_COOKIE = [];
+        $_COOKIE             = [];
+        self::$mockSpyCookie = null;
+        self::$mockSpyHeader = null;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|CookieStore
+     */
+    public function getMock(array $args = [])
+    {
+        $mockStore = $this->getMockBuilder(CookieStore::class)
+            ->setConstructorArgs([$args])
+            ->setMethods(['setCookie','setCookieHeader'])
+            ->getMock();
+
+        $mockStore->expects(self::$mockSpyCookie = $this->any())
+            ->method('setCookie')
+            ->willReturn(true);
+
+        $mockStore->expects(self::$mockSpyHeader = $this->any())
+            ->method('setCookieHeader');
+
+        return $mockStore;
     }
 
     public function testGetCookieName()
@@ -53,75 +58,166 @@ class CookieStoreTest extends TestCase
     {
         $store = new CookieStore(['base_name' => 'custom_base']);
         $this->assertEquals('custom_base_test_key', $store->getCookieName('test_key'));
+
+        $store = new CookieStore(['base_name' => 'custom_base_']);
+        $this->assertEquals('custom_base__test_key', $store->getCookieName('test_key'));
     }
 
-    public function testSet()
+    public function testSetNoSameSite()
     {
-        self::$mockStore->set('test_set_key', '__test_set_value__');
+        $mockStore = $this->getMock(['now' => 1, 'expiration' => 1]);
+        $mockStore->set('test_set_key', '__test_set_value__');
 
         $this->assertEquals('__test_set_value__', $_COOKIE['auth0__test_set_key']);
-        $this->assertCount(1, (array) self::$mockSpy->getInvocations());
+        $this->assertArrayNotHasKey('_auth0__test_set_key', $_COOKIE);
 
-        $setCookieParams = self::$mockSpy->getInvocations()[0]->getParameters();
+        $this->assertCount(0, (array) self::$mockSpyHeader->getInvocations());
+        $this->assertCount(1, (array) self::$mockSpyCookie->getInvocations());
+
+        $setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
 
         $this->assertEquals('auth0__test_set_key', $setCookieParams[0]);
         $this->assertEquals('__test_set_value__', $setCookieParams[1]);
+        $this->assertEquals(2, $setCookieParams[2]);
+    }
+
+    public function testSetSameSiteNone()
+    {
+        $mockStore = $this->getMock(['now' => 10, 'expiration' => 10, 'samesite' => 'None']);
+        $mockStore->set('test_set_key', '__test_set_value__');
+
+        $this->assertEquals('__test_set_value__', $_COOKIE['auth0__test_set_key']);
+        $this->assertEquals('__test_set_value__', $_COOKIE['_auth0__test_set_key']);
+
+        $this->assertCount(1, (array) self::$mockSpyHeader->getInvocations());
+
+        $setHeaderParams = self::$mockSpyHeader->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('auth0__test_set_key', $setHeaderParams[0]);
+        $this->assertEquals('__test_set_value__', $setHeaderParams[1]);
+        $this->assertEquals(20, $setHeaderParams[2]);
+
+        $this->assertCount(1, (array) self::$mockSpyCookie->getInvocations());
+
+        $setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('_auth0__test_set_key', $setCookieParams[0]);
+        $this->assertEquals('__test_set_value__', $setCookieParams[1]);
+        $this->assertEquals(20, $setCookieParams[2]);
+    }
+
+    public function testSetSameSiteNoneNoLegacy()
+    {
+        $mockStore = $this->getMock(['legacy_samesite_none' => false, 'samesite' => 'None']);
+        $mockStore->set('test_set_key', '__test_set_value__');
+
+        $this->assertEquals('__test_set_value__', $_COOKIE['auth0__test_set_key']);
+        $this->assertArrayNotHasKey('_auth0__test_set_key', $_COOKIE);
+        $this->assertCount(0, (array) self::$mockSpyCookie->getInvocations());
+        $this->assertCount(1, (array) self::$mockSpyHeader->getInvocations());
+
+        $setCookieParams = self::$mockSpyHeader->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('auth0__test_set_key', $setCookieParams[0]);
+        $this->assertEquals('__test_set_value__', $setCookieParams[1]);
+        $this->assertGreaterThanOrEqual(time() + 600, $setCookieParams[2]);
     }
 
     public function testGet()
     {
-        $store                          = new CookieStore();
-        $_COOKIE['auth0__test_get_key'] = '__test_get_value__';
+        $store = new CookieStore();
+
+        $_COOKIE['auth0__test_get_key']  = '__test_get_value__';
+        $_COOKIE['_auth0__test_get_key'] = '__test_get_legacy_value__';
 
         $this->assertEquals('__test_get_value__', $store->get('test_get_key'));
         $this->assertEquals('__test_default_value__', $store->get('test_empty_key', '__test_default_value__'));
+
+        unset($_COOKIE['auth0__test_get_key']);
+        $this->assertEquals('__test_get_legacy_value__', $store->get('test_get_key'));
+    }
+
+    public function testGetNoLegacy()
+    {
+        $store = new CookieStore(['legacy_samesite_none' => false]);
+
+        $_COOKIE['auth0__test_get_key']  = '__test_get_value__';
+        $_COOKIE['_auth0__test_get_key'] = '__test_get_legacy_value__';
+
+        $this->assertEquals('__test_get_value__', $store->get('test_get_key'));
+        $this->assertEquals('__test_default_value__', $store->get('test_empty_key', '__test_default_value__'));
+
+        unset($_COOKIE['auth0__test_get_key']);
+        $this->assertNull($store->get('test_get_key'));
     }
 
     public function testDelete()
     {
-        $_COOKIE['auth0__test_delete_key'] = '__test_delete_value__';
+        $_COOKIE['auth0__test_delete_key']  = '__test_delete_value__';
+        $_COOKIE['_auth0__test_delete_key'] = '__test_delete_value__';
 
-        self::$mockStore->delete('test_delete_key');
+        $mockStore = $this->getMock();
+        $mockStore->delete('test_delete_key');
 
-        $this->assertNull(self::$mockStore->get('test_delete_key'));
+        $this->assertNull($mockStore->get('test_delete_key'));
         $this->assertArrayNotHasKey('auth0__test_delete_key', $_COOKIE);
-        $this->assertCount(1, (array) self::$mockSpy->getInvocations());
+        $this->assertArrayNotHasKey('_auth0__test_delete_key', $_COOKIE);
 
-        $setCookieParams = self::$mockSpy->getInvocations()[0]->getParameters();
+        $this->assertCount(0, (array) self::$mockSpyHeader->getInvocations());
+        $this->assertCount(2, (array) self::$mockSpyCookie->getInvocations());
+
+        $setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
 
         $this->assertEquals('auth0__test_delete_key', $setCookieParams[0]);
         $this->assertEquals('', $setCookieParams[1]);
+        $this->assertEquals(0, $setCookieParams[2]);
+
+        $setCookieParams = self::$mockSpyCookie->getInvocations()[1]->getParameters();
+
+        $this->assertEquals('_auth0__test_delete_key', $setCookieParams[0]);
+        $this->assertEquals('', $setCookieParams[1]);
+        $this->assertEquals(0, $setCookieParams[2]);
     }
 
-    public function testGetSetCookieHeaderDefault()
+    public function testDeleteNoLegacy()
     {
-        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0]);
+        $_COOKIE['auth0__test_delete_key']  = '__test_delete_value__';
+        $_COOKIE['_auth0__test_delete_key'] = '__test_delete_value__';
 
-        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
-        $this->assertEquals(
-            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Lax',
-            $header
-        );
+        $mockStore = $this->getMock(['legacy_samesite_none' => false]);
+        $mockStore->delete('test_delete_key');
+
+        $this->assertNull($mockStore->get('test_delete_key'));
+        $this->assertArrayNotHasKey('auth0__test_delete_key', $_COOKIE);
+        $this->assertArrayHasKey('_auth0__test_delete_key', $_COOKIE);
+
+        $this->assertCount(1, (array) self::$mockSpyCookie->getInvocations());
+
+        $setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+        $this->assertEquals('auth0__test_delete_key', $setCookieParams[0]);
+        $this->assertEquals('', $setCookieParams[1]);
+        $this->assertEquals(0, $setCookieParams[2]);
     }
 
     public function testGetSetCookieHeaderStrict()
     {
-        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'strict']);
+        $store = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'lax']);
 
-        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
+        $header = $store->getSameSiteCookieHeader('__test_name_1__', '__test_value_1__', 303943620);
         $this->assertEquals(
-            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Strict',
+            'Set-Cookie: __test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=Lax',
             $header
         );
     }
 
     public function testGetSetCookieHeaderNone()
     {
-        $store        = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'none']);
+        $store = new CookieStore(['now' => 303943620, 'expiration' => 0, 'samesite' => 'none']);
 
-        $header = $store->getSetCookieHeader('__test_name_1__', '__test_value_1__');
+        $header = $store->getSameSiteCookieHeader('__test_name_1__', '__test_value_1__', 303943620);
         $this->assertEquals(
-            '__test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=None; Secure',
+            'Set-Cookie: __test_name_1__=__test_value_1__; path=/; expires=Sunday, 19-Aug-1979 20:47:00 GMT; HttpOnly; SameSite=None; Secure',
             $header
         );
     }


### PR DESCRIPTION
### Changes

This PR addresses upcoming changes to SameSite cookie attributes early next year. For a complete explanation of what SameSite is and what's changing, please see the web.dev article below. 

This PR will:

- Set default cookie SameSite attribute to `Lax`
- Set cookie SameSite attribute for `form_post` response mode to `None` (with a legacy fallback)

### References

[Web.dev: SameSite cookies explained](https://web.dev/samesite-cookies-explained/)

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on PHP 7.1 and 7.2

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
