### PR TITLE
Move AuthorizationBearer to new namespace

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\API;
 
-use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
+use Auth0\SDK\API\Header\AuthorizationBearer;
 use Auth0\SDK\API\Header\ForwardedFor;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\Exception\ApiException;

--- a/src/API/Header/AuthorizationBearer.php
+++ b/src/API/Header/AuthorizationBearer.php
@@ -1,7 +1,5 @@
 <?php
-namespace Auth0\SDK\API\Header\Authorization;
-
-use Auth0\SDK\API\Header\Header;
+namespace Auth0\SDK\API\Header;
 
 class AuthorizationBearer extends Header
 {

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\API;
 
-use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
+use Auth0\SDK\API\Header\AuthorizationBearer;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\API\Management\Blacklists;
 use Auth0\SDK\API\Management\Clients;

--- a/tests/API/Header/HeaderTest.php
+++ b/tests/API/Header/HeaderTest.php
@@ -2,7 +2,7 @@
 
 namespace Auth0\Tests;
 
-use Auth0\SDK\API\Header\Authorization\AuthorizationBearer;
+use Auth0\SDK\API\Header\AuthorizationBearer;
 use Auth0\SDK\API\Header\ContentType;
 use Auth0\SDK\API\Header\ForwardedFor;
 use Auth0\SDK\API\Header\Header;


### PR DESCRIPTION
### Changes

Change `Auth0\SDK\API\Header\Authorization\AuthorizationBearer` to `Auth0\SDK\API\Header\AuthorizationBearer`

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used - `7.0.0-dev`
