### PR TITLE
fix: add missing options for renewTokens method

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -594,12 +594,18 @@ class Auth0
     /**
      * Renews the access token and ID token using an existing refresh token.
      * Scope "offline_access" must be declared in order to obtain refresh token for later token renewal.
-     *
+     * @param array $options Options for the token endpoint request.
+     *      - options.grant_type    Grant type to use; required.
+     *      - options.client_id     Application Client ID; required.
+     *      - options.client_secret Application Client Secret; required if token endpoint requires authentication.
+     *      - options.scope         Access token scope requested.
+     *      - options.audience      API audience identifier for access token.
+     * 
      * @throws CoreException If the Auth0 object does not have access token and refresh token
      * @throws ApiException If the Auth0 API did not renew access and ID token properly
      * @link   https://auth0.com/docs/tokens/refresh-token/current
      */
-    public function renewTokens()
+    public function renewTokens(array $options = [])
     {
         if (! $this->accessToken) {
             throw new CoreException('Can\'t renew the access token if there isn\'t one valid');
@@ -609,7 +615,7 @@ class Auth0
             throw new CoreException('Can\'t renew the access token if there isn\'t a refresh token available');
         }
 
-        $response = $this->authentication->refresh_token( $this->refreshToken );
+        $response = $this->authentication->refresh_token( $this->refreshToken, $options);
 
         if (empty($response['access_token']) || empty($response['id_token'])) {
             throw new ApiException('Token did not refresh correctly. Access or ID token not provided.');

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -594,12 +594,9 @@ class Auth0
     /**
      * Renews the access token and ID token using an existing refresh token.
      * Scope "offline_access" must be declared in order to obtain refresh token for later token renewal.
+     * 
      * @param array $options Options for the token endpoint request.
-     *      - options.grant_type    Grant type to use; required.
-     *      - options.client_id     Application Client ID; required.
-     *      - options.client_secret Application Client Secret; required if token endpoint requires authentication.
-     *      - options.scope         Access token scope requested.
-     *      - options.audience      API audience identifier for access token.
+     *      - options.scope         Access token scope requested; optional.
      * 
      * @throws CoreException If the Auth0 object does not have access token and refresh token
      * @throws ApiException If the Auth0 API did not renew access and ID token properly

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -594,10 +594,10 @@ class Auth0
     /**
      * Renews the access token and ID token using an existing refresh token.
      * Scope "offline_access" must be declared in order to obtain refresh token for later token renewal.
-     * 
+     *
      * @param array $options Options for the token endpoint request.
      *      - options.scope         Access token scope requested; optional.
-     * 
+     *
      * @throws CoreException If the Auth0 object does not have access token and refresh token
      * @throws ApiException If the Auth0 API did not renew access and ID token properly
      * @link   https://auth0.com/docs/tokens/refresh-token/current
@@ -612,7 +612,7 @@ class Auth0
             throw new CoreException('Can\'t renew the access token if there isn\'t a refresh token available');
         }
 
-        $response = $this->authentication->refresh_token( $this->refreshToken, $options);
+        $response = $this->authentication->refresh_token( $this->refreshToken, $options );
 
         if (empty($response['access_token']) || empty($response['id_token'])) {
             throw new ApiException('Token did not refresh correctly. Access or ID token not provided.');

--- a/src/Helpers/Cache/FileSystemCacheHandler.php
+++ b/src/Helpers/Cache/FileSystemCacheHandler.php
@@ -21,9 +21,9 @@ class FileSystemCacheHandler implements CacheHandler
         $this->tmp_dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.$temp_directory_prefix.DIRECTORY_SEPARATOR;
         if (! is_dir($this->tmp_dir)
             && ! @mkdir($this->tmp_dir, 0777, true)
-            && ! is_dir($this->tmp_dir) // If mkdir failed it means that another process created it in between
+            && ! is_dir($this->tmp_dir) // If mkdir failed it means that another process created it in between or the directory is not writeable
         ) {
-            throw new \RuntimeException("Cache Handler was not able to create directory '$this->tmp_dir'");
+            trigger_error("Cache Handler was not able to create directory '$this->tmp_dir'", E_USER_WARNING);
         }
     }
 


### PR DESCRIPTION
### Changes
This PR adds possibility to provide additional options to `renewTokens` method. This options (especially `scope` option) are necessary in situation when we add custom scope to `context.accessToken` and would like to renew tokens. Without providing proper scope (`openid`) after calling `renewTokens` method we got following error: 
```Token did not refresh correctly. Access or ID token not provided.```

### Example rule - add custom scope to accessToken

```js
function (user, context, callback) {
  var permissions = [
    'permission1',
    'permission2'
  ];
  
  const requestedScope = (
    (context.request.query && context.request.query.scope) || 
    (context.request.body && context.request.body.scope)
  );

  if(requestedScope) {
    const scopes = requestedScope.split(' ');
    
    if(scopes.indexOf('openid') !== -1) {
      permissions.push('openid');
    }
    
    if(scopes.indexOf('profile') !== -1) {
      permissions.push('profile');
    }
    
    if(scopes.indexOf('email') !== -1) {
      permissions.push('email');
    }
    
    if(scopes.indexOf('offline_access') !== -1) {
      permissions.push('offline_access');
    }
  }

  context.accessToken.scope = (context.accessToken.scope || []).concat(permissions);
  callback(null, user, context);
}
```

### References

**Relates to:** 
- https://github.com/auth0/auth0-PHP/pull/257/files - this PR provides missing part for this implementation

**May be somehow related to these issues**:
- https://community.auth0.com/t/idtoken-not-returned-when-additional-scopes-are-defined/10780
- https://community.auth0.com/t/id-token-missing-in-oath-token-response-when-rule-adds-custom-scope-to-context-accesstoken/28833/6

**

### Testing

- [ ] This change adds test coverage

- [x] This change has been tested on the latest version of PHP

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

- [ ] All existing and new tests complete without errors.

- [x] The correct base branch is being used.
