### PR TITLE
Add default scopes to Auth0 class

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -107,7 +107,7 @@ class Auth0
      *
      * @var string
      */
-    protected $scope;
+    protected $scope = 'openid profile email';
 
     /**
      * Auth0 Refresh Token

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -34,7 +34,6 @@ class Auth0Test extends \PHPUnit_Framework_TestCase
         'redirect_uri'  => '__test_redirect_uri__',
         'store' => false,
         'state_handler' => false,
-        'scope' => 'openid offline_access',
     ];
 
     /**
@@ -305,7 +304,7 @@ class Auth0Test extends \PHPUnit_Framework_TestCase
 
         $url_query = explode( '&', $parsed_url['query'] );
 
-        $this->assertContains( 'scope=openid%20offline_access', $url_query );
+        $this->assertContains( 'scope=openid%20profile%20email', $url_query );
         $this->assertContains( 'response_type=code', $url_query );
         $this->assertContains( 'redirect_uri=__test_redirect_uri__', $url_query );
         $this->assertContains( 'client_id=__test_client_id__', $url_query );


### PR DESCRIPTION
### Changes

Add default scopes of `"openid profile email"` to the `Auth0` class.

### References

[Feedback from Community post](https://community.auth0.com/t/php-crash-issue-when-reloading-link-the-following-day/34739)

### Testing

- [x] This change adds test coverage

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used - `master`
