### PR TITLE
Add deprecation notices for removals in v7 major release

### DIFF
--- a/src/API/Helpers/State/DummyStateHandler.php
+++ b/src/API/Helpers/State/DummyStateHandler.php
@@ -14,6 +14,8 @@ namespace Auth0\SDK\API\Helpers\State;
 /**
  * Dummy implementation of the StateHandler
  *
+ * @deprecated 5.7.0, no replacement provided.
+ *
  * @author Auth0
  */
 class DummyStateHandler implements StateHandler

--- a/src/API/Helpers/State/SessionStateHandler.php
+++ b/src/API/Helpers/State/SessionStateHandler.php
@@ -16,6 +16,8 @@ use Auth0\SDK\Store\StoreInterface;
 /**
  * Session based implementation of StateHandler.
  *
+ * @deprecated 5.7.0, replaced by Auth0\SDK\Helpers\TransientStoreHandler
+ *
  * @author Auth0
  */
 class SessionStateHandler implements StateHandler

--- a/src/API/Helpers/State/StateHandler.php
+++ b/src/API/Helpers/State/StateHandler.php
@@ -14,6 +14,8 @@ namespace Auth0\SDK\API\Helpers\State;
 /**
  * This interface must be implemented by state handlers.
  *
+ * @deprecated 5.7.0, replaced by Auth0\SDK\Helpers\TransientStoreHandler
+ *
  * @author Auth0
  */
 interface StateHandler

--- a/src/Helpers/Cache/CacheHandler.php
+++ b/src/Helpers/Cache/CacheHandler.php
@@ -2,6 +2,9 @@
 
 namespace Auth0\SDK\Helpers\Cache;
 
+/**
+ * @deprecated 5.7.0, switching to Psr\SimpleCache\CacheInterface in 7.0.0
+ */
 interface CacheHandler
 {
 

--- a/src/Helpers/Cache/FileSystemCacheHandler.php
+++ b/src/Helpers/Cache/FileSystemCacheHandler.php
@@ -2,6 +2,9 @@
 
 namespace Auth0\SDK\Helpers\Cache;
 
+/**
+ * @deprecated 5.7.0, use a Psr\SimpleCache\CacheInterface in 7.0.0.
+ */
 class FileSystemCacheHandler implements CacheHandler
 {
 

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -13,6 +13,8 @@ use Firebase\JWT\JWT;
  * Class JWTVerifier.
  * Used to validate JWTs issued by Auth0.
  *
+ * @deprecated 5.7.0, replacement available in upcoming 7.0.0: Auth0\SDK\Helpers\Tokens\IdTokenVerifier
+ *
  * @package Auth0\SDK
  */
 class JWTVerifier

--- a/src/Store/EmptyStore.php
+++ b/src/Store/EmptyStore.php
@@ -17,6 +17,8 @@ namespace Auth0\SDK\Store;
  * This class is a mockup store, that discards the values, its a way of saying no store.
  *
  * @author Auth0
+ *
+ * @deprecated 5.7.0, no replacement provided.
  */
 class EmptyStore implements StoreInterface
 {

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -37,7 +37,7 @@ class SessionStore implements StoreInterface
      * SessionStore constructor.
      *
      * @param string  $base_name      Session base name.
-     * @param integer $cookie_expires Session expiration in seconds; default is 1 week.
+     * @param integer $cookie_expires Session expiration in seconds; default is 1 week - @deprecated 5.7.0
      */
     public function __construct($base_name = self::BASE_NAME, $cookie_expires = self::COOKIE_EXPIRES)
     {


### PR DESCRIPTION
### Changes

Deprecation notices for everything being removed in v7.

- Deprecate `DummyStateHandler`
- Deprecate `SessionStateHandler`
- Deprecate `StateHandler`
- Deprecate `CacheHandler`
- Deprecate `FileSystemCacheHandler`
- Deprecate `JWTVerifier`
- Deprecate `EmptyStore`
- Deprecate `$cookie_expires` parameter in `SessionStore` constructor

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used - `master` for v5
