### PR TITLE
Remove future iat check

### DIFF
--- a/src/Helpers/Tokens/IdTokenVerifier.php
+++ b/src/Helpers/Tokens/IdTokenVerifier.php
@@ -166,15 +166,6 @@ final class IdTokenVerifier
             throw new InvalidTokenException('Issued At (iat) claim must be a number present in the ID token');
         }
 
-        $issuedTime = $tokenIat - $leeway;
-        if ($now < $issuedTime) {
-            throw new InvalidTokenException( sprintf(
-                'Issued At (iat) claim error in the ID token; current time (%d) is before issued at time (%d)',
-                $now,
-                $issuedTime
-            ) );
-        }
-
         /*
          * Nonce check
          */

--- a/tests/Helpers/Tokens/IdTokenVerifierTest.php
+++ b/tests/Helpers/Tokens/IdTokenVerifierTest.php
@@ -263,29 +263,6 @@ class IdTokenVerifierTest extends TestCase
         $this->assertEquals('Issued At (iat) claim must be a number present in the ID token', $error_msg);
     }
 
-    public function testThatTokenIatInTheFutureFails()
-    {
-        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
-        $builder   = SymmetricVerifierTest::getTokenBuilder()
-            ->issuedBy('__test_iss__')
-            ->permittedFor('__test_aud__')
-            ->withClaim('exp', 20000)
-            ->withClaim('iat', 200000);
-        $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
-        $error_msg = 'No exception caught';
-
-        try {
-            $verifier->verify($token, ['time' => 20000, 'leeway' => 20]);
-        } catch (InvalidTokenException $e) {
-            $error_msg = $e->getMessage();
-        }
-
-        $this->assertEquals(
-            'Issued At (iat) claim error in the ID token; current time (20000) is before issued at time (199980)',
-            $error_msg
-        );
-    }
-
     public function testThatTokenWithoutNonceFails()
     {
         $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));


### PR DESCRIPTION
### Changes

Remove `iat` claim value check for ID token validation; continue to check for presence.

### Testing

- [x] This modifies test coverage
- [x] This change was created in PHP 7.2

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
