### PR TITLE
Add types for StoreInterface and implementors; add back EmptyStore

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -17,6 +17,7 @@ use Auth0\SDK\Helpers\Tokens\AsymmetricVerifier;
 use Auth0\SDK\Helpers\Tokens\SymmetricVerifier;
 use Auth0\SDK\Helpers\TransientStoreHandler;
 use Auth0\SDK\Store\CookieStore;
+use Auth0\SDK\Store\EmptyStore;
 use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Store\StoreInterface;
 use Auth0\SDK\API\Authentication;
@@ -135,7 +136,7 @@ class Auth0
     /**
      * Storage engine for persistence
      *
-     * @var null|StoreInterface
+     * @var StoreInterface
      */
     protected $store;
 
@@ -294,7 +295,10 @@ class Auth0
         }
 
         $this->store = $config['store'] ?? null;
-        if ($this->persistantMap && ! $this->store instanceof StoreInterface) {
+        if (empty($this->persistantMap)) {
+            // No need for storage, nothing to persist.
+            $this->store = new EmptyStore();
+        } else if (! $this->store instanceof StoreInterface) {
             // Need to have some kind of storage if user data needs to be persisted.
             $this->store = new SessionStore();
         }

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 namespace Auth0\SDK\Store;
 
 /**
+ * Class CookieStore.
  * This class provides a layer to persist transient auth data using cookies.
+ *
+ * @package Auth0\SDK\Store
  */
 class CookieStore implements StoreInterface
 {
@@ -93,7 +96,7 @@ class CookieStore implements StoreInterface
      *
      * @return void
      */
-    public function set($key, $value)
+    public function set(string $key, $value) : void
     {
         $key_name           = $this->getCookieName($key);
         $_COOKIE[$key_name] = $value;
@@ -121,7 +124,7 @@ class CookieStore implements StoreInterface
      *
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, $default = null)
     {
         $key_name = $this->getCookieName($key);
         $value    = $default;
@@ -141,7 +144,7 @@ class CookieStore implements StoreInterface
      *
      * @return void
      */
-    public function delete($key)
+    public function delete(string $key) : void
     {
         $key_name = $this->getCookieName($key);
         unset($_COOKIE[$key_name]);
@@ -175,12 +178,12 @@ class CookieStore implements StoreInterface
         $illegalCharsMsg = ",; \\t\\r\\n\\013\\014";
 
         if (strpbrk($name, $illegalChars) != null) {
-            trigger_error("Cookie names cannot contain any of the following '{$illegalCharsMsg}'", E_USER_WARNING);
+            trigger_error("Cookie names cannot contain any of the following '".$illegalCharsMsg."'", E_USER_WARNING);
             return '';
         }
 
         if (strpbrk($value, $illegalChars) != null) {
-            trigger_error("Cookie values cannot contain any of the following '{$illegalCharsMsg}'", E_USER_WARNING);
+            trigger_error("Cookie values cannot contain any of the following '".$illegalCharsMsg."'", E_USER_WARNING);
             return '';
         }
 

--- a/src/Store/EmptyStore.php
+++ b/src/Store/EmptyStore.php
@@ -4,38 +4,46 @@ declare(strict_types=1);
 namespace Auth0\SDK\Store;
 
 /**
- * Interface StoreInterface
+ * Class EmptyStore.
+ * Used to fulfill an interface without providing actual storage.
  *
  * @package Auth0\SDK\Store
  */
-interface StoreInterface
+class EmptyStore implements StoreInterface
 {
     /**
-     * Set a value on the store
+     * Do nothing.
      *
      * @param string $key   Key to set.
      * @param mixed  $value Value to set.
      *
      * @return void
      */
-    public function set(string $key, $value);
+    public function set(string $key, $value) : void
+    {
+    }
 
     /**
-     * Get a value from the store by a given key.
+     * Return the default.
      *
      * @param string      $key     Key to get.
      * @param null|string $default Return value if key not found.
      *
      * @return mixed
      */
-    public function get(string $key, $default = null);
+    public function get(string $key, $default = null)
+    {
+        return $default;
+    }
 
     /**
-     * Remove a value from the store
+     * Do nothing.
      *
      * @param string $key Key to delete.
      *
      * @return void
      */
-    public function delete(string $key);
+    public function delete(string $key) : void
+    {
+    }
 }

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -1,13 +1,17 @@
 <?php
+declare(strict_types=1);
 
 namespace Auth0\SDK\Store;
 
 /**
- * This class provides a layer to persist user access using PHP Sessions.
+ * Class SessionStore
+ * This class provides a layer to persist data using PHP Sessions.
  *
  * NOTE: If you are using this storage method for the transient_store option in the Auth0 class along with a
  * response_mode of form_post, the session cookie MUST be set to SameSite=None and Secure using
  * session_set_cookie_params() or another method. This combination will be enforced by browsers in early 2020.
+ *
+ * @package Auth0\SDK\Store
  */
 class SessionStore implements StoreInterface
 {
@@ -39,7 +43,7 @@ class SessionStore implements StoreInterface
      *
      * @return void
      */
-    private function initSession()
+    private function initSession() : void
     {
         if (! session_id()) {
             session_start();
@@ -54,7 +58,7 @@ class SessionStore implements StoreInterface
      *
      * @return void
      */
-    public function set($key, $value)
+    public function set(string $key, $value) : void
     {
         $this->initSession();
         $key_name            = $this->getSessionKeyName($key);
@@ -70,7 +74,7 @@ class SessionStore implements StoreInterface
      *
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, $default = null)
     {
         $this->initSession();
         $key_name = $this->getSessionKeyName($key);
@@ -89,7 +93,7 @@ class SessionStore implements StoreInterface
      *
      * @return void
      */
-    public function delete($key)
+    public function delete(string $key) : void
     {
         $this->initSession();
         $key_name = $this->getSessionKeyName($key);
@@ -103,7 +107,7 @@ class SessionStore implements StoreInterface
      *
      * @return string
      */
-    public function getSessionKeyName($key)
+    public function getSessionKeyName(string $key) : string
     {
         $key_name = $key;
         if (! empty( $this->session_base_name )) {


### PR DESCRIPTION
### Changes

- Add types to `StoreInterface` and implementors
- Add back `EmptyStore` for use when there is no persistence

### Testing

- [x] This change adds test coverage

### Checklist

- [x] All existing and new tests complete without errors.
- [x] The correct base branch is being used.
