### PR TITLE
Add Client ID to verification email method

### DIFF
--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -58,17 +58,28 @@ class Jobs extends GenericResource
     }
 
     /**
+     * Create a verification email job.
+     * Required scope: "update:users"
      *
-     * @param  string $user_id
+     * @param string $user_id User ID of the user to send the verification email to.
+     * @param array  $params  Array of optional parameters to add.
+     *        - client_id: Client ID of the requesting application.
+     *
      * @return mixed
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
      */
-    public function sendVerificationEmail($user_id)
+    public function sendVerificationEmail($user_id, array $params = [])
     {
+        $body = [ 'user_id' => $user_id ];
+
+        if (! empty( $params['client_id'] )) {
+            $body['client_id'] = $params['client_id'];
+        }
+
         return $this->apiClient->method('post')
-        ->addPath('jobs', 'verification-email')
-        ->withBody(json_encode([
-            'user_id' => $user_id
-        ]))
-        ->call();
+            ->addPath('jobs', 'verification-email')
+            ->withBody(json_encode($body))
+            ->call();
     }
 }

--- a/tests/API/Management/JobsTest.php
+++ b/tests/API/Management/JobsTest.php
@@ -135,7 +135,7 @@ class JobsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->jobs()->sendVerificationEmail( '__test_user_id__' );
+        $api->call()->jobs()->sendVerificationEmail( '__test_user_id__', [ 'client_id' => '__test_client_id__' ] );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/jobs/verification-email', $api->getHistoryUrl() );
@@ -144,6 +144,8 @@ class JobsTest extends ApiTests
         $body = $api->getHistoryBody();
         $this->assertArrayHasKey( 'user_id', $body );
         $this->assertEquals( '__test_user_id__', $body['user_id'] );
+        $this->assertArrayHasKey( 'client_id', $body );
+        $this->assertEquals( '__test_client_id__', $body['client_id'] );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );


### PR DESCRIPTION
### Description

Add optional `client_id` key to body sent to create a verification email job. 

### References

- [API v2 docs](https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email)
- Internal: ESD-4060

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
