### PR TITLE
Add signing key rotation and custom JWKS URI support

### DIFF
--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -109,7 +109,7 @@ class RequestBuilder
     public function __construct(array $config)
     {
         $this->method        = $config['method'];
-        $this->domain        = $config['domain'];
+        $this->domain        = $config['domain'] ?? '';
         $this->basePath      = $config['basePath'] ?? '';
         $this->guzzleOptions = $config['guzzleOptions'] ?? [];
         $this->headers       = $config['headers'] ?? [];

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -656,7 +656,7 @@ class Auth0
         $idTokenIss  = 'https://'.$this->domain.'/';
         $sigVerifier = null;
         if ('RS256' === $this->idTokenAlg) {
-            $jwksHttpOptions = array_merge( [ 'jwks_uri' => $this->jwksUri ], $this->guzzleOptions );
+            $jwksHttpOptions = array_merge( $this->guzzleOptions, [ 'base_uri' => $this->jwksUri ] );
             $jwksFetcher     = new JWKFetcher($this->cacheHandler, $jwksHttpOptions);
             $sigVerifier     = new AsymmetricVerifier($jwksFetcher);
         } else if ('HS256' === $this->idTokenAlg) {

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -16,6 +16,12 @@ use Psr\SimpleCache\CacheInterface;
  */
 class JWKFetcher
 {
+    /**
+     * How long should the cache persist? Set to 10 minutes.
+     *
+     * @see https://www.php-fig.org/psr/psr-16/#12-definitions
+     */
+    const CACHE_TTL = 600;
 
     /**
      * Cache handler or null for no caching.
@@ -29,22 +35,31 @@ class JWKFetcher
      *
      * @var array
      */
-    private $guzzleOptions;
+    private $httpOptions;
+
+    /**
+     * JWKS URI to use, set in $httpOptions['jwks_uri'].
+     *
+     * @var array
+     */
+    private $jwksUri;
 
     /**
      * JWKFetcher constructor.
      *
-     * @param CacheInterface|null $cache         Cache handler or null for no caching.
-     * @param array               $guzzleOptions Options for the Guzzle HTTP client.
+     * @param CacheInterface|null $cache      Cache handler or null for no caching.
+     * @param array               $httOptions HTTP options, including Guzzle options.
      */
-    public function __construct(CacheInterface $cache = null, array $guzzleOptions = [])
+    public function __construct(CacheInterface $cache = null, array $httOptions = [])
     {
         if ($cache === null) {
             $cache = new NoCacheHandler();
         }
 
-        $this->cache         = $cache;
-        $this->guzzleOptions = $guzzleOptions;
+        $this->cache       = $cache;
+        $this->httpOptions = $httOptions;
+        $this->jwksUri     = $this->httpOptions['jwks_uri'] ?? null;
+        unset( $this->httpOptions['jwks_uri'] );
     }
 
     /**
@@ -63,16 +78,42 @@ class JWKFetcher
     }
 
     /**
+     * Get a specific kid from a JWKS.
+     *
+     * @param string      $kid     Key ID to get.
+     * @param string|null $jwksUri JWKS URI to use, or fallback on class-level one.
+     *
+     * @return mixed|null
+     */
+    public function getKey(string $kid, string $jwksUri = null)
+    {
+        $jwksUri = $jwksUri ?? $this->jwksUri;
+        $keys    = $this->getKeys( $jwksUri );
+
+        if (! empty( $keys ) && empty( $keys[$kid] )) {
+            $keys = $this->getKeys( $jwksUri, false );
+        }
+
+        return $keys[$kid] ?? null;
+    }
+
+    /**
      * Gets an array of keys from the JWKS as kid => x5c.
      *
-     * @param string $jwks_url Full URL to the JWKS.
+     * @param string  $jwks_url  Full URL to the JWKS.
+     * @param boolean $use_cache Set to false to skip cache check; default true to use caching.
      *
      * @return array
      */
-    public function getKeys(string $jwks_url) : array
+    public function getKeys(string $jwks_url = null, bool $use_cache = true) : array
     {
+        $jwks_url = $jwks_url ?? $this->jwksUri;
+        if (empty( $jwks_url )) {
+            return [];
+        }
+
         $cache_key = md5($jwks_url);
-        $keys      = $this->cache->get($cache_key);
+        $keys      = $use_cache ? $this->cache->get($cache_key) : [];
         if (is_array($keys) && ! empty($keys)) {
             return $keys;
         }
@@ -92,7 +133,7 @@ class JWKFetcher
             $keys[$key['kid']] = $this->convertCertToPem( $key['x5c'][0] );
         }
 
-        $this->cache->set($cache_key, $keys);
+        $this->cache->set($cache_key, $keys, self::CACHE_TTL);
         return $keys;
     }
 
@@ -111,7 +152,7 @@ class JWKFetcher
         $request = new RequestBuilder([
             'domain' => $jwks_url,
             'method' => 'GET',
-            'guzzleOptions' => $this->guzzleOptions
+            'guzzleOptions' => $this->httpOptions
         ]);
         return $request->call();
     }

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -35,31 +35,22 @@ class JWKFetcher
      *
      * @var array
      */
-    private $httpOptions;
-
-    /**
-     * JWKS URI to use, set in $httpOptions['jwks_uri'].
-     *
-     * @var array
-     */
-    private $jwksUri;
+    private $guzzleOptions;
 
     /**
      * JWKFetcher constructor.
      *
-     * @param CacheInterface|null $cache      Cache handler or null for no caching.
-     * @param array               $httOptions HTTP options, including Guzzle options.
+     * @param CacheInterface|null $cache         Cache handler or null for no caching.
+     * @param array               $guzzleOptions Guzzle HTTP options.
      */
-    public function __construct(CacheInterface $cache = null, array $httOptions = [])
+    public function __construct(CacheInterface $cache = null, array $guzzleOptions = [])
     {
         if ($cache === null) {
             $cache = new NoCacheHandler();
         }
 
-        $this->cache       = $cache;
-        $this->httpOptions = $httOptions;
-        $this->jwksUri     = $this->httpOptions['jwks_uri'] ?? null;
-        unset( $this->httpOptions['jwks_uri'] );
+        $this->cache         = $cache;
+        $this->guzzleOptions = $guzzleOptions;
     }
 
     /**
@@ -106,7 +97,7 @@ class JWKFetcher
      */
     public function getKeys(string $jwks_url = null, bool $use_cache = true) : array
     {
-        $jwks_url = $jwks_url ?? $this->jwksUri;
+        $jwks_url = $jwks_url ?? $this->guzzleOptions['base_uri'] ?? '';
         if (empty( $jwks_url )) {
             return [];
         }
@@ -148,11 +139,13 @@ class JWKFetcher
      */
     protected function requestJwks(string $jwks_url) : array
     {
+        $options = array_merge( $this->guzzleOptions, [ 'base_uri' => $jwks_url ] );
+
         $request = new RequestBuilder([
-            'domain' => $jwks_url,
             'method' => 'GET',
-            'guzzleOptions' => $this->httpOptions
+            'guzzleOptions' => $options,
         ]);
+
         return $request->call();
     }
 }

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -87,8 +87,7 @@ class JWKFetcher
      */
     public function getKey(string $kid, string $jwksUri = null)
     {
-        $jwksUri = $jwksUri ?? $this->jwksUri;
-        $keys    = $this->getKeys( $jwksUri );
+        $keys = $this->getKeys( $jwksUri );
 
         if (! empty( $keys ) && empty( $keys[$kid] )) {
             $keys = $this->getKeys( $jwksUri, false );
@@ -112,10 +111,10 @@ class JWKFetcher
             return [];
         }
 
-        $cache_key = md5($jwks_url);
-        $keys      = $use_cache ? $this->cache->get($cache_key) : [];
-        if (is_array($keys) && ! empty($keys)) {
-            return $keys;
+        $cache_key    = md5($jwks_url);
+        $cached_value = $use_cache ? $this->cache->get($cache_key) : null;
+        if (! empty($cached_value) && is_array($cached_value)) {
+            return $cached_value;
         }
 
         $jwks = $this->requestJwks($jwks_url);

--- a/src/Helpers/Tokens/AsymmetricVerifier.php
+++ b/src/Helpers/Tokens/AsymmetricVerifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\Helpers\Tokens;
 
 use Auth0\SDK\Exception\InvalidTokenException;
+use Auth0\SDK\Helpers\JWKFetcher;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Rsa\Sha256 as RsSigner;
 use Lcobucci\JWT\Token;
@@ -17,18 +18,18 @@ final class AsymmetricVerifier extends SignatureVerifier
 {
 
     /**
-     * JWKS array with kid as keys, PEM cert as values.
+     * Array of kid => keys or a JWKFetcher instance.
      *
-     * @var array
+     * @var array|JWKFetcher
      */
     private $jwks;
 
     /**
      * JwksVerifier constructor.
      *
-     * @param array $jwks JWKS to use.
+     * @param array|JWKFetcher $jwks Array of kid => keys or a JWKFetcher instance.
      */
-    public function __construct(array $jwks)
+    public function __construct($jwks)
     {
         $this->jwks = $jwks;
         parent::__construct('RS256');
@@ -45,11 +46,12 @@ final class AsymmetricVerifier extends SignatureVerifier
      */
     protected function checkSignature(Token $token) : bool
     {
-        $tokenKid = $token->getHeader('kid', false);
-        if (! array_key_exists($tokenKid, $this->jwks)) {
+        $tokenKid   = $token->getHeader('kid', false);
+        $signingKey = is_array( $this->jwks ) ? ($this->jwks[$tokenKid] ?? null) : $this->jwks->getKey( $tokenKid );
+        if (! $signingKey) {
             throw new InvalidTokenException( 'ID token key ID "'.$tokenKid.'" was not found in the JWKS' );
         }
 
-        return $token->verify(new RsSigner(), new Key($this->jwks[$tokenKid]));
+        return $token->verify(new RsSigner(), new Key($signingKey));
     }
 }

--- a/tests/Helpers/JWKFetcherTest.php
+++ b/tests/Helpers/JWKFetcherTest.php
@@ -108,19 +108,17 @@ class JWKFetcherTest extends TestCase
         $jwks_body = '{"keys":[{"kid":"__kid_1__","x5c":["__x5c_1__"]}]}';
         $jwks = new MockJwks(
             [ new Response( 200, [ 'Content-Type' => 'application/json' ], $jwks_body ) ],
-            [
-                'cache' => new ArrayCachePool(),
-                'jwks_uri' => '__test_custom_uri__',
-            ]
+            [ 'cache' => new ArrayCachePool() ],
+            [ 'base_uri' => '__test_jwks_url__' ]
         );
 
         $jwks->call()->getKeys();
-        $this->assertEquals( '__test_custom_uri__', $jwks->getHistoryUrl() );
+        $this->assertEquals( '__test_jwks_url__', $jwks->getHistoryUrl() );
     }
 
     public function testThatGetKeyGetsSpecificKid() {
         $cache = new ArrayCachePool();
-        $jwks = new JWKFetcher( $cache, [ 'jwks_uri' => '__test_jwks_url__' ] );
+        $jwks = new JWKFetcher( $cache, [ 'base_uri' => '__test_jwks_url__' ] );
         $cache->set(md5('__test_jwks_url__'), ['__test_kid_1__' => '__test_x5c_1__']);
         $this->assertEquals('__test_x5c_1__', $jwks->getKey('__test_kid_1__'));
     }
@@ -131,10 +129,8 @@ class JWKFetcherTest extends TestCase
         $jwks_body = '{"keys":[{"kid":"__test_kid_2__","x5c":["__test_x5c_2__"]}]}';
         $jwks = new MockJwks(
             [ new Response( 200, [ 'Content-Type' => 'application/json' ], $jwks_body ) ],
-            [
-                'cache' => $cache,
-                'jwks_uri' => '__test_jwks_url__',
-            ]
+            [ 'cache' => $cache ],
+            [ 'base_uri' => '__test_jwks_url__' ]
         );
 
         $cache->set(md5('__test_jwks_url__'), ['__test_kid_1__' => '__test_x5c_1__']);
@@ -142,8 +138,7 @@ class JWKFetcherTest extends TestCase
         $this->assertContains('__test_x5c_2__', $jwks->call()->getKey('__test_kid_2__'));
     }
 
-    public function testThatEmptyUrlReturnsEmptyKeys()
-    {
+    public function testThatEmptyUrlReturnsEmptyKeys() {
         $jwks_formatted_1 = (new JWKFetcher())->getKeys();
         $this->assertEquals( [], $jwks_formatted_1 );
     }

--- a/tests/Helpers/MockJwks.php
+++ b/tests/Helpers/MockJwks.php
@@ -25,7 +25,10 @@ class MockJwks extends MockApi
      */
     public function setClient(array $guzzleOptions, array $config = [])
     {
-        $cache        = isset( $config['cache'] ) && $config['cache'] instanceof CacheInterface ? $config['cache'] : null;
+        $cache = isset( $config['cache'] ) && $config['cache'] instanceof CacheInterface ? $config['cache'] : null;
+
+        $guzzleOptions['jwks_uri'] = isset( $config['jwks_uri'] ) ? $config['jwks_uri'] : null;
+
         $this->client = new JWKFetcher( $cache, $guzzleOptions );
     }
 }

--- a/tests/Helpers/MockJwks.php
+++ b/tests/Helpers/MockJwks.php
@@ -26,9 +26,6 @@ class MockJwks extends MockApi
     public function setClient(array $guzzleOptions, array $config = [])
     {
         $cache = isset( $config['cache'] ) && $config['cache'] instanceof CacheInterface ? $config['cache'] : null;
-
-        $guzzleOptions['jwks_uri'] = isset( $config['jwks_uri'] ) ? $config['jwks_uri'] : null;
-
         $this->client = new JWKFetcher( $cache, $guzzleOptions );
     }
 }

--- a/tests/Helpers/Tokens/AsymmetricVerifierTest.php
+++ b/tests/Helpers/Tokens/AsymmetricVerifierTest.php
@@ -111,8 +111,9 @@ class AsymmetricVerifierTest extends TestCase
         return (new Builder())->withClaim('sub', '__test_sub__')->withHeader('kid', '__test_kid__');
     }
 
-    public static function getToken(string $rsa_private_key, Builder $builder = null) : Token
+    public static function getToken(string $rsa_private_key = null, Builder $builder = null) : Token
     {
+        $rsa_private_key = $rsa_private_key ?? self::getRsaKeys()['private'];
         $builder = $builder ?? self::getTokenBuilder();
         return $builder->getToken( new RsSigner(), new Key( $rsa_private_key ));
     }

--- a/tests/MockApi.php
+++ b/tests/MockApi.php
@@ -43,10 +43,10 @@ abstract class MockApi
      *
      * @param array $responses Array of GuzzleHttp\Psr7\Response objects.
      * @param array $config Additional optional configuration needed for mocked class.
+     * @param array $guzzleOptions Additional Guzzle HTTP options.
      */
-    public function __construct(array $responses = [], array $config = [])
+    public function __construct(array $responses = [], array $config = [], array $guzzleOptions = [])
     {
-        $guzzleOptions = [];
         if (count( $responses )) {
             $mock    = new MockHandler($responses);
             $handler = HandlerStack::create($mock);


### PR DESCRIPTION
### Description

- Adds cache retry if token kid is not found in cached JWKS
- Adds custom JWKS URL
- Adds cache TTL of 10 minutes

### References

Closes #417, #426 

[PSR-16 cache interface](https://www.php-fig.org/psr/psr-16/#12-definitions)

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
