### PR TITLE
Add TokenVerifier for non-OIDC-compliant JWTs

### DIFF
--- a/src/Helpers/Tokens/IdTokenVerifier.php
+++ b/src/Helpers/Tokens/IdTokenVerifier.php
@@ -12,11 +12,22 @@ use Auth0\SDK\Exception\InvalidTokenException;
  */
 final class IdTokenVerifier extends TokenVerifier
 {
-
     /**
      * Verifies and decodes an OIDC-compliant ID token.
      *
-     * {@inheritdoc}
+     * @param string $token   Raw JWT string.
+     * @param array  $options Options to adjust the verification. Can be:
+     *      - "nonce" to check the nonce contained in the token (recommended).
+     *      - "max_age" to check the auth_time of the token.
+     *      - "leeway" clock tolerance in seconds for the current check only. See $leeway above for default.
+     *
+     * @return array
+     *
+     * @throws InvalidTokenException Thrown if:
+     *      - ID token is missing (expected but none provided)
+     *      - Signature cannot be verified
+     *      - Token algorithm is not supported
+     *      - Any claim-based test fails
      */
     public function verify(string $token, array $options = []) : array
     {

--- a/src/Helpers/Tokens/IdTokenVerifier.php
+++ b/src/Helpers/Tokens/IdTokenVerifier.php
@@ -6,138 +6,29 @@ namespace Auth0\SDK\Helpers\Tokens;
 use Auth0\SDK\Exception\InvalidTokenException;
 
 /**
- * Class IdTokenVerifier
+ * Class IdTokenVerifier, an OIDC-compliant ID token verifier.
  *
- * @package Auth0\SDK\Helpers
+ * @package Auth0\SDK\Helpers\Tokens
  */
-final class IdTokenVerifier
+final class IdTokenVerifier extends TokenVerifier
 {
-
-    /**
-     * Token issuer base URL expected.
-     *
-     * @var string
-     */
-    private $issuer;
-
-    /**
-     * Token audience expected.
-     *
-     * @var string
-     */
-    private $audience;
-
-    /**
-     * Token signature verifier.
-     *
-     * @var SignatureVerifier
-     */
-    private $verifier;
-
-    /**
-     * Clock tolerance for time-base token checks in seconds.
-     *
-     * @var integer
-     */
-    private $leeway = 60;
-
-    /**
-     * IdTokenVerifier constructor.
-     *
-     * @param string            $issuer   Token issuer base URL expected.
-     * @param string            $audience Token audience expected.
-     * @param SignatureVerifier $verifier Token signature verifier.
-     */
-    public function __construct(string $issuer, string $audience, SignatureVerifier $verifier)
-    {
-        $this->issuer   = $issuer;
-        $this->audience = $audience;
-        $this->verifier = $verifier;
-    }
-
-    /**
-     * Set a new leeway time for all token checks.
-     *
-     * @param integer $newLeeway New leeway time for class instance.
-     *
-     * @return void
-     */
-    public function setLeeway(int $newLeeway) : void
-    {
-        $this->leeway = $newLeeway;
-    }
 
     /**
      * Verifies and decodes an OIDC-compliant ID token.
      *
-     * @param string $token   Raw JWT string.
-     * @param array  $options Options to adjust the verification. Can be:
-     *      - "nonce" to check the nonce contained in the token (recommended).
-     *      - "max_age" to check the auth_time of the token.
-     *      - "time" Unix timestamp to use as the current time for exp, iat, and auth_time checks. Used for testing.
-     *      - "leeway" clock tolerance in seconds for the current check only. See $leeway above for default.
-     *
-     * @return array
-     *
-     * @throws InvalidTokenException Thrown if:
-     *      - ID token is missing (expected but none provided)
-     *      - Signature cannot be verified
-     *      - Token algorithm is not supported
-     *      - Any claim-based test fails
+     * {@inheritdoc}
      */
     public function verify(string $token, array $options = []) : array
     {
-        if (empty($token)) {
-            throw new InvalidTokenException('ID token is required but missing');
-        }
-
-        $verifiedToken = $this->verifier->verifyAndDecode( $token );
-
-        /*
-         * Issuer checks
-         */
-
-        $tokenIss = $verifiedToken->getClaim('iss', false);
-        if (! $tokenIss || ! is_string($tokenIss)) {
-            throw new InvalidTokenException('Issuer (iss) claim must be a string present in the ID token');
-        }
-
-        if ($tokenIss !== $this->issuer) {
-            throw new InvalidTokenException( sprintf(
-                'Issuer (iss) claim mismatch in the ID token; expected "%s", found "%s"', $this->issuer, $tokenIss
-            ) );
-        }
+        $verifiedToken = parent::verify($token, $options);
 
         /*
          * Subject check
          */
 
-        $tokenSub = $verifiedToken->getClaim('sub', false);
+        $tokenSub = $verifiedToken['sub'] ?? null;
         if (! $tokenSub || ! is_string($tokenSub)) {
             throw new InvalidTokenException('Subject (sub) claim must be a string present in the ID token');
-        }
-
-        /*
-         * Audience checks
-         */
-
-        $tokenAud = $verifiedToken->getClaim('aud', false);
-        if (! $tokenAud || (! is_string($tokenAud) && ! is_array($tokenAud))) {
-            throw new InvalidTokenException(
-                'Audience (aud) claim must be a string or array of strings present in the ID token'
-            );
-        }
-
-        if (is_array($tokenAud) && ! in_array($this->audience, $tokenAud)) {
-            throw new InvalidTokenException( sprintf(
-                'Audience (aud) claim mismatch in the ID token; expected "%s" was not one of "%s"',
-                $this->audience,
-                implode(', ', $tokenAud)
-            ) );
-        } else if (is_string($tokenAud) && $tokenAud !== $this->audience) {
-            throw new InvalidTokenException( sprintf(
-                'Audience (aud) claim mismatch in the ID token; expected "%s", found "%s"', $this->audience, $tokenAud
-            ) );
         }
 
         /*
@@ -147,21 +38,7 @@ final class IdTokenVerifier
         $now    = $options['time'] ?? time();
         $leeway = $options['leeway'] ?? $this->leeway;
 
-        $tokenExp = $verifiedToken->getClaim('exp', false);
-        if (! $tokenExp || ! is_int($tokenExp)) {
-            throw new InvalidTokenException('Expiration Time (exp) claim must be a number present in the ID token');
-        }
-
-        $expireTime = $tokenExp + $leeway;
-        if ($now > $expireTime) {
-            throw new InvalidTokenException( sprintf(
-                'Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)',
-                $now,
-                $expireTime
-            ) );
-        }
-
-        $tokenIat = $verifiedToken->getClaim('iat', false);
+        $tokenIat = $verifiedToken['iat'] ?? null;
         if (! $tokenIat || ! is_int($tokenIat)) {
             throw new InvalidTokenException('Issued At (iat) claim must be a number present in the ID token');
         }
@@ -171,7 +48,8 @@ final class IdTokenVerifier
          */
 
         if (! empty($options['nonce'])) {
-            $tokenNonce = $verifiedToken->getClaim('nonce', false);
+            $tokenNonce = $verifiedToken['nonce'] ?? null;
+
             if (! $tokenNonce || ! is_string($tokenNonce)) {
                 throw new InvalidTokenException('Nonce (nonce) claim must be a string present in the ID token');
             }
@@ -188,9 +66,11 @@ final class IdTokenVerifier
         /*
          * Authorized party check
          */
+        $tokenAud = $verifiedToken['aud'] ?? null;
 
         if (is_array($tokenAud) && count($tokenAud) > 1) {
-            $tokenAzp = $verifiedToken->getClaim('azp', false);
+            $tokenAzp = $verifiedToken['azp'] ?? null;
+
             if (! $tokenAzp || ! is_string($tokenAzp)) {
                 throw new InvalidTokenException(
                     'Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values'
@@ -211,7 +91,8 @@ final class IdTokenVerifier
          */
 
         if (! empty($options['max_age'])) {
-            $tokenAuthTime = $verifiedToken->getClaim('auth_time', false);
+            $tokenAuthTime = $verifiedToken['auth_time'] ?? null;
+
             if (! $tokenAuthTime || ! is_int($tokenAuthTime)) {
                 throw new InvalidTokenException(
                     'Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified'
@@ -229,11 +110,6 @@ final class IdTokenVerifier
             }
         }
 
-        $profile = [];
-        foreach ($verifiedToken->getClaims() as $claim => $value) {
-            $profile[$claim] = $value->getValue();
-        }
-
-        return $profile;
+        return $verifiedToken;
     }
 }

--- a/src/Helpers/Tokens/TokenVerifier.php
+++ b/src/Helpers/Tokens/TokenVerifier.php
@@ -69,19 +69,16 @@ class TokenVerifier
     }
 
     /**
-     * Verifies and decodes an JWT.
+     * Verifies and decodes a JWT.
      *
      * @param string $token   Raw JWT string.
      * @param array  $options Options to adjust the verification. Can be:
-     *      - "nonce" to check the nonce contained in the token (recommended).
-     *      - "max_age" to check the auth_time of the token.
-     *      - "time" Unix timestamp to use as the current time for exp, iat, and auth_time checks. Used for testing.
      *      - "leeway" clock tolerance in seconds for the current check only. See $leeway above for default.
      *
      * @return array
      *
      * @throws InvalidTokenException Thrown if:
-     *      - ID token is missing (expected but none provided)
+     *      - Token is missing (expected but none provided)
      *      - Signature cannot be verified
      *      - Token algorithm is not supported
      *      - Any claim-based test fails

--- a/src/Helpers/Tokens/TokenVerifier.php
+++ b/src/Helpers/Tokens/TokenVerifier.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace Auth0\SDK\Helpers\Tokens;
+
+use Auth0\SDK\Exception\InvalidTokenException;
+
+/**
+ * Class TokenVerifier, a generic JWT verifier.
+ * For verifying OIDC-compliant ID tokens, use Auth0\SDK\Helpers\Tokens\IdTokenVerifier
+ *
+ * @package Auth0\SDK\Helpers\Tokens
+ */
+class TokenVerifier
+{
+
+    /**
+     * Token issuer base URL expected.
+     *
+     * @var string
+     */
+    protected $issuer;
+
+    /**
+     * Token audience expected.
+     *
+     * @var string
+     */
+    protected $audience;
+
+    /**
+     * Token signature verifier.
+     *
+     * @var SignatureVerifier
+     */
+    private $verifier;
+
+    /**
+     * Clock tolerance for time-base token checks in seconds.
+     *
+     * @var integer
+     */
+    protected $leeway = 60;
+
+    /**
+     * TokenVerifier constructor.
+     *
+     * @param string            $issuer   Token issuer base URL expected.
+     * @param string            $audience Token audience expected.
+     * @param SignatureVerifier $verifier Token signature verifier.
+     */
+    public function __construct(string $issuer, string $audience, SignatureVerifier $verifier)
+    {
+        $this->issuer   = $issuer;
+        $this->audience = $audience;
+        $this->verifier = $verifier;
+    }
+
+    /**
+     * Set a new leeway time for all token checks.
+     *
+     * @param integer $newLeeway New leeway time for class instance.
+     *
+     * @return void
+     */
+    public function setLeeway(int $newLeeway) : void
+    {
+        $this->leeway = $newLeeway;
+    }
+
+    /**
+     * Verifies and decodes an JWT.
+     *
+     * @param string $token   Raw JWT string.
+     * @param array  $options Options to adjust the verification. Can be:
+     *      - "nonce" to check the nonce contained in the token (recommended).
+     *      - "max_age" to check the auth_time of the token.
+     *      - "time" Unix timestamp to use as the current time for exp, iat, and auth_time checks. Used for testing.
+     *      - "leeway" clock tolerance in seconds for the current check only. See $leeway above for default.
+     *
+     * @return array
+     *
+     * @throws InvalidTokenException Thrown if:
+     *      - ID token is missing (expected but none provided)
+     *      - Signature cannot be verified
+     *      - Token algorithm is not supported
+     *      - Any claim-based test fails
+     */
+    public function verify(string $token, array $options = []) : array
+    {
+        if (empty($token)) {
+            throw new InvalidTokenException('ID token is required but missing');
+        }
+
+        $verifiedToken = $this->verifier->verifyAndDecode( $token );
+
+        /*
+         * Issuer checks
+         */
+
+        $tokenIss = $verifiedToken->getClaim('iss', false);
+        if (! $tokenIss || ! is_string($tokenIss)) {
+            throw new InvalidTokenException('Issuer (iss) claim must be a string present in the ID token');
+        }
+
+        if ($tokenIss !== $this->issuer) {
+            throw new InvalidTokenException( sprintf(
+                'Issuer (iss) claim mismatch in the ID token; expected "%s", found "%s"', $this->issuer, $tokenIss
+            ) );
+        }
+
+        /*
+         * Audience checks
+         */
+
+        $tokenAud = $verifiedToken->getClaim('aud', false);
+        if (! $tokenAud || (! is_string($tokenAud) && ! is_array($tokenAud))) {
+            throw new InvalidTokenException(
+                'Audience (aud) claim must be a string or array of strings present in the ID token'
+            );
+        }
+
+        if (is_array($tokenAud) && ! in_array($this->audience, $tokenAud)) {
+            throw new InvalidTokenException( sprintf(
+                'Audience (aud) claim mismatch in the ID token; expected "%s" was not one of "%s"',
+                $this->audience,
+                implode(', ', $tokenAud)
+            ) );
+        } else if (is_string($tokenAud) && $tokenAud !== $this->audience) {
+            throw new InvalidTokenException( sprintf(
+                'Audience (aud) claim mismatch in the ID token; expected "%s", found "%s"', $this->audience, $tokenAud
+            ) );
+        }
+
+        /*
+         * Clock checks
+         */
+
+        $now    = $options['time'] ?? time();
+        $leeway = $options['leeway'] ?? $this->leeway;
+
+        $tokenExp = $verifiedToken->getClaim('exp', false);
+        if (! $tokenExp || ! is_int($tokenExp)) {
+            throw new InvalidTokenException('Expiration Time (exp) claim must be a number present in the ID token');
+        }
+
+        $expireTime = $tokenExp + $leeway;
+        if ($now > $expireTime) {
+            throw new InvalidTokenException( sprintf(
+                'Expiration Time (exp) claim error in the ID token; current time (%d) is after expiration time (%d)',
+                $now,
+                $expireTime
+            ) );
+        }
+
+        $profile = [];
+        foreach ($verifiedToken->getClaims() as $claim => $value) {
+            $profile[$claim] = $value->getValue();
+        }
+
+        return $profile;
+    }
+}

--- a/tests/Helpers/Tokens/IdTokenVerifierTest.php
+++ b/tests/Helpers/Tokens/IdTokenVerifierTest.php
@@ -11,7 +11,7 @@ class IdTokenVerifierTest extends TestCase
 {
     public function testThatEmptyTokenFails()
     {
-        $verifier  = new IdTokenVerifier( uniqid(), uniqid(), new SymmetricVerifier( uniqid() ) );
+        $verifier  = new IdTokenVerifier( '__test_iss__', '__test_aud__', new SymmetricVerifier( uniqid() ) );
         $error_msg = 'No exception caught';
 
         try {
@@ -25,7 +25,7 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenMissingIssuerFails()
     {
-        $verifier  = new IdTokenVerifier(uniqid(), uniqid(), new SymmetricVerifier('__test_secret__'));
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
         $token     = SymmetricVerifierTest::getToken();
         $error_msg = 'No exception caught';
 
@@ -40,7 +40,7 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenWithNonStringIssuerFails()
     {
-        $verifier  = new IdTokenVerifier(uniqid(), uniqid(), new SymmetricVerifier('__test_secret__'));
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
         $builder   = (new Builder())->withClaim('iss', 123);
         $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
         $error_msg = 'No exception caught';
@@ -56,7 +56,7 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenWithInvalidIssuerFails()
     {
-        $verifier  = new IdTokenVerifier('__test_iss__', uniqid(), new SymmetricVerifier('__test_secret__'));
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
         $builder   = (new Builder())->issuedBy('__invalid_issuer__');
         $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
         $error_msg = 'No exception caught';
@@ -75,8 +75,11 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenWithMissingSubFails()
     {
-        $verifier  = new IdTokenVerifier('__test_iss__', uniqid(), new SymmetricVerifier('__test_secret__'));
-        $builder   = (new Builder())->issuedBy('__test_iss__');
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+        $builder   = (new Builder())
+            ->issuedBy('__test_iss__')
+            ->permittedFor('__test_aud__')
+            ->withClaim('exp', time() + 1000);
         $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
         $error_msg = 'No exception caught';
 
@@ -91,8 +94,12 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenWithNonStringSubFails()
     {
-        $verifier  = new IdTokenVerifier('__test_iss__', uniqid(), new SymmetricVerifier('__test_secret__'));
-        $builder   = (new Builder())->issuedBy('__test_iss__')->withClaim('sub', 123);
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+        $builder   = SymmetricVerifierTest::getTokenBuilder()
+            ->withClaim('sub', 123)
+            ->issuedBy('__test_iss__')
+            ->permittedFor('__test_aud__')
+            ->withClaim('exp', time() + 1000);
         $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
         $error_msg = 'No exception caught';
 
@@ -107,7 +114,7 @@ class IdTokenVerifierTest extends TestCase
 
     public function testThatTokenWithMissingAudFails()
     {
-        $verifier  = new IdTokenVerifier('__test_iss__', uniqid(), new SymmetricVerifier('__test_secret__'));
+        $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
         $builder   = SymmetricVerifierTest::getTokenBuilder()->issuedBy('__test_iss__');
         $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
         $error_msg = 'No exception caught';


### PR DESCRIPTION
### Description

Adds a generic JWT verifier class, `TokenVerifier`, which `IdTokenVerifier` now extends. 

### References

- Closes #422 
- [Validating JWT-formatted access tokens](https://auth0.com/docs/tokens/guides/validate-access-tokens#custom-api-access-tokens)
- [More about JWTs](https://jwt.io/introduction/)

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

**Note:** documentation will need to come after v7.1.0 of this library is released. PR:

https://github.com/auth0/docs/pull/8765

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
