### PR TITLE
/passwordless/start accepts client_secret now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.phar
 composer.lock
 phpunit.xml
 vendor
+.idea
 .env
 .phpcs.xml
 phpcs.xml

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -257,12 +257,14 @@ class Authentication
      * @param string $email      Email address to use.
      * @param string $type       Use null or "link" to send a link, use "code" to send a verification code.
      * @param array  $authParams Link parameters (like scope, redirect_uri, protocol, response_type) to modify.
+     * @param null|string $auth0_forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array
      *
      * @link https://auth0.com/docs/api/authentication#get-code-or-link
      */
-    public function email_passwordless_start(string $email, string $type, array $authParams = []) : array
+    public function email_passwordless_start(string $email, string $type, array $authParams = [],
+        ?string $auth0_forwarded_for = null) : array
     {
         $data = [
             'client_id' => $this->client_id,
@@ -279,22 +281,28 @@ class Authentication
             $data['authParams'] = $authParams;
         }
 
-        return $this->apiClient->method('post')
-        ->addPath('passwordless', 'start')
-        ->withBody(json_encode($data))
-        ->call();
+        $request = $this->apiClient->method('post')
+            ->addPath('passwordless', 'start')
+            ->withBody(json_encode($data));
+
+        if (isset($auth0_forwarded_for)) {
+            $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
+        }
+
+        $request->call();
     }
 
     /**
      * Start passwordless login process for SMS.
      *
      * @param string $phone_number Phone number to use.
+     * @param null|string $auth0_forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array
      *
      * @link https://auth0.com/docs/api/authentication#get-code-or-link
      */
-    public function sms_passwordless_start(string $phone_number) : array
+    public function sms_passwordless_start(string $phone_number, ?string $auth0_forwarded_for = null) : array
     {
         $data = [
             'client_id' => $this->client_id,
@@ -306,10 +314,15 @@ class Authentication
             $data['client_secret'] = $this->client_secret;
         }
 
-        return $this->apiClient->method('post')
-        ->addPath('passwordless', 'start')
-        ->withBody(json_encode($data))
-        ->call();
+        $request = $this->apiClient->method('post')
+            ->addPath('passwordless', 'start')
+            ->withBody(json_encode($data));
+
+        if (isset($auth0_forwarded_for)) {
+            $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
+        }
+
+        $request->call();
     }
 
     /**

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -271,6 +271,10 @@ class Authentication
             'email' => $email,
         ];
 
+        if (! empty($this->client_secret)) {
+            $data['client_secret'] = $this->client_secret;
+        }
+
         if (! empty($authParams)) {
             $data['authParams'] = $authParams;
         }
@@ -297,6 +301,10 @@ class Authentication
             'connection' => 'sms',
             'phone_number' => $phone_number,
         ];
+
+        if (! empty($this->client_secret)) {
+            $data['client_secret'] = $this->client_secret;
+        }
 
         return $this->apiClient->method('post')
         ->addPath('passwordless', 'start')

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -254,17 +254,21 @@ class Authentication
     /**
      * Start passwordless login process for email
      *
-     * @param string $email      Email address to use.
-     * @param string $type       Use null or "link" to send a link, use "code" to send a verification code.
-     * @param array  $authParams Link parameters (like scope, redirect_uri, protocol, response_type) to modify.
+     * @param string      $email         Email address to use.
+     * @param string      $type          Use null or "link" to send a link, use "code" to send a verification code.
+     * @param array       $authParams    Link parameters (like scope, redirect_uri, protocol, response_type) to modify.
      * @param null|string $forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array
      *
      * @link https://auth0.com/docs/api/authentication#get-code-or-link
      */
-    public function email_passwordless_start(string $email, string $type, array $authParams = [],
-        ?string $forwarded_for = null) : array
+    public function email_passwordless_start(
+        string $email,
+        string $type,
+        array $authParams = [],
+        ?string $forwarded_for = null
+    ) : array
     {
         $data = [
             'client_id' => $this->client_id,
@@ -295,7 +299,7 @@ class Authentication
     /**
      * Start passwordless login process for SMS.
      *
-     * @param string $phone_number Phone number to use.
+     * @param string      $phone_number  Phone number to use.
      * @param null|string $forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -289,7 +289,7 @@ class Authentication
             $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
         }
 
-        $request->call();
+        return $request->call();
     }
 
     /**
@@ -322,7 +322,7 @@ class Authentication
             $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
         }
 
-        $request->call();
+        return $request->call();
     }
 
     /**

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -257,14 +257,14 @@ class Authentication
      * @param string $email      Email address to use.
      * @param string $type       Use null or "link" to send a link, use "code" to send a verification code.
      * @param array  $authParams Link parameters (like scope, redirect_uri, protocol, response_type) to modify.
-     * @param null|string $auth0_forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
+     * @param null|string $forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array
      *
      * @link https://auth0.com/docs/api/authentication#get-code-or-link
      */
     public function email_passwordless_start(string $email, string $type, array $authParams = [],
-        ?string $auth0_forwarded_for = null) : array
+        ?string $forwarded_for = null) : array
     {
         $data = [
             'client_id' => $this->client_id,
@@ -285,8 +285,8 @@ class Authentication
             ->addPath('passwordless', 'start')
             ->withBody(json_encode($data));
 
-        if (isset($auth0_forwarded_for)) {
-            $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
+        if (! empty($forwarded_for)) {
+            $request->withHeader( new ForwardedFor( $forwarded_for ) );
         }
 
         return $request->call();
@@ -296,13 +296,13 @@ class Authentication
      * Start passwordless login process for SMS.
      *
      * @param string $phone_number Phone number to use.
-     * @param null|string $auth0_forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
+     * @param null|string $forwarded_for (optional) source IP address. requires Trust Token Endpoint IP Header
      *
      * @return array
      *
      * @link https://auth0.com/docs/api/authentication#get-code-or-link
      */
-    public function sms_passwordless_start(string $phone_number, ?string $auth0_forwarded_for = null) : array
+    public function sms_passwordless_start(string $phone_number, ?string $forwarded_for = null) : array
     {
         $data = [
             'client_id' => $this->client_id,
@@ -318,8 +318,8 @@ class Authentication
             ->addPath('passwordless', 'start')
             ->withBody(json_encode($data));
 
-        if (isset($auth0_forwarded_for)) {
-            $request->withHeader( new ForwardedFor( $auth0_forwarded_for ) );
+        if (! empty($forwarded_for)) {
+            $request->withHeader( new ForwardedFor( $forwarded_for ) );
         }
 
         return $request->call();

--- a/tests/API/Authentication/PasswordlessTest.php
+++ b/tests/API/Authentication/PasswordlessTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace Auth0\Tests\API\Authentication;
+
+use Auth0\Tests\API\ApiTests;
+use Auth0\Tests\Traits\ErrorHelpers;
+
+use Auth0\SDK\API\Authentication;
+use Auth0\SDK\Exception\ApiException;
+use Auth0\SDK\API\Helpers\InformationHeaders;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Class PasswordlessTest
+ * Tests the Authentication API class, specifically passwordless grants.
+ *
+ * @package Auth0\Tests\API\Authentication
+ */
+class PasswordlessTest extends ApiTests
+{
+
+    use ErrorHelpers;
+
+    /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $expectedTelemetry;
+
+    /**
+     * Runs before test suite starts.
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData->setCorePackage();
+        self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatEmailPasswordlessRequestIsCorrect()
+    {
+        $api = new MockAuthenticationApi( [
+            new Response( 200, [ 'Content-Type' => 'application/json' ], '{}' )
+        ] );
+
+        $api->call()->email_passwordless_start('__test_email__', '__test_type__', ['__test_key__' => '__test_value__']);
+
+        $this->assertEquals( 'https://test-domain.auth0.com/passwordless/start', $api->getHistoryUrl() );
+
+        $request_headers = $api->getHistoryHeaders();
+        $this->assertArrayHasKey( 'Auth0-Client', $request_headers );
+        $this->assertEquals( self::$expectedTelemetry, $request_headers['Auth0-Client'][0] );
+        $this->assertArrayHasKey( 'Content-Type', $request_headers );
+        $this->assertEquals( 'application/json', $request_headers['Content-Type'][0] );
+
+        $request_body = $api->getHistoryBody();
+
+        $this->assertCount(6, $request_body);
+
+        $this->assertArrayHasKey('email', $request_body);
+        $this->assertEquals( '__test_email__', $request_body['email'] );
+
+        $this->assertArrayHasKey('send', $request_body);
+        $this->assertEquals( '__test_type__', $request_body['send'] );
+
+        $this->assertArrayHasKey('connection', $request_body);
+        $this->assertEquals( 'email', $request_body['connection'] );
+
+        $this->assertArrayHasKey('client_id', $request_body);
+        $this->assertEquals( '__test_client_id__', $request_body['client_id'] );
+
+        $this->assertArrayHasKey('client_secret', $request_body);
+        $this->assertEquals( '__test_client_secret__', $request_body['client_secret'] );
+
+        $this->assertArrayHasKey('authParams', $request_body);
+        $this->assertArrayHasKey('__test_key__', $request_body['authParams']);
+        $this->assertEquals( '__test_value__', $request_body['authParams']['__test_key__'] );
+    }
+
+    public function testThatDefaultSmsPasswordlessRequestIsCorrect()
+    {
+        $api = new MockAuthenticationApi( [
+            new Response( 200, [ 'Content-Type' => 'application/json' ], '{}' )
+        ] );
+
+        $api->call()->sms_passwordless_start('__test_number__');
+
+        $this->assertEquals( 'https://test-domain.auth0.com/passwordless/start', $api->getHistoryUrl() );
+
+        $request_headers = $api->getHistoryHeaders();
+        $this->assertArrayHasKey( 'Auth0-Client', $request_headers );
+        $this->assertEquals( self::$expectedTelemetry, $request_headers['Auth0-Client'][0] );
+        $this->assertArrayHasKey( 'Content-Type', $request_headers );
+        $this->assertEquals( 'application/json', $request_headers['Content-Type'][0] );
+
+        $request_body = $api->getHistoryBody();
+
+        $this->assertCount(4, $request_body);
+
+        $this->assertArrayHasKey('phone_number', $request_body);
+        $this->assertEquals( '__test_number__', $request_body['phone_number'] );
+
+        $this->assertArrayHasKey('connection', $request_body);
+        $this->assertEquals( 'sms', $request_body['connection'] );
+
+        $this->assertArrayHasKey('client_id', $request_body);
+        $this->assertEquals( '__test_client_id__', $request_body['client_id'] );
+
+        $this->assertArrayHasKey('client_secret', $request_body);
+        $this->assertEquals( '__test_client_secret__', $request_body['client_secret'] );
+    }
+}


### PR DESCRIPTION
### Description

Purpose of this PR is to add two new functionality to passwordless API when used in server-side:

1. client_secret
2. auth0_forward_for IP

This is not a breaking change. Both parameters are optional. 

### References

- [Auth0 Passwordless API](https://auth0.com/docs/connections/passwordless/reference/relevant-api-endpoints)
- [Authentication API passwordless docs](https://auth0.com/docs/api/authentication#passwordless)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
