### PR TITLE
Allow no nonce option

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -564,10 +564,6 @@ class Auth0
      */
     public function renewTokens(array $options = [])
     {
-        if (! $this->accessToken) {
-            throw new CoreException('Can\'t renew the access token if there isn\'t one valid');
-        }
-
         if (! $this->refreshToken) {
             throw new CoreException('Can\'t renew the access token if there isn\'t a refresh token available');
         }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -570,8 +570,8 @@ class Auth0
 
         $response = $this->authentication->refresh_token( $this->refreshToken, $options );
 
-        if (empty($response['access_token']) || empty($response['id_token'])) {
-            throw new ApiException('Token did not refresh correctly. Access or ID token not provided.');
+        if (empty($response['access_token'])) {
+            throw new ApiException('Token did not refresh correctly. Access token not returned.');
         }
 
         $this->setAccessToken($response['access_token']);
@@ -662,7 +662,6 @@ class Auth0
 
         $verifierOptions = $verifierOptions + [
             'leeway' => $this->idTokenLeeway,
-        // Set a custom leeway if one was passed to the constructor.
             'max_age' => $this->transientHandler->getOnce('max_age') ?? $this->maxAge,
             self::TRANSIENT_NONCE_KEY => $this->transientHandler->getOnce(self::TRANSIENT_NONCE_KEY)
         ];

--- a/src/Helpers/TransientStoreHandler.php
+++ b/src/Helpers/TransientStoreHandler.php
@@ -58,6 +58,18 @@ class TransientStoreHandler
     }
 
     /**
+     * Check if a key has a stored value or not.
+     *
+     * @param string $key Key to check.
+     *
+     * @return boolean
+     */
+    public function isset(string $key) : bool
+    {
+        return ! is_null($this->store->get($key));
+    }
+
+    /**
      * Get a value and delete it from storage.
      *
      * @param string $key Key to get and delete.

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -90,6 +90,34 @@ class Auth0Test extends TestCase
      * @throws ApiException
      * @throws CoreException
      */
+    public function testThatExchangeFailsWithNoStoredNonce()
+    {
+        $id_token      = self::getIdToken();
+        $response_body = '{"access_token":"1.2.3","id_token":"'.$id_token.'","refresh_token":"4.5.6"}';
+
+        $mock = new MockHandler( [ new Response( 200, self::$headers, $response_body ) ] );
+
+        $add_config               = [
+            'skip_userinfo' => true,
+            'id_token_alg' => 'HS256',
+            'guzzle_options' => [
+                'handler' => HandlerStack::create($mock)
+            ]
+        ];
+        $auth0                    = new Auth0( self::$baseConfig + $add_config );
+        $_GET['code']             = uniqid();
+        $_GET['state']            = '__test_state__';
+        $_SESSION['auth0__state'] = '__test_state__';
+
+        $this->expectExceptionMessage('Nonce value not found in application store');
+        $auth0->exchange();
+    }
+    /**
+     * Test that the exchanges succeeds when there is both and access token and an ID token present.
+     *
+     * @throws ApiException
+     * @throws CoreException
+     */
     public function testThatExchangeSucceedsWithIdToken()
     {
         $id_token      = self::getIdToken();

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -294,7 +294,7 @@ class Auth0Test extends TestCase
 
         $mock = new MockHandler( [
             // Code exchange response.
-            new Response( 200, self::$headers, '{"access_token":"1.2.3","refresh_token":"2.3.4"}' ),
+            new Response( 200, self::$headers, '{"access_token":"1.2.3","refresh_token":"2.3.4","id_token":"'.$id_token.'"}' ),
             // Refresh token response.
             new Response( 200, self::$headers, '{"access_token":"__test_access_token__","id_token":"'.$id_token.'"}' ),
         ] );
@@ -315,6 +315,10 @@ class Auth0Test extends TestCase
         $_SESSION['auth0__state'] = '__test_state__';
 
         $this->assertTrue( $auth0->exchange() );
+
+        $this->assertArrayNotHasKey('auth0__nonce', $_SESSION);
+        $this->assertArrayNotHasKey('auth0__state', $_SESSION);
+
         $auth0->renewTokens(['scope' => 'openid']);
 
         $this->assertEquals( '__test_access_token__', $auth0->getAccessToken() );

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -261,15 +261,13 @@ class Auth0Test extends TestCase
      * @throws ApiException Should not be thrown in this test.
      * @throws CoreException Should not be thrown in this test.
      */
-    public function testThatRenewTokensFailsIfNoAccessOrIdTokenReturned()
+    public function testThatRenewTokensFailsIfNoAccessTokenReturned()
     {
         $mock = new MockHandler( [
             // Code exchange response.
             new Response( 200, self::$headers, '{"access_token":"1.2.3","refresh_token":"2.3.4"}' ),
-            // Refresh token response without ID token.
-            new Response( 200, self::$headers, '{"access_token":"1.2.3"}' ),
             // Refresh token response without access token.
-            new Response( 200, self::$headers, '{"id_token":"1.2.3"}' ),
+            new Response( 200, self::$headers, '{}' ),
         ] );
 
         $add_config = [
@@ -285,28 +283,8 @@ class Auth0Test extends TestCase
 
         $this->assertTrue( $auth0->exchange() );
 
-        try {
-            $caught_exception = false;
-            $auth0->renewTokens();
-        } catch (ApiException $e) {
-            $caught_exception = $this->errorHasString(
-                $e,
-                'Token did not refresh correctly. Access or ID token not provided' );
-        }
-
-        $this->assertTrue( $caught_exception );
-
-        // Run the same method again to get next queued response without an access token.
-        try {
-            $caught_exception = false;
-            $auth0->renewTokens();
-        } catch (ApiException $e) {
-            $caught_exception = $this->errorHasString(
-                $e,
-                'Token did not refresh correctly. Access or ID token not provided' );
-        }
-
-        $this->assertTrue( $caught_exception );
+        $this->expectExceptionMessage('Token did not refresh correctly. Access token not returned.');
+        $auth0->renewTokens();
     }
 
     /**

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -548,27 +548,6 @@ class Auth0Test extends TestCase
     /**
      * @throws CoreException
      */
-    public function testThatEmptyApplicationNonceFailsIdTokenValidation()
-    {
-        $custom_config = self::$baseConfig + ['id_token_alg' => 'HS256'];
-        $auth0         = new Auth0( $custom_config );
-        $id_token      = self::getIdToken();
-
-        $this->assertArrayNotHasKey('auth0__nonce', $_SESSION);
-
-        $e_message = 'No exception caught';
-        try {
-            $auth0->setIdToken( $id_token );
-        } catch (InvalidTokenException $e) {
-            $e_message = $e->getMessage();
-        }
-
-        $this->assertStringStartsWith('Nonce value not found in application store', $e_message);
-    }
-
-    /**
-     * @throws CoreException
-     */
     public function testThatIdTokenNonceIsCheckedWhenSet()
     {
         $custom_config = self::$baseConfig + ['id_token_alg' => 'HS256'];

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -190,25 +190,6 @@ class Auth0Test extends TestCase
     }
 
     /**
-     * Test that renewTokens fails if there is no access_token stored.
-     *
-     * @throws ApiException Should not be thrown in this test.
-     */
-    public function testThatRenewTokensFailsIfThereIsNoAccessToken()
-    {
-        $auth0 = new Auth0( self::$baseConfig );
-
-        try {
-            $caught_exception = false;
-            $auth0->renewTokens();
-        } catch (CoreException $e) {
-            $caught_exception = $this->errorHasString( $e, "Can't renew the access token if there isn't one valid" );
-        }
-
-        $this->assertTrue( $caught_exception );
-    }
-
-    /**
      * Test that renewTokens fails if there is no refresh_token stored.
      *
      * @throws ApiException Should not be thrown in this test.

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -85,7 +85,7 @@ class Auth0Test extends TestCase
     }
 
     /**
-     * Test that the exchanges succeeds when there is both and access token and an ID token present.
+     * Test that the exchanges fails when there is not a stored nonce value.
      *
      * @throws ApiException
      * @throws CoreException

--- a/tests/Helpers/TransientStoreHandlerTest.php
+++ b/tests/Helpers/TransientStoreHandlerTest.php
@@ -59,4 +59,21 @@ class TransientStoreHandlerTest extends TestCase
         $this->assertNull($transientStore->getOnce('test_verify_key'));
         $this->assertArrayNotHasKey('test_store_test_verify_key', $_SESSION);
     }
+
+    public function testThatTransientIssetReturnsCorrectly()
+    {
+        $sessionStore   = new SessionStore('test_store');
+        $transientStore = new TransientStoreHandler($sessionStore);
+
+        $this->assertFalse($transientStore->isset('test_verify_key'));
+
+        $transientStore->store('test_verify_key', '__test_get_value__');
+
+        $this->assertTrue($transientStore->isset('test_verify_key'));
+
+        $transientStore->getOnce('test_verify_key');
+
+        $this->assertFalse($transientStore->isset('test_verify_key'));
+
+    }
 }


### PR DESCRIPTION
### Description

- Fix `Auth0->renewTokens()` to skip nonce checking for the ID token
- Remove stored access token requirement from `Auth0->renewTokens()`
- Remove `id_token` check from `Auth0->renewTokens()` response
- Add `TransientStoreHandler->isset()` to check for stored transient value without getting/deleting it

### References

Closes #432 

### Testing

https://github.com/auth0/auth0-PHP/pull/434/commits/647aaed2baaf5274ccc0ad2bece434d8d6685f48 - Fixes the renew token test to fail because of missing nonce, as it would (see issue above)

- [x] This change adds test coverage for new/changed/fixed functionality
