### PR TITLE
Throw InvalidTokenException instead of RuntimeException when parsing malformed token (fix #438)

### DIFF
--- a/src/Helpers/Tokens/SignatureVerifier.php
+++ b/src/Helpers/Tokens/SignatureVerifier.php
@@ -65,7 +65,7 @@ abstract class SignatureVerifier
     {
         try {
             $parsedToken = $this->parser->parse($token);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException | \RuntimeException $e) {
             throw new InvalidTokenException( 'ID token could not be decoded' );
         }
 

--- a/tests/Helpers/Tokens/AsymmetricVerifierTest.php
+++ b/tests/Helpers/Tokens/AsymmetricVerifierTest.php
@@ -86,6 +86,18 @@ class AsymmetricVerifierTest extends TestCase
         $this->assertEquals('__test_sub__', $decodedToken->getClaim('sub'));
     }
 
+    public function testThatMalformedTokenFails()
+    {
+        $rsa_keys = self::getRsaKeys();
+        $verifier = new AsymmetricVerifier( [ '__test_kid__' => $rsa_keys['public'] ] );
+        $token    = 'a'.(string) self::getToken($rsa_keys['private']);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('ID token could not be decoded');
+
+        $verifier->verifyAndDecode( $token );
+    }
+
     /*
      * Helper methods
      */


### PR DESCRIPTION
Hello !

### Description

Fix #438 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
