### PR TITLE
Update composer requirements to support guzzle ~7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   php_7:
     docker:
-      - image: circleci/php:7.2
+      - image: circleci/php:7.1
     steps:
       - prepare
       - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   php_7:
     docker:
-      - image: circleci/php:7.1
+      - image: circleci/php:7.2
     steps:
       - prepare
       - run-tests

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "guzzlehttp/guzzle": "~6.0",
+    "php": "^7.2",
+    "guzzlehttp/guzzle": "~7.0",
     "ext-json": "*",
     "lcobucci/jwt": "^3.3",
     "psr/simple-cache": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": "^7.2",
-    "guzzlehttp/guzzle": "~7.0",
+    "php": "^7.1",
+    "guzzlehttp/guzzle": "~6.0 | ~7.0",
     "ext-json": "*",
     "lcobucci/jwt": "^3.3",
     "psr/simple-cache": "^1.0"


### PR DESCRIPTION
### Description
Update guzzle library to latest release.

### References
#421 
The latest [guzzle library](https://packagist.org/packages/guzzlehttp/guzzle) requires php 7.2.5, hence the change to that as well. This may require a bump in the versioning.
