### PR TITLE
Run integration tests on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,4 +74,7 @@ workflows:
   integration-tests:
     jobs:
       - php_7_integration_tests:
-          type: approval
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,16 @@ commands:
           key: composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}
           paths:
             - vendor
-  run-tests:
+  run-unit-tests:
     steps:
       - run: composer test-unit-ci
       - store_artifacts:
           path:  build/coverage.xml
-
+  run-integration-tests:
+    steps:
+      - run: composer test-integration-ci
+      - store_artifacts:
+          path:  build/coverage.xml
 
 jobs:
   php_7:
@@ -33,10 +37,16 @@ jobs:
       - image: circleci/php:7.1
     steps:
       - prepare
-      - run-tests
+      - run-unit-tests
       - run:
           command: bash <(curl -s https://codecov.io/bash)
           when: on_success
+  php_7_integration_tests:
+    docker:
+      - image: circleci/php:7.1
+    steps:
+      - prepare
+      - run-integration-tests
   snyk:
     docker:
       - image: snyk/snyk-cli:composer
@@ -61,3 +71,7 @@ workflows:
           context: snyk-env
           requires:
             - php_7
+  integration-tests:
+    jobs:
+      - php_7_integration_tests:
+          type: approval


### PR DESCRIPTION
### Description

Adds a job to run the integration tests on master branch only. Since the integration tests require secrets (which we can't share with forked PRs), these tests will run only on the master branch.

### References

Related to the test refactoring in #447 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
