### PR TITLE
Add Support for Log Streams Management APIs

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -16,6 +16,7 @@ use Auth0\SDK\API\Management\Grants;
 use Auth0\SDK\API\Management\Guardian;
 use Auth0\SDK\API\Management\Jobs;
 use Auth0\SDK\API\Management\Logs;
+use Auth0\SDK\API\Management\LogStreams;
 use Auth0\SDK\API\Management\ResourceServers;
 use Auth0\SDK\API\Management\Roles;
 use Auth0\SDK\API\Management\Rules;
@@ -117,6 +118,13 @@ class Management
      * @var Logs
      */
     private $logs;
+
+    /**
+     * Instance of Auth0\SDK\API\Management\LogStreams
+     *
+     * @var LogStreams
+     */
+    private $logStreams;
 
     /**
      * Instance of Auth0\SDK\API\Management\Roles
@@ -357,6 +365,20 @@ class Management
         }
 
         return $this->logs;
+    }
+
+    /**
+     * Return an instance of the LogStreams class.
+     *
+     * @return LogStreams
+     */
+    public function logStreams() : LogStreams
+    {
+        if (! $this->logStreams instanceof LogStreams) {
+            $this->logStreams = new LogStreams($this->apiClient);
+        }
+
+        return $this->logStreams;
     }
 
     /**

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Auth0\SDK\API\Management;
+
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+
+/**
+ * Class LogStreams.
+ * Access to the v2 Management API Log Streams endpoint.
+ *
+ * @package Auth0\SDK\API\Management
+ */
+class LogStreams extends GenericResource {
+
+    private const LOG_STREAMS_PATH = 'log-streams';
+
+    public function getAll()
+    {
+        return $this->apiClient->method('get')
+            ->addPath(self::LOG_STREAMS_PATH)
+            ->call();
+    }
+
+    /**
+     * Get a single Log Stream.
+     * Required scope: "read:log_streams"
+     *
+     * @param string $log_stream_id Log Stream ID to get.
+     *
+     * @return mixed
+     *
+     * @throws \Exception Thrown by Guzzle for API errors.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id
+     */
+    public function get($log_stream_id)
+    {
+        $this->checkEmptyOrInvalidString($log_stream_id, 'log_stream_id');
+
+        return $this->apiClient->method('get')
+            ->addPath(self::LOG_STREAMS_PATH, $log_stream_id)
+            ->call();
+    }
+
+    /**
+     * Create a new Log Stream.
+     * Required scope: "create:log_streams"
+     *
+     * @param array $data Log Stream data to create:
+     *      - "name" if not specified, a name of the Log Stream will be assigned by the Log Stream endpoint .
+     *      - "type" field is required.
+     *      - "sink" field is required. It's value and requirements depends upon the type of Log Stream to create; see the linked documentation below.
+     *
+     * @return mixed
+     *
+     * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
+     */
+    public function create(array $data)
+    {
+        if (empty($data)) {
+            throw new EmptyOrInvalidParameterException('Missing required "data" parameter.');
+        }
+
+        if (empty($data['type'])) {
+            throw new EmptyOrInvalidParameterException('Missing required "type" field.');
+        }
+
+        if (empty($data['sink'])) {
+            throw new EmptyOrInvalidParameterException('Missing required "sink" field.');
+        }
+
+        return $this->apiClient->method('post')
+            ->addPath(self::LOG_STREAMS_PATH)
+            ->withBody(json_encode($data))
+            ->call();
+    }
+
+    /**
+     * Updates an existing Log Stream.
+     * Required scope: "update:log_streams"
+     *
+     * @param string $log_stream_id the ID of the Log Stream to update.
+     * @param array  $data Log Stream data to update. Only certain fields are update-able; see the documentation linked below.
+     *
+     * @return mixed
+     *
+     * @throws EmptyOrInvalidParameterException Thrown if the log_stream_id parameter is empty.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
+     */
+    public function update($log_stream_id, array $data)
+    {
+        if (empty($log_stream_id)) {
+            throw new EmptyOrInvalidParameterException('Missing required "log_stream_id" field');
+        }
+
+        return $this->apiClient->method('patch')
+            ->addPath(self::LOG_STREAMS_PATH, $log_stream_id)
+            ->withBody(json_encode($data))
+            ->call();
+    }
+
+    /**
+     * Deletes a Log Stream.
+     * Required scope: "delete:log_streams"
+     *
+     * @param string $log_stream_id the ID of the Log Stream to delete.
+     *
+     * @return mixed
+     *
+     * @throws EmptyOrInvalidParameterException Thrown if the log_stream_id parameter is empty.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/delete_log_streams_by_id
+     */
+    public function delete($log_stream_id)
+    {
+        if (empty($log_stream_id)) {
+            throw new EmptyOrInvalidParameterException('Missing required "log_stream_id" field');
+        }
+
+        return $this->apiClient->method('delete')
+            ->addPath(self::LOG_STREAMS_PATH, $log_stream_id)
+            ->call();
+    }
+
+}

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -47,7 +47,7 @@ class LogStreams extends GenericResource {
      * Required scope: "create:log_streams"
      *
      * @param array $data Log Stream data to create:
-     *      - "name" if not specified, a name of the Log Stream will be assigned by the Log Stream endpoint .
+     *      - "name" if not specified, a name of the Log Stream will be assigned by the Log Stream endpoint.
      *      - "type" field is required.
      *      - "sink" field is required. It's value and requirements depends upon the type of Log Stream to create; see the linked documentation below.
      *

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -14,6 +14,16 @@ class LogStreams extends GenericResource {
 
     private const LOG_STREAMS_PATH = 'log-streams';
 
+    /**
+     * Get all Log Streams.
+     * Required scope: "read:log_streams"
+     *
+     * @return mixed
+     *
+     * @throws \Exception Thrown by Guzzle for API errors.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams
+     */
     public function getAll()
     {
         return $this->apiClient->method('get')
@@ -90,7 +100,7 @@ class LogStreams extends GenericResource {
      * @throws EmptyOrInvalidParameterException Thrown if the log_stream_id parameter is empty.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
-     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
+     * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/patch_log_streams_by_id
      */
     public function update($log_stream_id, array $data)
     {

--- a/tests/unit/API/Management/LogStreamsTest.php
+++ b/tests/unit/API/Management/LogStreamsTest.php
@@ -1,0 +1,249 @@
+<?php
+
+
+namespace Auth0\Tests\unit\API\Management;
+
+
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+use GuzzleHttp\Psr7\Response;
+use Auth0\Tests\API\ApiTests;
+
+class LogStreamsTest extends ApiTests
+{
+    /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $expectedTelemetry;
+
+    /**
+     * Default request headers.
+     *
+     * @var array
+     */
+    protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs before test suite starts.
+     */
+    public static function setUpBeforeClass()
+    {
+        $infoHeadersData = new InformationHeaders;
+        $infoHeadersData->setCorePackage();
+        self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatGetAllRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->logStreams()->getAll();
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertStringStartsWith( 'https://api.test.local/api/v2/log-streams', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    public function testThatGetLogStreamRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->logStreams()->get('123');
+
+        $this->assertEquals( 'GET', $api->getHistoryMethod() );
+        $this->assertStringStartsWith( 'https://api.test.local/api/v2/log-streams/123', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    public function testThatGetLogStreamWithEmptyIdThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->get( '' );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Empty or invalid log_stream_id', $exception_message );
+    }
+
+    public function testThatCreateLogStreamRequestIsFormedCorrectly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->logStreams()->create([
+            'name' => 'Test Stream',
+            'type' => 'http',
+            'sink' => [
+                'httpEndpoint' => 'https://me.org',
+                'httpContentFormat' => 'JSONLINES',
+                'httpContentType' => 'application/json',
+                'httpAuthorization' => 'abc123'
+            ]
+        ]);
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/log-streams', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'name', $body );
+        $this->assertEquals( 'Test Stream', $body['name'] );
+        $this->assertArrayHasKey( 'type', $body );
+        $this->assertEquals( 'http', $body['type'] );
+        $this->assertArrayHasKey( 'sink', $body );
+        $this->assertEquals('https://me.org', $body['sink']['httpEndpoint']);
+        $this->assertEquals('JSONLINES', $body['sink']['httpContentFormat']);
+        $this->assertEquals('application/json', $body['sink']['httpContentType']);
+        $this->assertEquals('abc123', $body['sink']['httpAuthorization']);
+    }
+
+    public function testThatCreateLogStreamRequestWithEmptyDataThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->create( [] );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "data" parameter', $exception_message );
+    }
+
+    public function testThatCreateLogStreamRequestWithEmptyTypeThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->create( [
+                'name' => 'test stream',
+                'sink' => [
+                    'httpEndpoint' => 'https://me.org',
+                    'httpContentFormat' => 'JSONLINES',
+                    'httpContentType' => 'application/json',
+                    'httpAuthorization' => 'abc123'
+                ]
+            ] );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "type" field', $exception_message );
+    }
+
+    public function testThatCreateLogStreamRequestWithMissingSinkThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->create( [
+                'name' => 'test stream',
+                'type' => 'http'
+            ] );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "sink" field', $exception_message );
+    }
+
+    public function testThatCreateLogStreamRequestWithEmptySinkThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->create( [
+                'name' => 'test stream',
+                'type' => 'http',
+                'sink' => [ ]
+            ] );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "sink" field', $exception_message );
+    }
+
+    public function testThatUpdateLogStreamRequestIsFormedCorrectly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->logStreams()->update('123', [
+            'name' => 'Test Name'
+        ]);
+
+        $this->assertEquals( 'PATCH', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/log-streams/123', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'name', $body );
+        $this->assertEquals( 'Test Name', $body['name'] );
+    }
+
+    public function testThatUpdateLogStreamRequestWithEmptyIdThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+            $api->call()->logStreams()->update('', [] );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "log_stream_id" field', $exception_message );
+    }
+
+    public function testThatDeleteLogStreamRequestIsFormedCorrectly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->logStreams()->delete( '123' );
+
+        $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/log-streams/123', $api->getHistoryUrl() );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+    }
+
+    public function testThatDeleteLogStreamRequestWithEmptyIdThrowsException()
+    {
+        $api = new MockManagementApi();
+
+        try {
+        $api->call()->logStreams()->delete('' );
+            $exception_message = '';
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertContains( 'Missing required "log_stream_id" field', $exception_message );
+    }
+}


### PR DESCRIPTION
### Description

This PR adds support for the Log Streams APIs available in the Management API. The following new methods are added:

- `Auth0\SDK\API\Management\LogStreams::getAll()`
- `Auth0\SDK\API\Management\LogStreams::get($log_stream_id)`
- `Auth0\SDK\API\Management\LogStreams::create($data)`
- `Auth0\SDK\API\Management\LogStreams::update($log_stream_id, $data)`
- `Auth0\SDK\API\Management\LogStreams::delete($log_stream_id)`

### References

- [Log Streaming feature documentation](https://auth0.com/docs/logs/export-log-events-with-log-streaming)
- [Log Streaming API documentation](https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams)

### Testing

Unit tests are added. I did develop an integration test to verify locally, but am not including it on the PR as there are limits on the number of Log Streams that can be created (limit is two), and any failure to clean up the created data or pause the Log Stream would lead to unnecessary resource usage.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
