### PR TITLE
Add support for new identity field for email verifications

### DIFF
--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -2,6 +2,8 @@
 
 namespace Auth0\SDK\API\Management;
 
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+
 class Jobs extends GenericResource
 {
     /**
@@ -64,6 +66,12 @@ class Jobs extends GenericResource
      * @param string $user_id User ID of the user to send the verification email to.
      * @param array  $params  Array of optional parameters to add.
      *        - client_id: Client ID of the requesting application.
+     *        - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
+     *              - user_id: User ID of the identity to be verified.
+     *              - provider: Identity provider name of the identity (e.g. google-oauth2).
+     *
+     * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
      * @return mixed
      *
@@ -75,6 +83,16 @@ class Jobs extends GenericResource
 
         if (! empty( $params['client_id'] )) {
             $body['client_id'] = $params['client_id'];
+        }
+
+        if (! empty( $params['identity'] )) {
+            if ( empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id']) ) {
+                throw new EmptyOrInvalidParameterException('Missing required "user_id" field of the "identity" object.');
+            }
+            if ( empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider']) ) {
+                throw new EmptyOrInvalidParameterException('Missing required "provider" field of the "identity" object.');
+            }
+            $body['identity'] = $params['identity'];
         }
 
         return $this->apiClient->method('post')

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -65,10 +65,10 @@ class Jobs extends GenericResource
      *
      * @param string $user_id User ID of the user to send the verification email to.
      * @param array  $params  Array of optional parameters to add.
-     *        - client_id: Client ID of the requesting application.
+     *        - client_id: Client ID of the requesting application. If not provided, the global Client ID will be used.
      *        - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
-     *              - user_id: User ID of the identity to be verified.
-     *              - provider: Identity provider name of the identity (e.g. google-oauth2).
+     *              - user_id: User ID of the identity to be verified. Must be a non-empty string.
+     *              - provider: Identity provider name of the identity (e.g. google-oauth2). Must be a non-empty string.
      *
      * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -11,10 +11,11 @@ class Tickets extends GenericResource
      * @param  string      $user_id
      * @param  null|string $result_url
      * @param array  $params  Array of optional parameters to add.
-     *      - client_id: Client ID of the requesting application.
+     *      - ttl_sec: Number of seconds for which the ticket is valid before expiration. If unspecified or set to 0, this value defaults to 432000 seconds (5 days).
+     *      - includeEmailInRedirect: Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *      - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
-     *              - user_id: User ID of the identity to be verified.
-     *              - provider: Identity provider name of the identity (e.g. google-oauth2).
+     *              - user_id: User ID of the identity to be verified. Must be a non-empty string.
+     *              - provider: Identity provider name of the identity (e.g. google-oauth2). Must be a non-empty string.
      *
      * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -2,19 +2,42 @@
 
 namespace Auth0\SDK\API\Management;
 
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+
 class Tickets extends GenericResource
 {
     /**
      *
      * @param  string      $user_id
      * @param  null|string $result_url
+     * @param array  $params  Array of optional parameters to add.
+     *      - client_id: Client ID of the requesting application.
+     *      - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
+     *              - user_id: User ID of the identity to be verified.
+     *              - provider: Identity provider name of the identity (e.g. google-oauth2).
+     *
+     * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
      * @return mixed
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
      */
-    public function createEmailVerificationTicket($user_id, $result_url = null)
+    public function createEmailVerificationTicket($user_id, $result_url = null, array $params = [])
     {
         $body = ['user_id' => $user_id];
         if ($result_url !== null) {
             $body['result_url'] = $result_url;
+        }
+
+        if (! empty( $params['identity'] )) {
+            if ( empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id']) ) {
+                throw new EmptyOrInvalidParameterException('Missing required "user_id" field of the "identity" object.');
+            }
+            if ( empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider']) ) {
+                throw new EmptyOrInvalidParameterException('Missing required "provider" field of the "identity" object.');
+            }
+            $body['identity'] = $params['identity'];
         }
 
         $request = $this->apiClient->method('post')

--- a/tests/unit/API/Management/TicketsTest.php
+++ b/tests/unit/API/Management/TicketsTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Auth0\Tests\unit\API\Management;
+
+use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+use Auth0\Tests\API\ApiTests;
+use GuzzleHttp\Psr7\Response;
+
+
+class TicketsTest extends ApiTests
+{
+
+    /**
+     * Expected telemetry value.
+     *
+     * @var string
+     */
+    protected static $expectedTelemetry;
+
+    /**
+     * Default request headers.
+     *
+     * @var array
+     */
+    protected static $headers = [ 'content-type' => 'json' ];
+
+    /**
+     * Runs before test suite starts.
+     */
+    public static function setUpBeforeClass()
+    {
+        $infoHeadersData               = new InformationHeaders;
+        $infoHeadersData->setCorePackage();
+        self::$expectedTelemetry = $infoHeadersData->build();
+    }
+
+    public function testThatSendVerificationEmailTicketRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->tickets()->createEmailVerificationTicket( '__test_user_id__', '__test_result_url__', [
+            'identity' => [
+                'user_id' => '__test_secondary_user_id__',
+                'provider' => '__test_provider__'
+            ]
+        ] );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/tickets/email-verification', $api->getHistoryUrl() );
+        $this->assertEmpty( $api->getHistoryQuery() );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'user_id', $body );
+        $this->assertEquals( '__test_user_id__', $body['user_id'] );
+        $this->assertArrayHasKey( 'result_url', $body );
+        $this->assertEquals( '__test_result_url__', $body['result_url'] );
+        $this->assertArrayHasKey( 'identity', $body);
+        $this->assertEquals( [
+            'user_id' => '__test_secondary_user_id__',
+            'provider' => '__test_provider__'
+        ], $body['identity']);
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+    }
+
+    public function testIdentityParamRequiresUserId()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+        $exception_message = '';
+
+        try {
+            $api->call()->tickets()->createEmailVerificationTicket( '__test_user_id__', null, [
+                'identity' => [
+                    'provider' => '__test_provider__'
+                ]
+            ] );
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertStringContainsString( 'Missing required "user_id" field of the "identity" object.', $exception_message );
+    }
+
+    public function testIdentityParamRequiresUserIdAsString()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+        $exception_message = '';
+
+        try {
+            $api->call()->tickets()->createEmailVerificationTicket( '__test_user_id__', null, [
+                'identity' => [
+                    'user_id' => 42,
+                    'provider' => '__test_provider__'
+                ]
+            ] );
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertStringContainsString( 'Missing required "user_id" field of the "identity" object.', $exception_message );
+    }
+
+    public function testIdentityParamRequiresProvider()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+        $exception_message = '';
+
+        try {
+            $api->call()->tickets()->createEmailVerificationTicket( '__test_user_id__', null, [
+                'identity' => [
+                    'user_id' => '__test_secondary_user_id__'
+                ]
+            ] );
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertStringContainsString( 'Missing required "provider" field of the "identity" object.', $exception_message );
+    }
+
+    public function testIdentityParamRequiresProviderAsString()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+        $exception_message = '';
+
+        try {
+            $api->call()->tickets()->createEmailVerificationTicket( '__test_user_id__', null, [
+                'identity' => [
+                    'user_id' => '__test_secondary_user_id__',
+                    'provider' => 42
+                ]
+            ] );
+        } catch (EmptyOrInvalidParameterException $e) {
+            $exception_message = $e->getMessage();
+        }
+
+        $this->assertStringContainsString( 'Missing required "provider" field of the "identity" object.', $exception_message );
+    }
+}


### PR DESCRIPTION
### Description

Adds support for specifying the (optional) `identity` object when creating email verification tickets or jobs. This is needed when verifying emails when the primary is social, enterprise, or passwordless. Also needed to verify secondary identities.

### References

- https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
- https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email

### Testing

Unit tests added, and verified manually with a real tenant and users.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
