### PR TITLE
[SDK-1514] Implement Management V2 users export job support

### DIFF
--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -39,9 +39,9 @@ class RequestBuilder
     /**
      * HTTP method to use for the request.
      *
-     * @var array
+     * @var string
      */
-    protected $method = [];
+    protected $method;
 
     /**
      * Headers to include for the request.

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -101,7 +101,7 @@ class Jobs extends GenericResource
         $body = [];
 
         if (!empty($params['connection_id'])) {
-            $body['connection_id'] = filter_var($params['connection_id'], FILTER_SANITIZE_STRING);
+            $body['connection_id'] = $params['connection_id'];
         }
 
         if (!empty($params['format']) && in_array($params['format'], ['json', 'csv'])) {

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -7,9 +7,16 @@ use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 class Jobs extends GenericResource
 {
     /**
+     * Retrieves a job. Useful to check its status.
+     * Required scopes: "create:users" "read:users"
      *
-     * @param  string $id
+     * @param  string  $id
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
      * @return mixed
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
      */
     public function get($id)
     {
@@ -19,9 +26,16 @@ class Jobs extends GenericResource
     }
 
     /**
+     * Retrieve error details of a failed job.
+     * Required scopes: "create:users" "read:users"
      *
-     * @param  string $id
+     * @param  string  $id
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
      * @return mixed
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Jobs/get_errors
      */
     public function getErrors($id)
     {
@@ -31,11 +45,18 @@ class Jobs extends GenericResource
     }
 
     /**
+     * Import users from a formatted file into a connection via a long-running job.
+     * Required scopes: "create:users" "read:users"
      *
-     * @param  string $file_path
-     * @param  string $connection_id
-     * @param  array  $params
+     * @param  string  $file_path
+     * @param  string  $connection_id
+     * @param  array   $params
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
      * @return mixed
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports
      */
     public function importUsers($file_path, $connection_id, $params = [])
     {
@@ -61,11 +82,16 @@ class Jobs extends GenericResource
 
 
     /**
-     * Create an export users job.
-     * Required scope: "read:users"
+     * Export all users to a file via a long-running job.
+     * Required scopes: "read:users"
      *
      * @param  array  $params
+     *
+     * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
+     *
      * @return mixed
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports
      */
     public function exportUsers($params = [])
     {

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -59,6 +59,40 @@ class Jobs extends GenericResource
         return $request->call();
     }
 
+
+    /**
+     * Create an export users job.
+     * Required scope: "read:users"
+     *
+     * @param  array  $params
+     * @return mixed
+     */
+    public function exportUsers($params = [])
+    {
+        $request = $this->apiClient->method('post')
+        ->addPath('jobs', 'users-exports');
+
+        $body = [];
+
+        if (!empty($params['connection_id'])) {
+            $body['connection_id'] = filter_var($params['connection_id'], FILTER_SANITIZE_STRING);
+        }
+
+        if (!empty($params['format']) && in_array($params['format'], ['json', 'csv'])) {
+            $body['format'] = $params['format'];
+        }
+
+        if (!empty($params['limit']) && is_numeric($params['limit'])) {
+            $body['limit'] = $params['limit'];
+        }
+
+        if (!empty($params['fields']) && is_array($params['fields'])) {
+            $body['fields'] = $params['fields'];
+        }
+
+        return $request->withBody(json_encode($body))->call();
+    }
+
     /**
      * Create a verification email job.
      * Required scope: "update:users"

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -90,7 +90,7 @@ class Jobs extends GenericResource
             $body['fields'] = $params['fields'];
         }
 
-        return $request->withBody(json_encode($body))->call();
+        return $request->withBody(json_encode($body), JSON_FORCE_OBJECT)->call();
     }
 
     /**

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -70,40 +70,6 @@ class JobsIntegrationTest extends ApiTests
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Exception
      */
-    public function testIntegrationExportUsersJob()
-    {
-        $env = self::getEnv();
-
-        if (! $env['API_TOKEN']) {
-            $this->markTestSkipped( 'No client secret; integration test skipped' );
-        }
-
-        $api = new Management($env['API_TOKEN'], $env['DOMAIN']);
-
-        $default_db_name       = 'Username-Password-Authentication';
-        $get_connection_result = $api->connections()->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
-
-        $connectionId = $get_connection_result[0]['id'];
-        $export_users_result = $api->jobs()->exportUsers([
-            'connection_id' => $connectionId,
-            'limit' => 5,
-            'format' => 'json',
-            'fields' => [['name' => 'user_id']],
-        ]);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
-
-        $this->assertEquals( 'users_export', $export_users_result['type'] );
-        $this->assertEquals( $connectionId, $export_users_result['connection_id'] );
-        $this->assertEquals( 'json', $export_users_result['format'] );
-        $this->assertEquals( 5, $export_users_result['limit'] );
-        $this->assertEquals( [['name' => 'user_id']], $export_users_result['fields'] );
-    }
-
-    /**
-     * @throws \Auth0\SDK\Exception\ApiException
-     * @throws \Exception
-     */
     public function testIntegrationSendEmailVerificationJob()
     {
         $env = self::getEnv();

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -80,6 +80,7 @@ class JobsIntegrationTest extends ApiTests
 
         $api = new Management($env['API_TOKEN'], $env['DOMAIN']);
 
+        $default_db_name       = 'Username-Password-Authentication';
         $get_connection_result = $api->connections()->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
 

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -70,6 +70,39 @@ class JobsIntegrationTest extends ApiTests
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Exception
      */
+    public function testIntegrationExportUsersJob()
+    {
+        $env = self::getEnv();
+
+        if (! $env['API_TOKEN']) {
+            $this->markTestSkipped( 'No client secret; integration test skipped' );
+        }
+
+        $api = new Management($env['API_TOKEN'], $env['DOMAIN']);
+
+        $get_connection_result = $api->connections()->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+
+        $connectionId = $get_connection_result[0]['id'];
+        $export_users_result = $api->jobs()->exportUsers([
+            'connection_id' => $connectionId,
+            'limit' => 5,
+            'format' => 'json',
+            'fields' => [['name' => 'user_id']],
+        ]);
+        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+
+        $this->assertEquals( 'users_export', $export_users_result['type'] );
+        $this->assertEquals( $connectionId, $export_users_result['connection_id'] );
+        $this->assertEquals( 'json', $export_users_result['format'] );
+        $this->assertEquals( 5, $export_users_result['limit'] );
+        $this->assertEquals( [['name' => 'user_id']], $export_users_result['fields'] );
+    }
+
+    /**
+     * @throws \Auth0\SDK\Exception\ApiException
+     * @throws \Exception
+     */
     public function testIntegrationSendEmailVerificationJob()
     {
         $env = self::getEnv();

--- a/tests/unit/API/Management/JobsTest.php
+++ b/tests/unit/API/Management/JobsTest.php
@@ -165,6 +165,27 @@ class JobsTest extends ApiTests
     /**
      * @throws \Exception Should not be thrown in this test.
      */
+    public function testThatExportUsersRequestIsFilteringProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs()->exportUsers(
+            [
+                'connection_id' => '__test_conn_id__',
+                'limit' => 'invalid limit',
+                'format' => 'invalid format',
+            ]
+        );
+
+        $request_body = $api->getHistoryBody();
+
+        $this->assertArrayNotHasKey('limit', $request_body);
+        $this->assertArrayNotHasKey('format', $request_body);
+    }
+
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
     public function testThatSendVerificationEmailIsFormedProperly()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );

--- a/tests/unit/API/Management/JobsTest.php
+++ b/tests/unit/API/Management/JobsTest.php
@@ -127,6 +127,40 @@ class JobsTest extends ApiTests
         $this->assertEquals( '__test_ext_id__', $form_body_arr[$ext_id_key + self::FORM_DATA_VALUE_KEY_OFFSET] );
     }
 
+    /**
+     * @throws \Exception Should not be thrown in this test.
+     */
+    public function testThatExportUsersRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->jobs()->exportUsers(
+            [
+                'connection_id' => '__test_conn_id__',
+                'limit' => 5,
+                'format' => 'json',
+                'fields' => [['name' => 'user_id']],
+            ]
+        );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/jobs/users-exports', $api->getHistoryUrl() );
+        $this->assertEmpty( $api->getHistoryQuery() );
+
+        $request_body = $api->getHistoryBody();
+
+        $this->assertNotEmpty( $request_body['connection_id'] );
+        $this->assertEquals( '__test_conn_id__', $request_body['connection_id'] );
+
+        $this->assertNotEmpty( $request_body['limit'] );
+        $this->assertEquals( '5', $request_body['limit'] );
+
+        $this->assertNotEmpty( $request_body['format'] );
+        $this->assertEquals( 'json', $request_body['format'] );
+
+        $this->assertNotEmpty( $request_body['fields'] );
+        $this->assertEquals( [['name' => 'user_id']], $request_body['fields'] );
+    }
 
     /**
      * @throws \Exception Should not be thrown in this test.


### PR DESCRIPTION
### Changes

- Adds support for the POST /api/v2/jobs/users-exports endpoint.

### References

- https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors