### PR TITLE
[SDK-2142] Allow specifying TTL when creating password change tickets.

### DIFF
--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -60,10 +60,11 @@ class Tickets extends GenericResource
         $user_id,
         $new_password = null,
         $result_url = null,
-        $connection_id = null
+        $connection_id = null,
+        $ttl = null
     )
     {
-        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id);
+        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id, $ttl);
     }
 
     /**
@@ -72,16 +73,18 @@ class Tickets extends GenericResource
      * @param  null|string $new_password
      * @param  null|string $result_url
      * @param  null|string $connection_id
+     * @param  null|integer $ttl
      * @return mixed
      */
     public function createPasswordChangeTicketByEmail(
         $email,
         $new_password = null,
         $result_url = null,
-        $connection_id = null
+        $connection_id = null,
+        $ttl = null
     )
     {
-        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id);
+        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id, $ttl);
     }
 
     /**
@@ -91,6 +94,7 @@ class Tickets extends GenericResource
      * @param  null|string $new_password
      * @param  null|string $result_url
      * @param  null|string $connection_id
+     * @param  null|integer $ttl
      * @return mixed
      */
     public function createPasswordChangeTicketRaw(
@@ -98,7 +102,8 @@ class Tickets extends GenericResource
         $email = null,
         $new_password = null,
         $result_url = null,
-        $connection_id = null
+        $connection_id = null,
+        $ttl = null
     )
     {
         $body = [];
@@ -121,6 +126,10 @@ class Tickets extends GenericResource
 
         if ($connection_id) {
             $body['connection_id'] = $connection_id;
+        }
+
+        if ($ttl) {
+            $body['ttl_sec'] = $ttl;
         }
 
         return $this->apiClient->method('post')

--- a/tests/unit/API/Management/TicketsTest.php
+++ b/tests/unit/API/Management/TicketsTest.php
@@ -67,6 +67,34 @@ class TicketsTest extends ApiTests
         $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
     }
 
+    public function testThatPasswordChangeTicketRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $api->call()->tickets()->createPasswordChangeTicket( '__test_user_id__', '__test_password__', '__test_result_url__', '__test_connection_id__', 8675309 );
+
+        $this->assertEquals( 'POST', $api->getHistoryMethod() );
+        $this->assertEquals( 'https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl() );
+        $this->assertEmpty( $api->getHistoryQuery() );
+
+        $body = $api->getHistoryBody();
+        $this->assertArrayHasKey( 'user_id', $body );
+        $this->assertEquals( '__test_user_id__', $body['user_id'] );
+        $this->assertArrayHasKey( 'new_password', $body );
+        $this->assertEquals( '__test_password__', $body['new_password'] );
+        $this->assertArrayHasKey( 'result_url', $body );
+        $this->assertEquals( '__test_result_url__', $body['result_url'] );
+        $this->assertArrayHasKey( 'connection_id', $body );
+        $this->assertEquals( '__test_connection_id__', $body['connection_id'] );
+        $this->assertArrayHasKey( 'ttl_sec', $body );
+        $this->assertEquals( 8675309, $body['ttl_sec'] );
+
+        $headers = $api->getHistoryHeaders();
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+    }
+
     public function testIdentityParamRequiresUserId()
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );


### PR DESCRIPTION
### Changes

- Adds optional TTL parameter to createPasswordChangeTicket
- Adds optional TTL parameter to createPasswordChangeTicketByEmail
- Adds optional TTL parameter to createPasswordChangeTicketRaw

### References

- https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change
- Closes #457 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors