### PR TITLE
Support for PHP 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,24 +32,6 @@ commands:
           path: build/coverage.xml
 
 jobs:
-  php_7:
-    docker:
-      - image: circleci/php:7.1
-    steps:
-      - prepare
-      - run-unit-tests
-      - run:
-          command: bash <(curl -s https://codecov.io/bash)
-          when: on_success
-  php_7_2:
-    docker:
-      - image: circleci/php:7.2
-    steps:
-      - prepare
-      - run-unit-tests
-      - run:
-          command: bash <(curl -s https://codecov.io/bash)
-          when: on_success
   php_7_3:
     docker:
       - image: circleci/php:7.3
@@ -68,9 +50,18 @@ jobs:
       - run:
           command: bash <(curl -s https://codecov.io/bash)
           when: on_success
+  php_8_0:
+    docker:
+      - image: circleci/php:8.0
+    steps:
+      - prepare
+      - run-unit-tests
+      - run:
+          command: bash <(curl -s https://codecov.io/bash)
+          when: on_success
   php_7_integration_tests:
     docker:
-      - image: circleci/php:7.1
+      - image: circleci/php:7.3
     steps:
       - prepare
       - run-integration-tests
@@ -92,15 +83,14 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - php_7
-      - php_7_2
       - php_7_3
       - php_7_4
+      - php_8_0
       - snyk:
           # Must define SNYK_TOKEN env
           context: snyk-env
           requires:
-            - php_7
+            - php_7_3
   integration-tests:
     jobs:
       - php_7_integration_tests:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 .env
 .phpcs.xml
 phpcs.xml
+.phpunit.result.cache

--- a/.phpcs-compat.xml.dist
+++ b/.phpcs-compat.xml.dist
@@ -11,6 +11,6 @@
     PHPCompatibility sniffs to check for PHP cross-version incompatible code.
     https://github.com/PHPCompatibility/PHPCompatibility
     -->
-    <config name="testVersion" value="7.1-"/>
+    <config name="testVersion" value="7.3-"/>
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,83 @@
 # CHANGELOG
 
+## [7.5.0](https://github.com/auth0/auth0-PHP/tree/7.5.0) (2020-11-16)
+
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.4.0...7.5.0)
+
+**Closed issues**
+
+- createPasswordChangeTicket doesn't support 'ttl_sec' parameter [\#457](https://github.com/auth0/auth0-PHP/issues/457)
+- Make the CACHE_TTL used in the JWKFetcher configurable. [\#450](https://github.com/auth0/auth0-PHP/issues/450)
+- Allow programmatic clearing of cache values managed by Auth0Service [\#441](https://github.com/auth0/auth0-PHP/issues/441)
+
+**Added**
+
+- Add support for Authorization Code Flow with PKCE [\#449](https://github.com/auth0/auth0-PHP/pull/449) ([ls-youssef-jlidat](https://github.com/ls-youssef-jlidat))
+- Allow specifying TTL when creating password change tickets [#463](https://github.com/auth0/auth0-PHP/pull/463) ([evansims](https://github.com/evansims))
+- Expand control over TTL/Caching in JWKFetcher [#462](https://github.com/auth0/auth0-PHP/pull/462) ([evansims](https://github.com/evansims))
+- Add support for Management V2 users export job endpoint [#461](https://github.com/auth0/auth0-PHP/pull/461) ([evansims](https://github.com/evansims))
+
 ## [7.4.0](https://github.com/auth0/auth0-PHP/tree/7.4.0) (2020-09-28)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.3.0...7.4.0)
 
 **Added**
+
 - Add support for new identity field for email verifications [\#455](https://github.com/auth0/auth0-PHP/pull/455) ([jimmyjames](https://github.com/jimmyjames))
 
 ## [7.3.0](https://github.com/auth0/auth0-PHP/tree/7.3.0) (2020-08-27)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.2.0...7.3.0)
 
 **Closed issues**
+
 - TokenVerifier::verify throws a \RuntimeException instead of an InvalidTokenException [\#438](https://github.com/auth0/auth0-PHP/issues/438)
 - Support Guzzle 7 [\#421](https://github.com/auth0/auth0-PHP/issues/421)
 
 **Added**
+
 - Add Support for Log Streams Management APIs [\#451](https://github.com/auth0/auth0-PHP/pull/451) ([jimmyjames](https://github.com/jimmyjames))
 - Update composer requirements to support guzzle ~7.0 [\#443](https://github.com/auth0/auth0-PHP/pull/443) ([banderon1](https://github.com/banderon1))
 
 **Fixed**
+
 - Throw InvalidTokenException instead of RuntimeException when parsing malformed token [\#439](https://github.com/auth0/auth0-PHP/pull/439) ([B-Galati](https://github.com/B-Galati))
 
 ## [7.2.0](https://github.com/auth0/auth0-PHP/tree/7.2.0) (2020-04-23)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.1.0...7.2.0)
 
 **Closed issues**
+
 - Renew Tokens throws nonce error [\#432](https://github.com/auth0/auth0-PHP/issues/432)
-- email_passwordless_start not setting client_secret  [\#431](https://github.com/auth0/auth0-PHP/issues/431)
+- email_passwordless_start not setting client_secret [\#431](https://github.com/auth0/auth0-PHP/issues/431)
 
 **Added**
+
 - /passwordless/start accepts client_secret now [\#430](https://github.com/auth0/auth0-PHP/pull/430) ([abbaspour](https://github.com/abbaspour))
 
 **Fixed**
+
 - Allow no nonce option [\#434](https://github.com/auth0/auth0-PHP/pull/434) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [7.1.0](https://github.com/auth0/auth0-PHP/tree/7.1.0) (2020-02-19)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.0.0...7.1.0)
 
 **Closed issues**
+
 - Authorized Party (azp) claim mismatch in the ID token [\#422](https://github.com/auth0/auth0-PHP/issues/422)
 - JWTVerifier alternatives [\#419](https://github.com/auth0/auth0-PHP/issues/419)
 - Consider to customize the jwks path [\#417](https://github.com/auth0/auth0-PHP/issues/417)
 
 **Added**
+
 - Add TokenVerifier for non-OIDC-compliant JWTs [\#428](https://github.com/auth0/auth0-PHP/pull/428) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add signing key rotation and custom JWKS URI support [\#426](https://github.com/auth0/auth0-PHP/pull/426) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add Client ID to verification email method [\#423](https://github.com/auth0/auth0-PHP/pull/423) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [7.0.0](https://github.com/auth0/auth0-PHP/tree/7.0.0) (2020-01-15)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.7.0...7.0.0)
 
 **BEFORE YOU UPGRADE**
@@ -54,6 +85,7 @@
 This is a major release with several breaking changes. Please see the [v5 to v7 migration guide here](https://github.com/auth0/auth0-PHP/blob/master/MIGRATE-v5-TO-v7.md) before you upgrade.
 
 **Added**
+
 - Add types for StoreInterface and implementors; add back EmptyStore [\#414](https://github.com/auth0/auth0-PHP/pull/414) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add select Guardian management endpoints [\#412](https://github.com/auth0/auth0-PHP/pull/412) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add Auth0->decodeIdToken() method for ID token decoding by deps [\#410](https://github.com/auth0/auth0-PHP/pull/410) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -61,6 +93,7 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Nonce and max_age handling with new CookieStore class [\#395](https://github.com/auth0/auth0-PHP/pull/395) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Changed**
+
 - Convert caching to PSR-16 interface [\#403](https://github.com/auth0/auth0-PHP/pull/403) ([joshcanhelp](https://github.com/joshcanhelp))
 - Move AuthorizationBearer to new namespace [\#402](https://github.com/auth0/auth0-PHP/pull/402) ([joshcanhelp](https://github.com/joshcanhelp))
 - Improve transient authorization data handling [\#397](https://github.com/auth0/auth0-PHP/pull/397) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -70,6 +103,7 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Update minimum PHP from 5.5 to 7.1 [\#377](https://github.com/auth0/auth0-PHP/pull/377) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Removed**
+
 - Remove future iat check [\#411](https://github.com/auth0/auth0-PHP/pull/411) ([joshcanhelp](https://github.com/joshcanhelp))
 - Remove Firebase JWT library [\#396](https://github.com/auth0/auth0-PHP/pull/396) ([joshcanhelp](https://github.com/joshcanhelp))
 - Remove session cookie expiration option [\#389](https://github.com/auth0/auth0-PHP/pull/389) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -83,77 +117,96 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Update management props [\#378](https://github.com/auth0/auth0-PHP/pull/378) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.7.0](https://github.com/auth0/auth0-PHP/tree/5.7.0) (2019-12-09)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.6.0...5.7.0)
 
 **Added**
+
 - Add default scopes to Auth0 class [\#406](https://github.com/auth0/auth0-PHP/pull/406) ([joshcanhelp](https://github.com/joshcanhelp))
 - fix: add missing options for renewTokens method [\#405](https://github.com/auth0/auth0-PHP/pull/405) ([bkotrys](https://github.com/bkotrys))
 
 **Deprecated**
+
 - Add deprecation notices for removals in v7 major release [\#407](https://github.com/auth0/auth0-PHP/pull/407) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Fix mkdir race condition in FileSystemCacheHandler [\#375](https://github.com/auth0/auth0-PHP/pull/375) ([B-Galati](https://github.com/B-Galati))
 
 ## [5.6.0](https://github.com/auth0/auth0-PHP/tree/5.6.0) (2019-09-26)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.5.1...5.6.0)
 
 **Closed issues**
+
 - [Auth0\SDK\Exception\CoreException] Invalid domain when trying to run unit tests with Codeception 3.1.0 [\#358](https://github.com/auth0/auth0-PHP/issues/358)
 - JWT Verification fails everytime [\#356](https://github.com/auth0/auth0-PHP/issues/356)
 - Bulk User Imports - I can't Use `upsert` as a paramater for the `importUsers` feature [\#353](https://github.com/auth0/auth0-PHP/issues/353)
 
 **Added**
+
 - Add \Auth0\SDK\Auth0::getLoginUrl() method and switch login() to use it [\#371](https://github.com/auth0/auth0-PHP/pull/371) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add JWKFetcher::getFormatted() method and switch validator to use [\#369](https://github.com/auth0/auth0-PHP/pull/369) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add additional API params to Jobs > importUsers [\#354](https://github.com/auth0/auth0-PHP/pull/354) ([pinodex](https://github.com/pinodex))
 
 **Deprecated**
+
 - Deprecated unused JWKFetcher methods [\#373](https://github.com/auth0/auth0-PHP/pull/373) ([joshcanhelp](https://github.com/joshcanhelp))
-- Deprecate magic __call method on RequestBuilder class [\#366](https://github.com/auth0/auth0-PHP/pull/366) ([joshcanhelp](https://github.com/joshcanhelp))
+- Deprecate magic \_\_call method on RequestBuilder class [\#366](https://github.com/auth0/auth0-PHP/pull/366) ([joshcanhelp](https://github.com/joshcanhelp))
 - Deprecate Management properties; add lazy-load methods [\#363](https://github.com/auth0/auth0-PHP/pull/363) ([joshcanhelp](https://github.com/joshcanhelp))
 - Deprecate and stop using magic call method on ApiClient [\#362](https://github.com/auth0/auth0-PHP/pull/362) ([joshcanhelp](https://github.com/joshcanhelp))
 - Deprecate addPathVariable and dump methods on RequestBuilder [\#361](https://github.com/auth0/auth0-PHP/pull/361) ([joshcanhelp](https://github.com/joshcanhelp))
 - Deprecate TokenGenerator class [\#360](https://github.com/auth0/auth0-PHP/pull/360) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Fix boolean form parameters not sending as strings [\#357](https://github.com/auth0/auth0-PHP/pull/357) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.5.1](https://github.com/auth0/auth0-PHP/tree/5.5.1) (2019-07-15)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.5.0...5.5.1)
 
 **Closed issues**
+
 - No packagist package created for 5.5.0 [\#346](https://github.com/auth0/auth0-PHP/issues/346)
 
 **Fixed**
+
 - Fix empty url params [\#349](https://github.com/auth0/auth0-PHP/pull/349) ([joshcanhelp](https://github.com/joshcanhelp))
 - Fix tests to reduce the number of sensitive credentials used [\#348](https://github.com/auth0/auth0-PHP/pull/348) ([joshcanhelp](https://github.com/joshcanhelp))
 - Change normalizeIncludeTotals() in GenericResource to have sane defaults [\#347](https://github.com/auth0/auth0-PHP/pull/347) ([kler](https://github.com/kler))
 
 ## [5.5.0](https://github.com/auth0/auth0-PHP/tree/5.5.0) (2019-06-07)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.4.0...5.5.0)
 
 **Closed issues**
+
 - Consider dropping PHP-5.x version supports [\#343](https://github.com/auth0/auth0-PHP/issues/343)
-- Auth0 Error:  'Invalid state' in /auth0/vendor/auth0/auth0-php/src/Auth0.php: line#537  [\#333](https://github.com/auth0/auth0-PHP/issues/333)
+- Auth0 Error: 'Invalid state' in /auth0/vendor/auth0/auth0-php/src/Auth0.php: line#537 [\#333](https://github.com/auth0/auth0-PHP/issues/333)
 
 **Added**
+
 - Add missing User endpoints for Management API [\#341](https://github.com/auth0/auth0-PHP/pull/341) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add all Management API Roles endpoints [\#337](https://github.com/auth0/auth0-PHP/pull/337) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add missing Users test and switch to mocked calls. [\#336](https://github.com/auth0/auth0-PHP/pull/336) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add Authentication::refresh_token() method [\#335](https://github.com/auth0/auth0-PHP/pull/335) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.4.0](https://github.com/auth0/auth0-PHP/tree/5.4.0) (2019-02-28)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.3.2...5.4.0)
 
 **Notes for this release:**
+
 - `\Auth0\SDK\Auth0` now accepts a `$config` key called `skip_userinfo` that uses the decoded ID token for the user profile instead of a call to the `/userinfo` endpoint. This will save an HTTP call during login and should have no affect on most applications.
 
 **Closed issues**
+
 - `Auth0::exchange()` assumes a valid id_token [\#317](https://github.com/auth0/auth0-PHP/issues/317)
 - Feature Request: Support sending `auth0-forwarded-for` header [\#208](https://github.com/auth0/auth0-PHP/issues/208)
 
 **Added**
+
 - Authentication class cleanup and tests [\#322](https://github.com/auth0/auth0-PHP/pull/322) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add Grants Management endpoint [\#321](https://github.com/auth0/auth0-PHP/pull/321) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add `Auth0-Forwarded-For` header for RO grant [\#320](https://github.com/auth0/auth0-PHP/pull/320) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -161,66 +214,80 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Add Mock API Request Capability and Mocked Connections Tests [\#314](https://github.com/auth0/auth0-PHP/pull/314) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Changed**
+
 - Test suite improvements [\#313](https://github.com/auth0/auth0-PHP/pull/313) ([joshcanhelp](https://github.com/joshcanhelp))
 - Improve repo documentation [\#312](https://github.com/auth0/auth0-PHP/pull/312) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Deprecated**
+
 - Official deprecation for `JWKFetcher` method [\#328](https://github.com/auth0/auth0-PHP/pull/328) ([joshcanhelp](https://github.com/joshcanhelp))
-    - `\Auth0\SDK\Helpers\JWKFetcher::fetchKeys()`
+  - `\Auth0\SDK\Helpers\JWKFetcher::fetchKeys()`
 - Official deprecation for `User` methods [\#327](https://github.com/auth0/auth0-PHP/pull/327) ([joshcanhelp](https://github.com/joshcanhelp))
-    - `\Auth0\SDK\API\Management\Users::search()`
-    - `\Auth0\SDK\API\Management\Users::unlinkDevice()`
+  - `\Auth0\SDK\API\Management\Users::search()`
+  - `\Auth0\SDK\API\Management\Users::unlinkDevice()`
 - Official deprecation of `ClientGrants` method [\#326](https://github.com/auth0/auth0-PHP/pull/326) ([joshcanhelp](https://github.com/joshcanhelp))
-    - `\Auth0\SDK\API\Management\ClientGrants::get()`
+  - `\Auth0\SDK\API\Management\ClientGrants::get()`
 - Official deprecation of legacy `InformationHeaders` methods [\#325](https://github.com/auth0/auth0-PHP/pull/325) ([joshcanhelp](https://github.com/joshcanhelp))
-    - `\Auth0\SDK\API\Helpers\InformationHeaders::setEnvironment()`
-    - `\Auth0\SDK\API\Helpers\InformationHeaders::setDependency()`
-    - `\Auth0\SDK\API\Helpers\InformationHeaders::setDependencyData()`
+  - `\Auth0\SDK\API\Helpers\InformationHeaders::setEnvironment()`
+  - `\Auth0\SDK\API\Helpers\InformationHeaders::setDependency()`
+  - `\Auth0\SDK\API\Helpers\InformationHeaders::setDependencyData()`
 - Official deprecation of legacy `Authentication` methods [\#324](https://github.com/auth0/auth0-PHP/pull/324) ([joshcanhelp](https://github.com/joshcanhelp))
-    - `\Auth0\SDK\API\Authentication::setApiClient()`
-    - `\Auth0\SDK\API\Authentication::sms_code_passwordless_verify()`
-    - `\Auth0\SDK\API\Authentication::email_code_passwordless_verify()`
-    - `\Auth0\SDK\API\Authentication::impersonate()`
+  - `\Auth0\SDK\API\Authentication::setApiClient()`
+  - `\Auth0\SDK\API\Authentication::sms_code_passwordless_verify()`
+  - `\Auth0\SDK\API\Authentication::email_code_passwordless_verify()`
+  - `\Auth0\SDK\API\Authentication::impersonate()`
 
 **Fixed**
+
 - Fix `Auth0::exchange()` to handle missing id_token [\#318](https://github.com/auth0/auth0-PHP/pull/318) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.3.2](https://github.com/auth0/auth0-PHP/tree/5.3.2) (2018-11-2)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.3.1...5.3.2)
 
 **Closed issues**
+
 - Something is wrong with the latest release 5.3.1 [\#303](https://github.com/auth0/auth0-PHP/issues/303)
 
 **Fixed**
+
 - Fix info headers Extend error in dependant libs [\#304](https://github.com/auth0/auth0-PHP/pull/304) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.3.1](https://github.com/auth0/auth0-PHP/tree/5.3.1) (2018-10-31)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.3.0...5.3.1)
 
 **Closed issues**
+
 - Array to String exception when audience is an array [\#296](https://github.com/auth0/auth0-PHP/issues/296)
 - Passing accessToken from frontend to PHP API [\#281](https://github.com/auth0/auth0-PHP/issues/281)
 - Deprecated method email_code_passwordless_verify [\#280](https://github.com/auth0/auth0-PHP/issues/280)
 
 **Added**
+
 - Fix documentation for Auth0 constructor options [\#298](https://github.com/auth0/auth0-PHP/pull/298) ([biganfa](https://github.com/biganfa))
 
 **Changed**
+
 - Change telemetry headers to new format and add tests [\#300](https://github.com/auth0/auth0-PHP/pull/300) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Fix bad exception message generation [\#297](https://github.com/auth0/auth0-PHP/pull/297) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.3.0](https://github.com/auth0/auth0-PHP/tree/5.3.0) (2018-10-09)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.2.0...5.3.0)
 
 **Closed issues**
+
 - Question: Handling rate limits [\#277](https://github.com/auth0/auth0-PHP/issues/277)
 - Allow configuration of the JWKS URL [\#276](https://github.com/auth0/auth0-PHP/issues/276)
 - Allow changing the session key name [\#273](https://github.com/auth0/auth0-PHP/issues/273)
 - SessionStore overrides PHP session cookie lifetime setting [\#215](https://github.com/auth0/auth0-PHP/issues/215)
 
 **Added**
+
 - Add custom JWKS path and kid check to JWKFetcher + tests [\#287](https://github.com/auth0/auth0-PHP/pull/287) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add config keys for session base name and cookie expires [\#279](https://github.com/auth0/auth0-PHP/pull/279) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add return request object [\#278](https://github.com/auth0/auth0-PHP/pull/278) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -233,29 +300,37 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Add session state and dummy state handler tests [\#266](https://github.com/auth0/auth0-PHP/pull/266) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Changed**
+
 - Build/PHPCS: update/improve the PHPCS configuration [\#284](https://github.com/auth0/auth0-PHP/pull/284) ([jrfnl](https://github.com/jrfnl))
 
 **Deprecated**
+
 - Deprecate Auth0\SDK\API\Oauth2Client class [\#269](https://github.com/auth0/auth0-PHP/pull/269) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Removed**
+
 - Remove examples, add links to Quickstarts [\#293](https://github.com/auth0/auth0-PHP/pull/293) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Whitespace pass with new standards using composer phpcbf [\#268](https://github.com/auth0/auth0-PHP/pull/268) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Security**
+
 - Add ID token validation [\#285](https://github.com/auth0/auth0-PHP/pull/285) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.2.0](https://github.com/auth0/auth0-PHP/tree/5.2.0) (2018-06-13)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.1.1...5.2.0)
 
 **Closed issues**
+
 - getAppMetadata - how to use? [\#248](https://github.com/auth0/auth0-PHP/issues/248)
 - Auth0 class missing action to renew access token [\#234](https://github.com/auth0/auth0-PHP/issues/234)
 - DOC maj [\#217](https://github.com/auth0/auth0-PHP/issues/217)
 
 **Added**
+
 - User pagination and fields, docblocks, formatting, test improvements [\#261](https://github.com/auth0/auth0-PHP/pull/261) ([joshcanhelp](https://github.com/joshcanhelp))
 - Unit test for withDictParams method [\#260](https://github.com/auth0/auth0-PHP/pull/260) ([joshcanhelp](https://github.com/joshcanhelp))
 - Pagination, additional parameters, and tests for the Connections endpoint [\#258](https://github.com/auth0/auth0-PHP/pull/258) ([joshcanhelp](https://github.com/joshcanhelp))
@@ -264,29 +339,36 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Add email template endpoints [\#251](https://github.com/auth0/auth0-PHP/pull/251) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Changed**
+
 - Code style scan and fixes [\#250](https://github.com/auth0/auth0-PHP/pull/250) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Fix PHPUnit test. [\#262](https://github.com/auth0/auth0-PHP/pull/262) ([maurobonfietti](https://github.com/maurobonfietti))
-- Allow $page to be null for Clients so pagination is not triggered [\#259](https://github.com/auth0/auth0-PHP/pull/259) ([joshcanhelp](https://github.com/joshcanhelp))
+- Allow \$page to be null for Clients so pagination is not triggered [\#259](https://github.com/auth0/auth0-PHP/pull/259) ([joshcanhelp](https://github.com/joshcanhelp))
 - Rewrite README; add news and notes to CHANGELOG [\#253](https://github.com/auth0/auth0-PHP/pull/253) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.1.1](https://github.com/auth0/auth0-PHP/tree/5.1.1) (2018-04-03)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.1.0...5.1.1)
 
 **Closed issues**
+
 - State Handler with Custom Session Store [\#233](https://github.com/auth0/auth0-PHP/issues/233)
 - Implement ResourceServices::getAll [\#200](https://github.com/auth0/auth0-PHP/issues/200)
 
 **Added**
+
 - Implement ResourceServices::getAll() [\#236](https://github.com/auth0/auth0-PHP/pull/236) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
-- Incorrect type hint on SessionStateHandler __construct [\#235](https://github.com/auth0/auth0-PHP/pull/235) ([joshcanhelp](https://github.com/joshcanhelp))
+
+- Incorrect type hint on SessionStateHandler \_\_construct [\#235](https://github.com/auth0/auth0-PHP/pull/235) ([joshcanhelp](https://github.com/joshcanhelp))
 - Auth0 class documentation fixed for store and state handler [\#232](https://github.com/auth0/auth0-PHP/pull/232) ([jspetrak](https://github.com/jspetrak))
 - Fixing minor code quality issues [\#231](https://github.com/auth0/auth0-PHP/pull/231) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.1.0](https://github.com/auth0/auth0-PHP/tree/5.1.0) (2018-03-02)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.0.6...5.1.0)
 
 **Notes on this release:**
@@ -294,38 +376,49 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 [State validation](https://auth0.com/docs/protocols/oauth2/oauth-state) was added for improved security. Please see our [troubleshooting page](https://auth0.com/docs/libraries/auth0-php/troubleshooting) for more information on how this works and potential issues.
 
 **Closed issues**
+
 - Support for php-jwt 5 [\#210](https://github.com/auth0/auth0-PHP/issues/210)
 
 **Added**
+
 - Added XSRF State Storage / Validation [\#214](https://github.com/auth0/auth0-PHP/pull/214) ([cocojoe](https://github.com/cocojoe))
 - Adding tests for state handler; correcting storage method used [\#228](https://github.com/auth0/auth0-PHP/pull/228) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Changed**
+
 - Bumping JWT package version [\#229](https://github.com/auth0/auth0-PHP/pull/229) ([joshcanhelp](https://github.com/joshcanhelp))
 
 ## [5.0.6](https://github.com/auth0/auth0-PHP/tree/5.0.4) (2017-11-24)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.0.4...5.0.6)
 
 **Added**
+
 - Add support for the new users by email API [\#213](https://github.com/auth0/auth0-PHP/pull/213) ([erichard](https://github.com/erichard))
 
 **Fixed**
+
 - Fixes build [\#211](https://github.com/auth0/auth0-PHP/pull/211) ([aknosis](https://github.com/aknosis))
 
 ## [5.0.4](https://github.com/auth0/auth0-PHP/tree/5.0.4) (2017-06-26)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/5.0.0...5.0.4)
 
 **Added**
+
 - Added setter for debugger [\#149](https://github.com/auth0/auth0-PHP/pull/149) ([AxaliaN](https://github.com/AxaliaN))
 
 **Changed**
+
 - Restructured tests and fixed hhvm build [\#164](https://github.com/auth0/auth0-PHP/pull/164) ([Nyholm](https://github.com/Nyholm))
 - Update .env.example with more appropriate values [\#148](https://github.com/auth0/auth0-PHP/pull/148) ([AmaanC](https://github.com/AmaanC))
 
 **Removed**
+
 - Remove non-essential dev package [\#157](https://github.com/auth0/auth0-PHP/pull/157) ([Nyholm](https://github.com/Nyholm))
 
 ## [3.4.0](https://github.com/auth0/auth0-PHP/tree/3.4.0) (2016-06-21)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.7...3.4.0)
 
 **Closed issues:**
@@ -337,16 +430,19 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Correctly build logout url query string [\#87](https://github.com/auth0/auth0-PHP/pull/87) ([robinvdvleuten](https://github.com/robinvdvleuten))
 
 ## [3.3.7](https://github.com/auth0/auth0-PHP/tree/3.3.7) (2016-06-09)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.6...3.3.7)
 
 ## [3.3.6](https://github.com/auth0/auth0-PHP/tree/3.3.6) (2016-06-09)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.5...3.3.6)
 
 **Merged pull requests:**
 
-- $this-\>access\_token is an array, not object [\#85](https://github.com/auth0/auth0-PHP/pull/85) ([dev101](https://github.com/dev101))
+- \$this-\>access_token is an array, not object [\#85](https://github.com/auth0/auth0-PHP/pull/85) ([dev101](https://github.com/dev101))
 
 ## [3.3.5](https://github.com/auth0/auth0-PHP/tree/3.3.5) (2016-05-24)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.4...3.3.5)
 
 **Closed issues:**
@@ -356,24 +452,31 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Add support for auth api endpoints \(/ro\) [\#22](https://github.com/auth0/auth0-PHP/issues/22)
 
 ## [3.3.4](https://github.com/auth0/auth0-PHP/tree/3.3.4) (2016-05-24)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.3...3.3.4)
 
 ## [3.3.3](https://github.com/auth0/auth0-PHP/tree/3.3.3) (2016-05-24)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.2.3...3.3.3)
 
 ## [2.2.3](https://github.com/auth0/auth0-PHP/tree/2.2.3) (2016-05-10)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.2...2.2.3)
 
 ## [3.3.2](https://github.com/auth0/auth0-PHP/tree/3.3.2) (2016-05-10)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.1...3.3.2)
 
 ## [3.3.1](https://github.com/auth0/auth0-PHP/tree/3.3.1) (2016-05-10)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.2.2...3.3.1)
 
 ## [2.2.2](https://github.com/auth0/auth0-PHP/tree/2.2.2) (2016-05-10)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.3.0...2.2.2)
 
 ## [3.3.0](https://github.com/auth0/auth0-PHP/tree/3.3.0) (2016-05-09)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.2.1...3.3.0)
 
 **Merged pull requests:**
@@ -384,9 +487,11 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Added auth api support [\#78](https://github.com/auth0/auth0-PHP/pull/78) ([glena](https://github.com/glena))
 
 ## [3.2.1](https://github.com/auth0/auth0-PHP/tree/3.2.1) (2016-05-02)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.2.1...3.2.1)
 
 ## [2.2.1](https://github.com/auth0/auth0-PHP/tree/2.2.1) (2016-04-27)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.2.0...2.2.1)
 
 **Closed issues:**
@@ -398,14 +503,17 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - dependencies update in basic api example [\#79](https://github.com/auth0/auth0-PHP/pull/79) ([Amialc](https://github.com/Amialc))
 
 ## [3.2.0](https://github.com/auth0/auth0-PHP/tree/3.2.0) (2016-04-15)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.2.0...3.2.0)
 
 - Now the SDK supports RS256 codes, it will decode using the `.well-known/jwks.json` endpoint to fetch the public key
 
 ## [2.2.0](https://github.com/auth0/auth0-PHP/tree/2.2.0) (2016-04-15)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.1.0...2.2.0)
 
 **Notes**
+
 - Now the SDK fetches the user using the `tokeninfo` endpoint to be fully compliant with the openid spec
 - Now the SDK supports RS256 codes, it will decode using the `.well-known/jwks.json` endpoint to fetch the public key
 
@@ -419,12 +527,13 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Fix typo in DocBlock [\#77](https://github.com/auth0/auth0-PHP/pull/77) ([tflight](https://github.com/tflight))
 
 ## [3.1.0](https://github.com/auth0/auth0-PHP/tree/3.1.0) (2016-03-10)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.0.1...3.1.0)
 
 **Closed issues:**
 
 - API seed incomptaible with auth0-php 3 [\#70](https://github.com/auth0/auth0-PHP/issues/70)
--  "cURL error 60: SSL certificate problem: self signed certificate in certificate chain \(see http://curl.haxx.se/libcurl/c/libcurl-errors.html\)", [\#69](https://github.com/auth0/auth0-PHP/issues/69)
+- "cURL error 60: SSL certificate problem: self signed certificate in certificate chain \(see http://curl.haxx.se/libcurl/c/libcurl-errors.html\)", [\#69](https://github.com/auth0/auth0-PHP/issues/69)
 - basic-webapp outdated dependencies [\#68](https://github.com/auth0/auth0-PHP/issues/68)
 - basic-webapp project relative path [\#67](https://github.com/auth0/auth0-PHP/issues/67)
 - Typo on README [\#63](https://github.com/auth0/auth0-PHP/issues/63)
@@ -442,6 +551,7 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Fix typo [\#58](https://github.com/auth0/auth0-PHP/pull/58) ([vboctor](https://github.com/vboctor))
 
 ## [3.0.1](https://github.com/auth0/auth0-PHP/tree/3.0.1) (2016-02-03)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.11...3.0.1)
 
 **Merged pull requests:**
@@ -449,6 +559,7 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Fixed Importing users [\#61](https://github.com/auth0/auth0-PHP/pull/61) ([polishdeveloper](https://github.com/polishdeveloper))
 
 ## [1.0.11](https://github.com/auth0/auth0-PHP/tree/1.0.11) (2016-01-27)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/3.0.0...1.0.11)
 
 **Closed issues:**
@@ -460,9 +571,11 @@ This is a major release with several breaking changes. Please see the [v5 to v7 
 - Fix ApiConnections class name [\#60](https://github.com/auth0/auth0-PHP/pull/60) ([bjyoungblood](https://github.com/bjyoungblood))
 
 ## [3.0.0](https://github.com/auth0/auth0-PHP/tree/3.0.0) (2016-01-18)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.1.2...3.0.0)
 
 **General 3.x notes**
+
 - SDK api changes, now the Auth0 API client is not build of static classes anymore. Usage example:
 
 ```php
@@ -486,6 +599,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - V3 with new API and full support for API V2 [\#57](https://github.com/auth0/auth0-PHP/pull/57) ([glena](https://github.com/glena))
 
 ## [2.1.2](https://github.com/auth0/auth0-PHP/tree/2.1.2) (2016-01-14)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.1.1...2.1.2)
 
 **Merged pull requests:**
@@ -495,6 +609,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Update lock [\#45](https://github.com/auth0/auth0-PHP/pull/45) ([Annyv2](https://github.com/Annyv2))
 
 ## [2.1.1](https://github.com/auth0/auth0-PHP/tree/2.1.1) (2015-11-29)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.1.0...2.1.1)
 
 **Merged pull requests:**
@@ -502,6 +617,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Fix Closure namespace issue [\#49](https://github.com/auth0/auth0-PHP/pull/49) ([mkeasling](https://github.com/mkeasling))
 
 ## [2.1.0](https://github.com/auth0/auth0-PHP/tree/2.1.0) (2015-11-24)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/2.0.0...2.1.0)
 
 **Closed issues:**
@@ -513,6 +629,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - 2.0.1 updated JWT dependency [\#48](https://github.com/auth0/auth0-PHP/pull/48) ([glena](https://github.com/glena))
 
 ## [2.0.0](https://github.com/auth0/auth0-PHP/tree/2.0.0) (2015-11-23)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.10...2.0.0)
 
 **General 2.x notes**
@@ -534,19 +651,21 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Update composer instructions [\#39](https://github.com/auth0/auth0-PHP/pull/39) ([iWader](https://github.com/iWader))
 
 ## [1.0.10](https://github.com/auth0/auth0-PHP/tree/1.0.10) (2015-09-23)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.9...1.0.10)
 
 **Closed issues:**
 
-- Improve error message when no id\_token is received after code exchange [\#35](https://github.com/auth0/auth0-PHP/issues/35)
+- Improve error message when no id_token is received after code exchange [\#35](https://github.com/auth0/auth0-PHP/issues/35)
 - PHP should be 5.4+, not 5.3+ [\#34](https://github.com/auth0/auth0-PHP/issues/34)
 
 **Merged pull requests:**
 
 - Release 1.0.10 [\#36](https://github.com/auth0/auth0-PHP/pull/36) ([glena](https://github.com/glena))
-- Remove code that rewrites user\_id property in $body [\#33](https://github.com/auth0/auth0-PHP/pull/33) ([Ring](https://github.com/Ring))
+- Remove code that rewrites user_id property in \$body [\#33](https://github.com/auth0/auth0-PHP/pull/33) ([Ring](https://github.com/Ring))
 
 ## [1.0.9](https://github.com/auth0/auth0-PHP/tree/1.0.9) (2015-08-03)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.8...1.0.9)
 
 **Closed issues:**
@@ -559,6 +678,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Bad reference in Android PHP API Seed Project Readme file \#67 [\#29](https://github.com/auth0/auth0-PHP/pull/29) ([glena](https://github.com/glena))
 
 ## [1.0.8](https://github.com/auth0/auth0-PHP/tree/1.0.8) (2015-07-27)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.7...1.0.8)
 
 **Closed issues:**
@@ -571,6 +691,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Fix create client api call + new create user example [\#28](https://github.com/auth0/auth0-PHP/pull/28) ([glena](https://github.com/glena))
 
 ## [1.0.7](https://github.com/auth0/auth0-PHP/tree/1.0.7) (2015-07-17)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.6...1.0.7)
 
 **Closed issues:**
@@ -586,6 +707,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - ApiUsers link account identities fix [\#16](https://github.com/auth0/auth0-PHP/pull/16) ([deboorn](https://github.com/deboorn))
 
 ## [1.0.6](https://github.com/auth0/auth0-PHP/tree/1.0.6) (2015-06-12)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.5...1.0.6)
 
 **Merged pull requests:**
@@ -593,6 +715,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Make Auth0::setUser public in order to let update the stored user [\#17](https://github.com/auth0/auth0-PHP/pull/17) ([glena](https://github.com/glena))
 
 ## [1.0.5](https://github.com/auth0/auth0-PHP/tree/1.0.5) (2015-06-02)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.4...1.0.5)
 
 **Merged pull requests:**
@@ -602,9 +725,11 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Auth0JWT encode fix to allow scope with null custom payload [\#13](https://github.com/auth0/auth0-PHP/pull/13) ([deboorn](https://github.com/deboorn))
 
 ## [1.0.4](https://github.com/auth0/auth0-PHP/tree/1.0.4) (2015-05-19)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.3...1.0.4)
 
 ## [1.0.3](https://github.com/auth0/auth0-PHP/tree/1.0.3) (2015-05-15)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.2...1.0.3)
 
 **Merged pull requests:**
@@ -612,18 +737,20 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Applied the new Info Headers schema [\#12](https://github.com/auth0/auth0-PHP/pull/12) ([glena](https://github.com/glena))
 
 ## [1.0.2](https://github.com/auth0/auth0-PHP/tree/1.0.2) (2015-05-13)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.1...1.0.2)
 
 **Closed issues:**
 
 - EU tenants are getting Unauthorize on api calls [\#10](https://github.com/auth0/auth0-PHP/issues/10)
-- PHP Fatal error:  Class 'Auth0\SDK\API\ApiUsers' not found in vendor/auth0/auth0-php/src/Auth0.php on line 256 [\#9](https://github.com/auth0/auth0-PHP/issues/9)
+- PHP Fatal error: Class 'Auth0\SDK\API\ApiUsers' not found in vendor/auth0/auth0-php/src/Auth0.php on line 256 [\#9](https://github.com/auth0/auth0-PHP/issues/9)
 
 **Merged pull requests:**
 
 - Fix EU api calls and autoloading issue [\#11](https://github.com/auth0/auth0-PHP/pull/11) ([glena](https://github.com/glena))
 
 ## [1.0.1](https://github.com/auth0/auth0-PHP/tree/1.0.1) (2015-05-12)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/1.0.0...1.0.1)
 
 **Closed issues:**
@@ -636,9 +763,10 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - SDK Client headers spec compliant \#7 [\#8](https://github.com/auth0/auth0-PHP/pull/8) ([glena](https://github.com/glena))
 
 ## [1.0.0](https://github.com/auth0/auth0-PHP/tree/1.0.0) (2015-05-07)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/0.6.6...1.0.0)
 
-**General 1.x notes** 
+**General 1.x notes**
 
 - Now, all the SDK is under the namespace `\Auth0\SDK`
 - The exceptions were moved to the namespace `\Auth0\SDK\Exceptions`
@@ -659,6 +787,7 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - Fixed port number on PHP README [\#2](https://github.com/auth0/auth0-PHP/pull/2) ([mgonto](https://github.com/mgonto))
 
 ## [0.6.6](https://github.com/auth0/auth0-PHP/tree/0.6.6) (2014-04-14)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/0.6.5...0.6.6)
 
 **Closed issues:**
@@ -666,12 +795,13 @@ $usersList = $auth0Api->users->search([ "q" => "email@test.com" ]);
 - generateUrl\(\) in BaseAuth0 is creating bad URLs [\#1](https://github.com/auth0/auth0-PHP/issues/1)
 
 ## [0.6.5](https://github.com/auth0/auth0-PHP/tree/0.6.5) (2014-04-02)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/0.6.4...0.6.5)
 
 ## [0.6.4](https://github.com/auth0/auth0-PHP/tree/0.6.4) (2014-02-13)
+
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/0.6.3...0.6.4)
 
 ## [0.6.3](https://github.com/auth0/auth0-PHP/tree/0.6.3) (2014-01-06)
 
-
-\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+\* _This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)_

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.3 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
-    "guzzlehttp/guzzle": "^7.0",
+    "guzzlehttp/guzzle": "^7.2",
     "lcobucci/jwt": "dev-3.3-php8-compatibility",
     "psr/simple-cache": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,18 @@
     {
       "type": "git",
       "url": "https://github.com/evansims/jwt.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/php-cache/adapter-common.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/php-cache/hierarchical-cache.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/php-cache/array-adapter.git"
     }
   ],
   "require": {
@@ -30,7 +42,9 @@
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "cache/array-adapter": "^1.0"
+    "cache/adapter-common": "dev-master#b045f70527275df86484a88dd27972251b6be79b",
+    "cache/hierarchical-cache": "dev-master#fd05acabd8396955a4e801c0b5c168d7426a387f",
+    "cache/array-adapter": "dev-master#a0aa5bbd02878079952d730e10b584bfb0cd1625"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.2",
-    "lcobucci/jwt": "dev-3.3-php8-compatibility",
+    "lcobucci/jwt": "dev-3.3-php8-compatibility#daa6aff67a22bf737504143ae55a6913d9ff484d",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "ext-json": "*",
     "lcobucci/jwt": "^3.3",
     "ext-openssl": "*",
+    "guzzlehttp/guzzle": "^7.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,8 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "guzzlehttp/guzzle": "~6.0 | ~7.0",
+    "php": "^7.3 | ^8.0",
     "ext-json": "*",
-    "lcobucci/jwt": "^3.3",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0",
     "lcobucci/jwt": "dev-3.3-php8-compatibility",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^9.3",
     "josegonzalez/dotenv": "^2.0",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",
-    "josegonzalez/dotenv": "^2.0",
+    "josegonzalez/dotenv": "^3.2",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/evansims/jwt.git"
+      "url": "https://github.com/evansims/php-jwt.git"
     }
   ],
   "require": {
@@ -51,15 +51,15 @@
     "test-unit-ci": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --stop-on-failure --coverage-clover=build/coverage.xml --testsuite=unit",
     "test-integration": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text --testsuite=integration",
     "test-integration-ci": "\"vendor/bin/phpunit\" --stop-on-failure --coverage-clover=build/coverage.xml --testsuite=integration",
-    "phpcs": "\"vendor/bin/phpcs\"",
-    "phpcbf": "\"vendor/bin/phpcbf\"",
-    "compat": "\"vendor/bin/phpcs\" --standard=.phpcs-compat.xml.dist",
+    "compat": "@php ./vendor/bin/phpcs --standard=.phpcs-compat.xml.dist",
+    "format": "@php ./vendor/bin/phpcbf",
+    "lint": "@php ./vendor/bin/phpcs",
     "sniffs": "\"vendor/bin/phpcs\" -e",
     "config-phpcs": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
     "pre-commit": [
       "@test",
-      "@compat",
-      "@phpcbf"
+      "@format",
+      "@compat"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,6 @@
     {
       "type": "git",
       "url": "https://github.com/evansims/jwt.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/php-cache/adapter-common.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/php-cache/hierarchical-cache.git"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/php-cache/array-adapter.git"
     }
   ],
   "require": {
@@ -42,9 +30,9 @@
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "cache/adapter-common": "dev-master#b045f70527275df86484a88dd27972251b6be79b",
-    "cache/hierarchical-cache": "dev-master#fd05acabd8396955a4e801c0b5c168d7426a387f",
-    "cache/array-adapter": "dev-master#a0aa5bbd02878079952d730e10b584bfb0cd1625"
+    "cache/adapter-common": "^1.2",
+    "cache/hierarchical-cache": "^1.1",
+    "cache/array-adapter": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/evansims/php-jwt.git"
+      "url": "https://github.com/auth0/php-jwt.git"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,12 @@
       "homepage": "http://www.auth0.com/"
     }
   ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/evansims/jwt.git"
+    }
+  ],
   "require": {
     "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0 | ~7.0",
@@ -17,6 +23,7 @@
     "lcobucci/jwt": "^3.3",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0",
+    "lcobucci/jwt": "dev-3.3-php8-compatibility",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "guzzlehttp/guzzle": "~6.0 | ~7.0",
     "ext-json": "*",
     "lcobucci/jwt": "^3.3",
+    "ext-openssl": "*",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^9.0",
     "josegonzalez/dotenv": "^2.0",
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -389,8 +389,8 @@ class Authentication
     /**
      * Makes a call to the `oauth/token` endpoint with `authorization_code` grant type
      *
-     * @param string $code               Authorization code received during login.
-     * @param string $redirect_uri       Redirect URI sent with authorize request.
+     * @param string      $code          Authorization code received during login.
+     * @param string      $redirect_uri  Redirect URI sent with authorize request.
      * @param string|null $code_verifier The clear-text version of the code_challenge from the /authorize call
      *
      * @return array

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -12,7 +12,7 @@ use Auth0\SDK\API\Header\Telemetry;
 class ApiClient
 {
 
-    const API_VERSION = '7.4.0';
+    const API_VERSION = '7.5.0';
 
     /**
      * Flag to turn telemetry headers off.

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -10,7 +10,7 @@ class Jobs extends GenericResource
      * Retrieves a job. Useful to check its status.
      * Required scopes: "create:users" "read:users"
      *
-     * @param  string  $id
+     * @param string $id
      *
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
@@ -29,7 +29,7 @@ class Jobs extends GenericResource
      * Retrieve error details of a failed job.
      * Required scopes: "create:users" "read:users"
      *
-     * @param  string  $id
+     * @param string $id
      *
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
@@ -48,9 +48,9 @@ class Jobs extends GenericResource
      * Import users from a formatted file into a connection via a long-running job.
      * Required scopes: "create:users" "read:users"
      *
-     * @param  string  $file_path
-     * @param  string  $connection_id
-     * @param  array   $params
+     * @param string $file_path
+     * @param string $connection_id
+     * @param array  $params
      *
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
@@ -85,7 +85,7 @@ class Jobs extends GenericResource
      * Export all users to a file via a long-running job.
      * Required scopes: "read:users"
      *
-     * @param  array  $params
+     * @param array $params
      *
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
      *
@@ -100,19 +100,19 @@ class Jobs extends GenericResource
 
         $body = [];
 
-        if (!empty($params['connection_id'])) {
+        if (! empty($params['connection_id'])) {
             $body['connection_id'] = $params['connection_id'];
         }
 
-        if (!empty($params['format']) && in_array($params['format'], ['json', 'csv'])) {
+        if (! empty($params['format']) && in_array($params['format'], ['json', 'csv'])) {
             $body['format'] = $params['format'];
         }
 
-        if (!empty($params['limit']) && is_numeric($params['limit'])) {
+        if (! empty($params['limit']) && is_numeric($params['limit'])) {
             $body['limit'] = $params['limit'];
         }
 
-        if (!empty($params['fields']) && is_array($params['fields'])) {
+        if (! empty($params['fields']) && is_array($params['fields'])) {
             $body['fields'] = $params['fields'];
         }
 
@@ -146,12 +146,14 @@ class Jobs extends GenericResource
         }
 
         if (! empty( $params['identity'] )) {
-            if ( empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id']) ) {
+            if (empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id'])) {
                 throw new EmptyOrInvalidParameterException('Missing required "user_id" field of the "identity" object.');
             }
-            if ( empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider']) ) {
+
+            if (empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider'])) {
                 throw new EmptyOrInvalidParameterException('Missing required "provider" field of the "identity" object.');
             }
+
             $body['identity'] = $params['identity'];
         }
 

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -10,7 +10,8 @@ use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
  *
  * @package Auth0\SDK\API\Management
  */
-class LogStreams extends GenericResource {
+class LogStreams extends GenericResource
+{
 
     private const LOG_STREAMS_PATH = 'log-streams';
 
@@ -57,9 +58,9 @@ class LogStreams extends GenericResource {
      * Required scope: "create:log_streams"
      *
      * @param array $data Log Stream data to create:
-     *      - "name" if not specified, a name of the Log Stream will be assigned by the Log Stream endpoint.
-     *      - "type" field is required.
-     *      - "sink" field is required. It's value and requirements depends upon the type of Log Stream to create; see the linked documentation below.
+     *                    "name" if not specified, a name of the Log Stream will be assigned by the Log Stream endpoint.
+     *                    "type" field is required.
+     *                    "sink" field is required. It's value and requirements depends upon the type of Log Stream to create; see the linked documentation below.
      *
      * @return mixed
      *
@@ -93,7 +94,7 @@ class LogStreams extends GenericResource {
      * Required scope: "update:log_streams"
      *
      * @param string $log_stream_id the ID of the Log Stream to update.
-     * @param array  $data Log Stream data to update. Only certain fields are update-able; see the documentation linked below.
+     * @param array  $data          Log Stream data to update. Only certain fields are update-able; see the documentation linked below.
      *
      * @return mixed
      *

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -8,14 +8,14 @@ class Tickets extends GenericResource
 {
     /**
      *
-     * @param  string      $user_id
-     * @param  null|string $result_url
-     * @param array  $params  Array of optional parameters to add.
-     *      - ttl_sec: Number of seconds for which the ticket is valid before expiration. If unspecified or set to 0, this value defaults to 432000 seconds (5 days).
-     *      - includeEmailInRedirect: Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
-     *      - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
-     *              - user_id: User ID of the identity to be verified. Must be a non-empty string.
-     *              - provider: Identity provider name of the identity (e.g. google-oauth2). Must be a non-empty string.
+     * @param string      $user_id
+     * @param null|string $result_url
+     * @param array       $params     Array of optional parameters to add.
+     *              - ttl_sec: Number of seconds for which the ticket is valid before expiration. If unspecified or set to 0, this value defaults to 432000 seconds (5 days).
+     *              - includeEmailInRedirect: Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     *              - identity:  The optional identity of the user, as an array. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
+     *                      - user_id: User ID of the identity to be verified. Must be a non-empty string.
+     *                      - provider: Identity provider name of the identity (e.g. google-oauth2). Must be a non-empty string.
      *
      * @throws EmptyOrInvalidParameterException Thrown if any required parameters are empty or invalid.
      * @throws \Exception Thrown by the HTTP client when there is a problem with the API call.
@@ -32,12 +32,14 @@ class Tickets extends GenericResource
         }
 
         if (! empty( $params['identity'] )) {
-            if ( empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id']) ) {
+            if (empty( $params['identity']['user_id']) || ! is_string($params['identity']['user_id'])) {
                 throw new EmptyOrInvalidParameterException('Missing required "user_id" field of the "identity" object.');
             }
-            if ( empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider']) ) {
+
+            if (empty( $params['identity']['provider'] ) || ! is_string($params['identity']['provider'])) {
                 throw new EmptyOrInvalidParameterException('Missing required "provider" field of the "identity" object.');
             }
+
             $body['identity'] = $params['identity'];
         }
 
@@ -69,10 +71,10 @@ class Tickets extends GenericResource
 
     /**
      *
-     * @param  string      $email
-     * @param  null|string $new_password
-     * @param  null|string $result_url
-     * @param  null|string $connection_id
+     * @param  string       $email
+     * @param  null|string  $new_password
+     * @param  null|string  $result_url
+     * @param  null|string  $connection_id
      * @param  null|integer $ttl
      * @return mixed
      */
@@ -89,11 +91,11 @@ class Tickets extends GenericResource
 
     /**
      *
-     * @param  null|string $user_id
-     * @param  null|string $email
-     * @param  null|string $new_password
-     * @param  null|string $result_url
-     * @param  null|string $connection_id
+     * @param  null|string  $user_id
+     * @param  null|string  $email
+     * @param  null|string  $new_password
+     * @param  null|string  $result_url
+     * @param  null|string  $connection_id
      * @param  null|integer $ttl
      * @return mixed
      */

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -34,8 +34,8 @@ use Psr\SimpleCache\CacheInterface;
  */
 class Auth0
 {
-    const TRANSIENT_STATE_KEY = 'state';
-    const TRANSIENT_NONCE_KEY = 'nonce';
+    const TRANSIENT_STATE_KEY         = 'state';
+    const TRANSIENT_NONCE_KEY         = 'nonce';
     const TRANSIENT_CODE_VERIFIER_KEY = 'code_verifier';
 
     /**
@@ -172,12 +172,12 @@ class Auth0
      */
     protected $skipUserinfo;
 
-	/**
-	 * Enable Authorization Code Flow with Proof Key for Code Exchange (PKCE)
-	 *
-	 * @var boolean
-	 */
-	protected $enablePkce;
+    /**
+     * Enable Authorization Code Flow with Proof Key for Code Exchange (PKCE)
+     *
+     * @var boolean
+     */
+    protected $enablePkce;
 
     /**
      * Algorithm used for ID token validation.
@@ -425,7 +425,7 @@ class Auth0
         }
 
         if ($this->enablePkce) {
-            $codeVerifier = PKCE::generateCodeVerifier(128);
+            $codeVerifier                  = PKCE::generateCodeVerifier(128);
             $auth_params['code_challenge'] = PKCE::generateCodeChallenge($codeVerifier);
             // The PKCE spec defines two methods, S256 and plain, the former is
             // the only one supported by Auth0 since the latter is discouraged.
@@ -541,7 +541,7 @@ class Auth0
         $code_verifier = null;
         if ($this->enablePkce) {
             $code_verifier = $this->transientHandler->getOnce(self::TRANSIENT_CODE_VERIFIER_KEY);
-            if (!$code_verifier) {
+            if (! $code_verifier) {
                 throw new CoreException('Missing code_verifier');
             }
         }

--- a/src/Helpers/JWKFetcher.php
+++ b/src/Helpers/JWKFetcher.php
@@ -70,7 +70,7 @@ class JWKFetcher
         $this->cache         = $cache;
         $this->guzzleOptions = $guzzleOptions;
 
-        if (!empty($options['ttl'])) {
+        if (! empty($options['ttl'])) {
             $this->setTtl($options['ttl']);
         }
     }
@@ -176,7 +176,7 @@ class JWKFetcher
      * Set how long to cache JWKs in seconds.
      * We strongly encouraged you leave the default value.
      *
-     * @param string  $ttlSeconds  Number of seconds to keep a JWK in memory.
+     * @param string $ttlSeconds Number of seconds to keep a JWK in memory.
      *
      * @return $this
      *
@@ -205,7 +205,7 @@ class JWKFetcher
     /**
      * Generate a cache id to use for a URL.
      *
-     * @param string  $jwks_url  Full URL to the JWKS.
+     * @param string $jwks_url Full URL to the JWKS.
      *
      * @return string
      */
@@ -224,7 +224,7 @@ class JWKFetcher
     /**
      * Get a specific JWK from the cache by it's URL.
      *
-     * @param string  $jwks_url  Full URL to the JWKS.
+     * @param string $jwks_url Full URL to the JWKS.
      *
      * @return null|array
      */
@@ -240,11 +240,11 @@ class JWKFetcher
         return null;
     }
 
-   /**
+    /**
      * Add or overwrite a specific JWK from the cache.
      *
-     * @param string  $jwks_url  Full URL to the JWKS.
-     * @param array   $keys      An array representing the JWKS.
+     * @param string $jwks_url Full URL to the JWKS.
+     * @param array  $keys     An array representing the JWKS.
      *
      * @return $this
      */
@@ -260,7 +260,7 @@ class JWKFetcher
     /**
      * Remove a specific JWK from the cache by it's URL.
      *
-     * @param string  $jwks_url  Full URL to the JWKS.
+     * @param string $jwks_url Full URL to the JWKS.
      *
      * @return boolean
      */

--- a/src/Helpers/PKCE.php
+++ b/src/Helpers/PKCE.php
@@ -15,7 +15,7 @@ class PKCE
      * letters, numbers and "-", ".", "_", "~", as defined in the RFC 7636
      * specification.
      *
-     * @param int $length Code verifier length
+     * @param integer $length Code verifier length
      *
      * @return string
      *

--- a/src/Helpers/PKCE.php
+++ b/src/Helpers/PKCE.php
@@ -25,7 +25,7 @@ class PKCE
     {
         if ($length < 43 || $length > 128) {
             throw new \InvalidArgumentException(
-                'Code verifier must be crated with a minimum length of 43 characters and a maximum length of 128 characters.'
+                'Code verifier must be created with a minimum length of 43 characters and a maximum length of 128 characters.'
             );
         }
 

--- a/tests/integration/API/Authentication/DbConnectionsIntegrationTest.php
+++ b/tests/integration/API/Authentication/DbConnectionsIntegrationTest.php
@@ -11,7 +11,7 @@ class DbConnectionsIntegrationTest extends ApiTests
 
     protected $connection = 'Username-Password-Authentication';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->email = 'test-dbconnections-user'.rand().'@test.com';
     }
@@ -46,6 +46,6 @@ class DbConnectionsIntegrationTest extends ApiTests
         $response = $api->dbconnections_change_password($email, $connection);
 
         $this->assertNotEmpty($response);
-        $this->assertContains('email', $response);
+        $this->assertStringContainsString('email', $response);
     }
 }

--- a/tests/integration/API/Management/ClientGrantsIntegrationTest.php
+++ b/tests/integration/API/Management/ClientGrantsIntegrationTest.php
@@ -42,7 +42,7 @@ class ClientGrantsIntegrationTest extends ApiTests
      * @throws \Auth0\SDK\Exception\ApiException
      * @throws \Exception
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::getEnv();
         $api       = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
@@ -59,7 +59,7 @@ class ClientGrantsIntegrationTest extends ApiTests
         usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -68,7 +68,7 @@ class ClientGrantsIntegrationTest extends ApiTests
      * @throws CoreException
      * @throws \Exception
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -18,7 +18,7 @@ class JobsIntegrationTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$testImportUsersJsonPath = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
     }

--- a/tests/integration/API/Management/LogsIntegrationTest.php
+++ b/tests/integration/API/Management/LogsIntegrationTest.php
@@ -28,7 +28,7 @@ class LogsIntegrationTest extends ApiTests
      *
      * @throws \Auth0\SDK\Exception\ApiException
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $env = self::getEnv();
         $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);

--- a/tests/integration/API/Management/ResourceServersIntegrationTest.php
+++ b/tests/integration/API/Management/ResourceServersIntegrationTest.php
@@ -52,7 +52,7 @@ class ResourceServersIntegrationTest extends ApiTests
      *
      * @throws \Auth0\SDK\Exception\ApiException
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $env = self::getEnv();
         $api = new Management($env['API_TOKEN'], $env['DOMAIN'], ['timeout' => 30]);

--- a/tests/integration/API/Management/RulesIntegrationTest.php
+++ b/tests/integration/API/Management/RulesIntegrationTest.php
@@ -28,7 +28,7 @@ class RulesIntegrationTest extends ApiTests
      *
      * @throws \Auth0\SDK\Exception\ApiException
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::getEnv();
     }

--- a/tests/unit/API/Authentication/PasswordGrantTest.php
+++ b/tests/unit/API/Authentication/PasswordGrantTest.php
@@ -29,7 +29,7 @@ class PasswordGrantTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/unit/API/Authentication/PasswordlessTest.php
+++ b/tests/unit/API/Authentication/PasswordlessTest.php
@@ -27,7 +27,7 @@ class PasswordlessTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/unit/API/Authentication/RefreshTokenTest.php
+++ b/tests/unit/API/Authentication/RefreshTokenTest.php
@@ -33,7 +33,7 @@ class RefreshTokenTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();

--- a/tests/unit/API/Authentication/UrlBuildersTest.php
+++ b/tests/unit/API/Authentication/UrlBuildersTest.php
@@ -22,11 +22,11 @@ class UrlBuildersTest extends TestCase
         $this->assertContains('redirect_uri=https%3A%2F%2Fexample.com%2Fcb', $authorize_url_query);
         $this->assertContains('response_type=code', $authorize_url_query);
         $this->assertContains('client_id=__test_client_id__', $authorize_url_query);
-        $this->assertNotContains('connection=', $authorize_url_parts['query']);
-        $this->assertNotContains('state=', $authorize_url_parts['query']);
+        $this->assertStringNotContainsString('connection=', $authorize_url_parts['query']);
+        $this->assertStringNotContainsString('state=', $authorize_url_parts['query']);
 
         // Telemetry should not be added to any browser URLs.
-        $this->assertNotContains('auth0Client=', $authorize_url_parts['query']);
+        $this->assertStringNotContainsString('auth0Client=', $authorize_url_parts['query']);
     }
 
     public function testThatAuthorizeLinkIncludesConnection()

--- a/tests/unit/API/Helpers/InformationHeadersExtendTest.php
+++ b/tests/unit/API/Helpers/InformationHeadersExtendTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class InformationHeadersExtendTest extends TestCase
 {
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $reset_headers = new InformationHeaders;
         $reset_headers->setCorePackage();

--- a/tests/unit/API/Management/BlacklistsTest.php
+++ b/tests/unit/API/Management/BlacklistsTest.php
@@ -26,7 +26,7 @@ class BlacklistsTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();

--- a/tests/unit/API/Management/ClientsTest.php
+++ b/tests/unit/API/Management/ClientsTest.php
@@ -32,7 +32,7 @@ class ClientsTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -69,11 +69,11 @@ class ClientsTest extends ApiTests
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/clients', $api->getHistoryUrl() );
 
         $query = '&'.$api->getHistoryQuery();
-        $this->assertContains( '&fields=field1,field2', $query );
-        $this->assertContains( '&include_fields=false', $query );
-        $this->assertContains( '&page=1', $query );
-        $this->assertContains( '&per_page=5', $query );
-        $this->assertContains( '&include_totals=true', $query );
+        $this->assertStringContainsString( '&fields=field1,field2', $query );
+        $this->assertStringContainsString( '&include_fields=false', $query );
+        $this->assertStringContainsString( '&page=1', $query );
+        $this->assertStringContainsString( '&per_page=5', $query );
+        $this->assertStringContainsString( '&include_totals=true', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -93,8 +93,8 @@ class ClientsTest extends ApiTests
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/clients/__test_id__', $api->getHistoryUrl() );
 
         $query = '&'.$api->getHistoryQuery();
-        $this->assertContains( '&fields=field3,field4', $query );
-        $this->assertContains( '&include_fields=true', $query );
+        $this->assertStringContainsString( '&fields=field3,field4', $query );
+        $this->assertStringContainsString( '&include_fields=true', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );

--- a/tests/unit/API/Management/ConnectionsMockedTest.php
+++ b/tests/unit/API/Management/ConnectionsMockedTest.php
@@ -33,7 +33,7 @@ class ConnectionsTestMocked extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -79,7 +79,7 @@ class ConnectionsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
-        $this->assertContains( 'strategy='.$strategy, $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'strategy='.$strategy, $api->getHistoryQuery() );
     }
 
     /**
@@ -96,17 +96,19 @@ class ConnectionsTestMocked extends TestCase
         $strategy = null;
         $fields   = ['id', 'name'];
         $api->call()->connections()->getAll($strategy, $fields);
+        $query = $api->getHistoryQuery();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
-        $this->assertContains( 'fields='.implode(',', $fields), $api->getHistoryQuery() );
-        $this->assertNotContains( 'include_fields=true', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'fields='.implode(',', $fields), $query );
+        $this->assertStringNotContainsString( 'include_fields=true', $query );
 
         // Test an explicit true for includeFields.
         $include_fields = true;
         $api->call()->connections()->getAll($strategy, $fields, $include_fields);
+        $query = $api->getHistoryQuery();
 
-        $this->assertContains( 'include_fields=true', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'include_fields=true', $query );
     }
 
     /**
@@ -127,8 +129,10 @@ class ConnectionsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
-        $this->assertContains( 'fields='.implode(',', $fields), $api->getHistoryQuery() );
-        $this->assertContains( 'include_fields=false', $api->getHistoryQuery() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'fields='.implode(',', $fields), $query );
+        $this->assertStringContainsString( 'include_fields=false', $query );
     }
 
     /**
@@ -151,8 +155,10 @@ class ConnectionsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
-        $this->assertContains( 'page=0', $api->getHistoryQuery() );
-        $this->assertContains( 'per_page=5', $api->getHistoryQuery() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'page=0', $query );
+        $this->assertStringContainsString( 'per_page=5', $query );
     }
 
     /**
@@ -176,8 +182,10 @@ class ConnectionsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections', $api->getHistoryUrl() );
-        $this->assertContains( 'param1=value1', $api->getHistoryQuery() );
-        $this->assertContains( 'param2=value2', $api->getHistoryQuery() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'param1=value1', $query );
+        $this->assertStringContainsString( 'param2=value2', $query );
     }
 
     /**
@@ -213,17 +221,19 @@ class ConnectionsTestMocked extends TestCase
         $id     = 'con_testConnection10';
         $fields = ['name', 'strategy'];
         $api->call()->connections()->get($id, $fields);
+        $query = $api->getHistoryQuery();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
-        $this->assertContains( 'fields='.implode(',', $fields), $api->getHistoryQuery() );
-        $this->assertNotContains( 'include_fields=', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'fields='.implode(',', $fields), $query );
+        $this->assertStringNotContainsString( 'include_fields=', $query );
 
         // Test an explicit true for includeFields.
         $include_fields = true;
         $api->call()->connections()->get($id, $fields, $include_fields);
+        $query = $api->getHistoryQuery();
 
-        $this->assertContains( 'include_fields=true', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'include_fields=true', $query );
     }
 
     /**
@@ -244,8 +254,10 @@ class ConnectionsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/connections/'.$id, $api->getHistoryUrl() );
-        $this->assertContains( 'fields='.implode(',', $fields), $api->getHistoryQuery() );
-        $this->assertContains( 'include_fields=false', $api->getHistoryQuery() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'fields='.implode(',', $fields), $query );
+        $this->assertStringContainsString( 'include_fields=false', $query );
     }
 
     /**
@@ -287,7 +299,7 @@ class ConnectionsTestMocked extends TestCase
         $api->call()->connections()->deleteUser($id, $email);
 
         $this->assertEquals( 'DELETE', $api->getHistoryMethod() );
-        $this->assertContains( 'https://api.test.local/api/v2/connections/'.$id.'/users', $api->getHistoryUrl() );
+        $this->assertStringContainsString( 'https://api.test.local/api/v2/connections/'.$id.'/users', $api->getHistoryUrl() );
         $this->assertEquals( 'email='.$email, $api->getHistoryQuery() );
 
         $headers = $api->getHistoryHeaders();

--- a/tests/unit/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/unit/API/Management/EmailTemplatesMockedTest.php
@@ -35,7 +35,7 @@ class EmailTemplatesMockedTest extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();

--- a/tests/unit/API/Management/EmailsMockedTest.php
+++ b/tests/unit/API/Management/EmailsMockedTest.php
@@ -34,7 +34,7 @@ class EmailsMockedTest extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -69,7 +69,7 @@ class EmailsMockedTest extends TestCase
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/emails/provider', $api->getHistoryUrl() );
 
         $params = $api->getHistoryQuery();
-        $this->assertContains( 'fields=name,credentials', $params );
-        $this->assertContains( 'include_fields=true', $params );
+        $this->assertStringContainsString( 'fields=name,credentials', $params );
+        $this->assertStringContainsString( 'include_fields=true', $params );
     }
 }

--- a/tests/unit/API/Management/GrantsMockedTest.php
+++ b/tests/unit/API/Management/GrantsMockedTest.php
@@ -28,7 +28,7 @@ class GrantsTestMocked extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -71,18 +71,21 @@ class GrantsTestMocked extends TestCase
         $page     = 1;
         $per_page = 5;
         $api->call()->grants()->getAll($page, $per_page);
+        $query = $api->getHistoryQuery();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
-        $this->assertContains( 'page=1', $api->getHistoryQuery() );
-        $this->assertContains( 'per_page=5', $api->getHistoryQuery() );
+
+        $this->assertStringContainsString( 'page=1', $query );
+        $this->assertStringContainsString( 'per_page=5', $query );
 
         $page     = 2;
         $per_page = null;
         $api->call()->grants()->getAll($page, $per_page);
+        $query = $api->getHistoryQuery();
 
-        $this->assertContains( 'page=2', $api->getHistoryQuery() );
-        $this->assertNotContains( 'per_page=', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'page=2', $query );
+        $this->assertStringNotContainsString( 'per_page=', $query );
 
         $page     = false;
         $per_page = false;
@@ -107,8 +110,10 @@ class GrantsTestMocked extends TestCase
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/grants', $api->getHistoryUrl() );
-        $this->assertContains( 'param1=value1', $api->getHistoryQuery() );
-        $this->assertContains( 'param2=value2', $api->getHistoryQuery() );
+
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'param1=value1', $query );
+        $this->assertStringContainsString( 'param2=value2', $query );
     }
 
     /**
@@ -141,8 +146,9 @@ class GrantsTestMocked extends TestCase
 
         $api->call()->grants()->getByClientId('__test_client_id__', 1, 2);
 
-        $this->assertContains( 'page=1', $api->getHistoryQuery() );
-        $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'page=1', $query );
+        $this->assertStringContainsString( 'per_page=2', $query );
     }
 
     /**
@@ -205,8 +211,9 @@ class GrantsTestMocked extends TestCase
 
         $api->call()->grants()->getByAudience('__test_audience__', 1, 2);
 
-        $this->assertContains( 'page=1', $api->getHistoryQuery() );
-        $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'page=1', $query );
+        $this->assertStringContainsString( 'per_page=2', $query );
     }
 
     /**
@@ -269,8 +276,9 @@ class GrantsTestMocked extends TestCase
 
         $api->call()->grants()->getByUserId('__test_user_id__', 1, 2);
 
-        $this->assertContains( 'page=1', $api->getHistoryQuery() );
-        $this->assertContains( 'per_page=2', $api->getHistoryQuery() );
+        $query = $api->getHistoryQuery();
+        $this->assertStringContainsString( 'page=1', $query );
+        $this->assertStringContainsString( 'per_page=2', $query );
     }
 
     /**

--- a/tests/unit/API/Management/GuardianTest.php
+++ b/tests/unit/API/Management/GuardianTest.php
@@ -26,7 +26,7 @@ class GuardianTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();

--- a/tests/unit/API/Management/JobsTest.php
+++ b/tests/unit/API/Management/JobsTest.php
@@ -35,7 +35,7 @@ class JobsTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$testImportUsersJsonPath = AUTH0_PHP_TEST_JSON_DIR.'test-import-users-file.json';
         $infoHeadersData               = new InformationHeaders;
@@ -107,8 +107,8 @@ class JobsTest extends ApiTests
 
         // Test that the form data contains our import file content.
         $import_content = file_get_contents( self::$testImportUsersJsonPath );
-        $this->assertContains( 'name="users"; filename="test-import-users-file.json"', $form_body );
-        $this->assertContains( $import_content, $form_body );
+        $this->assertStringContainsString( 'name="users"; filename="test-import-users-file.json"', $form_body );
+        $this->assertStringContainsString( $import_content, $form_body );
 
         $conn_id_key = array_search( 'Content-Disposition: form-data; name="connection_id"', $form_body_arr );
         $this->assertNotEmpty( $conn_id_key );

--- a/tests/unit/API/Management/LogStreamsTest.php
+++ b/tests/unit/API/Management/LogStreamsTest.php
@@ -28,7 +28,7 @@ class LogStreamsTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -74,7 +74,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid log_stream_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid log_stream_id', $exception_message );
     }
 
     public function testThatCreateLogStreamRequestIsFormedCorrectly()
@@ -123,7 +123,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "data" parameter', $exception_message );
+        $this->assertStringContainsString( 'Missing required "data" parameter', $exception_message );
     }
 
     public function testThatCreateLogStreamRequestWithEmptyTypeThrowsException()
@@ -145,7 +145,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "type" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "type" field', $exception_message );
     }
 
     public function testThatCreateLogStreamRequestWithMissingSinkThrowsException()
@@ -162,7 +162,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "sink" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "sink" field', $exception_message );
     }
 
     public function testThatCreateLogStreamRequestWithEmptySinkThrowsException()
@@ -180,7 +180,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "sink" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "sink" field', $exception_message );
     }
 
     public function testThatUpdateLogStreamRequestIsFormedCorrectly()
@@ -215,7 +215,7 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "log_stream_id" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "log_stream_id" field', $exception_message );
     }
 
     public function testThatDeleteLogStreamRequestIsFormedCorrectly()
@@ -244,6 +244,6 @@ class LogStreamsTest extends ApiTests
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "log_stream_id" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "log_stream_id" field', $exception_message );
     }
 }

--- a/tests/unit/API/Management/RolesMockedTest.php
+++ b/tests/unit/API/Management/RolesMockedTest.php
@@ -35,7 +35,7 @@ class RolesTestMocked extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -59,8 +59,8 @@ class RolesTestMocked extends TestCase
         $this->assertStringStartsWith( 'https://api.test.local/api/v2/roles', $api->getHistoryUrl() );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=2', $query );
-        $this->assertContains( 'name_filter=__test_name_filter__', $query );
+        $this->assertStringContainsString( 'page=2', $query );
+        $this->assertStringContainsString( 'name_filter=__test_name_filter__', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -85,7 +85,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid name', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid name', $exception_message );
     }
 
     /**
@@ -134,7 +134,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -176,7 +176,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -218,7 +218,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -265,7 +265,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -292,8 +292,8 @@ class RolesTestMocked extends TestCase
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=3', $query );
-        $this->assertContains( 'per_page=6', $query );
+        $this->assertStringContainsString( 'page=3', $query );
+        $this->assertStringContainsString( 'per_page=6', $query );
     }
 
     /**
@@ -312,11 +312,11 @@ class RolesTestMocked extends TestCase
 
         $api->call()->roles()->getPermissions( '__test_role_id__', [ 'include_totals' => false ] );
 
-        $this->assertContains( 'include_totals=false', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'include_totals=false', $api->getHistoryQuery() );
 
         $api->call()->roles()->getPermissions( '__test_role_id__', [ 'include_totals' => 1 ] );
 
-        $this->assertContains( 'include_totals=true', $api->getHistoryQuery() );
+        $this->assertStringContainsString( 'include_totals=true', $api->getHistoryQuery() );
     }
 
     /**
@@ -337,7 +337,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -420,7 +420,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -517,7 +517,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -544,8 +544,8 @@ class RolesTestMocked extends TestCase
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=6', $query );
-        $this->assertContains( 'include_totals=true', $query );
+        $this->assertStringContainsString( 'page=6', $query );
+        $this->assertStringContainsString( 'include_totals=true', $query );
     }
 
     /**
@@ -566,7 +566,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid role_id', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid role_id', $exception_message );
     }
 
     /**
@@ -587,7 +587,7 @@ class RolesTestMocked extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid users', $exception_message );
+        $this->assertStringContainsString( 'Empty or invalid users', $exception_message );
     }
 
     /**

--- a/tests/unit/API/Management/TicketsTest.php
+++ b/tests/unit/API/Management/TicketsTest.php
@@ -28,7 +28,7 @@ class TicketsTest extends ApiTests
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData               = new InformationHeaders;
         $infoHeadersData->setCorePackage();

--- a/tests/unit/API/Management/UsersMockedTest.php
+++ b/tests/unit/API/Management/UsersMockedTest.php
@@ -36,7 +36,7 @@ class UsersMockedTest extends TestCase
     /**
      * Runs before test suite starts.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $infoHeadersData = new InformationHeaders;
         $infoHeadersData->setCorePackage();
@@ -112,7 +112,7 @@ class UsersMockedTest extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "connection" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "connection" field', $exception_message );
     }
 
     public function testThatExceptionIsThrownWhenSmsConnectionHasNoPhoneNumber()
@@ -126,7 +126,7 @@ class UsersMockedTest extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "phone_number" field for sms connection', $exception_message );
+        $this->assertStringContainsString( 'Missing required "phone_number" field for sms connection', $exception_message );
     }
 
     public function testThatExceptionIsThrownWhenConnectionHasNoEmailAddress()
@@ -140,7 +140,7 @@ class UsersMockedTest extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "email" field', $exception_message );
+        $this->assertStringContainsString( 'Missing required "email" field', $exception_message );
     }
 
     public function testThatExceptionIsThrownWhenDbConnectionHasNoPassword()
@@ -154,7 +154,7 @@ class UsersMockedTest extends TestCase
             $exception_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Missing required "password" field for "auth0" connection', $exception_message );
+        $this->assertStringContainsString( 'Missing required "password" field for "auth0" connection', $exception_message );
     }
 
     /**
@@ -285,8 +285,8 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [], [ 'field3', 'field4' ], true );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'fields=field3,field4', $query );
-        $this->assertContains( 'include_fields=true', $query );
+        $this->assertStringContainsString( 'fields=field3,field4', $query );
+        $this->assertStringContainsString( 'include_fields=true', $query );
     }
 
     /**
@@ -303,8 +303,8 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [ 'include_fields' => false ], [ 'field3' ], true );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'fields=field3', $query );
-        $this->assertContains( 'include_fields=false', $query );
+        $this->assertStringContainsString( 'fields=field3', $query );
+        $this->assertStringContainsString( 'include_fields=false', $query );
     }
 
     /**
@@ -321,8 +321,8 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [], [ 'field3' ], uniqid() );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'fields=field3', $query );
-        $this->assertContains( 'include_fields=true', $query );
+        $this->assertStringContainsString( 'fields=field3', $query );
+        $this->assertStringContainsString( 'include_fields=true', $query );
     }
 
     /**
@@ -342,12 +342,12 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [], [], null, 10 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=10', $query );
+        $this->assertStringContainsString( 'page=10', $query );
 
         $api->call()->users()->getAll( [], [], null, -10 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=10', $query );
+        $this->assertStringContainsString( 'page=10', $query );
     }
 
     /**
@@ -364,7 +364,7 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [ 'page' => 11 ], [], null, 22 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'page=11', $query );
+        $this->assertStringContainsString( 'page=11', $query );
     }
 
     /**
@@ -384,12 +384,12 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [], [], null, null, 10 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=10', $query );
+        $this->assertStringContainsString( 'per_page=10', $query );
 
         $api->call()->users()->getAll( [], [], null, null, -10 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=10', $query );
+        $this->assertStringContainsString( 'per_page=10', $query );
     }
 
     /**
@@ -406,7 +406,7 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll( [ 'per_page' => 8 ], [], null, null, 9 );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=8', $query );
+        $this->assertStringContainsString( 'per_page=8', $query );
     }
 
     /**
@@ -537,7 +537,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -560,9 +560,9 @@ class UsersMockedTest extends TestCase
         );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=5', $query );
-        $this->assertContains( 'page=1', $query );
-        $this->assertContains( 'include_totals=true', $query );
+        $this->assertStringContainsString( 'per_page=5', $query );
+        $this->assertStringContainsString( 'page=1', $query );
+        $this->assertStringContainsString( 'include_totals=true', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -587,7 +587,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -608,7 +608,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid roles', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid roles', $caught_message );
     }
 
     /**
@@ -659,7 +659,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -680,7 +680,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid roles', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid roles', $caught_message );
     }
 
     /**
@@ -731,7 +731,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -776,7 +776,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -802,9 +802,9 @@ class UsersMockedTest extends TestCase
         );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=3', $query );
-        $this->assertContains( 'page=2', $query );
-        $this->assertContains( 'include_totals=false', $query );
+        $this->assertStringContainsString( 'per_page=3', $query );
+        $this->assertStringContainsString( 'page=2', $query );
+        $this->assertStringContainsString( 'include_totals=false', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -829,7 +829,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -912,7 +912,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -995,7 +995,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -1021,10 +1021,10 @@ class UsersMockedTest extends TestCase
         );
 
         $query = $api->getHistoryQuery();
-        $this->assertContains( 'per_page=3', $query );
-        $this->assertContains( 'page=2', $query );
-        $this->assertContains( 'include_totals=false', $query );
-        $this->assertContains( 'fields=date,type,ip', $query );
+        $this->assertStringContainsString( 'per_page=3', $query );
+        $this->assertStringContainsString( 'page=2', $query );
+        $this->assertStringContainsString( 'include_totals=false', $query );
+        $this->assertStringContainsString( 'fields=date,type,ip', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -1049,7 +1049,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**
@@ -1095,7 +1095,7 @@ class UsersMockedTest extends TestCase
             $caught_message = $e->getMessage();
         }
 
-        $this->assertContains( 'Empty or invalid user_id', $caught_message );
+        $this->assertStringContainsString( 'Empty or invalid user_id', $caught_message );
     }
 
     /**

--- a/tests/unit/Auth0StoreTest.php
+++ b/tests/unit/Auth0StoreTest.php
@@ -32,7 +32,7 @@ class Auth0StoreTest extends TestCase
     /**
      * Runs after each test completes.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -47,7 +47,7 @@ class Auth0StoreTest extends TestCase
     /**
      * Runs after each test completes.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $_GET     = [];

--- a/tests/unit/Auth0Test.php
+++ b/tests/unit/Auth0Test.php
@@ -43,7 +43,7 @@ class Auth0Test extends TestCase
     /**
      * Runs after each test completes.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class Auth0Test extends TestCase
     /**
      * Runs after each test completes.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $_GET     = [];
@@ -525,7 +525,7 @@ class Auth0Test extends TestCase
         $url_query        = explode( '&', $parsed_url_query );
 
         $this->assertArrayHasKey( 'auth0__code_verifier', $_SESSION );
-        $this->assertContains( 'code_challenge=', $parsed_url_query );
+        $this->assertStringContainsString( 'code_challenge=', $parsed_url_query );
         $this->assertContains( 'code_challenge_method=S256', $url_query );
     }
 

--- a/tests/unit/Helpers/JWKFetcherTest.php
+++ b/tests/unit/Helpers/JWKFetcherTest.php
@@ -68,14 +68,14 @@ class JWKFetcherTest extends TestCase
 
         $jwks_formatted_1 = $jwks->call()->getKeys( '__test_url__' );
         $this->assertArrayHasKey( 'abc', $jwks_formatted_1 );
-        $this->assertContains( '123', $jwks_formatted_1['abc'] );
+        $this->assertStringContainsString( '123', $jwks_formatted_1['abc'] );
 
         $jwks_formatted_2 = $jwks->call()->getKeys( '__test_url__' );
         $this->assertEquals( $jwks_formatted_1, $jwks_formatted_2 );
 
         $jwks_formatted_2 = $jwks->call()->getKeys( '__test_url_2__' );
         $this->assertArrayHasKey( 'def', $jwks_formatted_2 );
-        $this->assertContains( '456', $jwks_formatted_2['def'] );
+        $this->assertStringContainsString( '456', $jwks_formatted_2['def'] );
     }
 
     public function testThatGetKeyBreaksCache()
@@ -136,7 +136,7 @@ class JWKFetcherTest extends TestCase
 
         $cache->set(md5('__test_jwks_url__'), ['__test_kid_1__' => '__test_x5c_1__']);
 
-        $this->assertContains('__test_x5c_2__', $jwks->call()->getKey('__test_kid_2__'));
+        $this->assertStringContainsString('__test_x5c_2__', $jwks->call()->getKey('__test_kid_2__'));
     }
 
     public function testThatEmptyUrlReturnsEmptyKeys() {
@@ -186,7 +186,7 @@ class JWKFetcherTest extends TestCase
         $this->assertEquals(null, $jwks->call()->getKey('__test_missing_kid__'));
 
         // Requesting a valid kid MUST return an ARRAY containing the x5c
-        $this->assertContains('__x5c_1__', $jwks->call()->getKey('__kid_1__'));
+        $this->assertStringContainsString('__x5c_1__', $jwks->call()->getKey('__kid_1__'));
 
         // Pulling directly from cache will return same results as getKeys()
         $this->assertArrayHasKey('__kid_1__', $jwks->call()->getCacheEntry('__test_jwks_url__'));

--- a/tests/unit/Helpers/PKCETest.php
+++ b/tests/unit/Helpers/PKCETest.php
@@ -14,7 +14,7 @@ class PKCETest extends TestCase
     public function testThatGenerateCodeVerifierThrowsExceptionWhenLengthIsInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Code verifier must be crated with a minimum length of 43 characters and a maximum length of 128 characters.');
+        $this->expectExceptionMessage('Code verifier must be created with a minimum length of 43 characters and a maximum length of 128 characters.');
         PKCE::generateCodeVerifier(10);
     }
 

--- a/tests/unit/Helpers/TransientStoreHandlerTest.php
+++ b/tests/unit/Helpers/TransientStoreHandlerTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class TransientStoreHandlerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $_SESSION = [];

--- a/tests/unit/Store/SessionStoreTest.php
+++ b/tests/unit/Store/SessionStoreTest.php
@@ -45,7 +45,7 @@ class SessionStoreTest extends TestCase
      *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$sessionStore = new SessionStore();
         self::$sessionKey   = 'auth0__'.self::TEST_KEY;


### PR DESCRIPTION
### Description
This branch includes work necessary for the SDK to work with the new release of PHP 8. Most of this PR involves making accommodations for updated dependencies, as the library's own code is compatible with PHP 8.

- These changes require us to bump our minimum supported PHP version from 7.1 to 7.3.
- PHPUnit dependency bumped to 9.3 (from 7) as PHP 8 support will not be getting backported.
- Updated unit tests to support syntax changes in PHPUnit 9. Functionally they are unchanged.
- Introduced a reflection workaround to accommodate PHPUnit 8+ dropping support for accessing invocation stacks natively.
- Guzzle dependency bumped to 7.2 as PHP 8 support will not be getting backported. Drops support for Guzzle 6.
- Overrides our JWT dependency to use a patched repo @ https://github.com/auth0/php-jwt/tree/3.3-php8-compatibility (1)
- Improvements to code styling/formatting and docblock definitions

1. PHP 8 introduces [changes to the OpenSSL functions](https://github.com/php/php-src/blob/php-8.0.0RC4/UPGRADING#L408) which cause the JWT library we depend on to break. The author of the library appears to be working on a major refactoring for a future release (which will require non-trivial effort for us to adapt the SDK to those changes), so I've forked the stable build we currently use and have applied a patch to fix the issues until the upstream package is fixed, and we're able to adapt the SDK to the changes they're making to the library.

~~Note: Our CircleCI tests will fail for this PR as we are testing against PHP versions that this PR drops support for.~~ PHP 7.1 and 7.2 CI tests have been removed to make way for these changes.

### Testing these changes locally
CircleCI is already configured to run our standard tests using PHP 8.0 for this PR; you can review the results in the PR timeline. If you'd like to test these changes locally, you should:

- Install PHP 8.0; configure your local environment to use it
- Fork PR branch
- Run 'composer install' to install dependencies
- Run 'composer test-unit' to ensure 8.0 compatibility
- Run 'composer compat' to ensure 7.3+ compatibility