### PR TITLE
Secret keys should be instances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0 | ~7.0",
     "ext-json": "*",
-    "lcobucci/jwt": "^3.3",
+    "lcobucci/jwt": "^3.3 | ^4.0.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/src/Helpers/Tokens/SymmetricVerifier.php
+++ b/src/Helpers/Tokens/SymmetricVerifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\Helpers\Tokens;
 
 use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
+use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token;
 
 /**
@@ -17,7 +18,7 @@ final class SymmetricVerifier extends SignatureVerifier
     /**
      * Client secret for the application.
      *
-     * @var string
+     * @var Key
      */
     private $clientSecret;
 
@@ -28,7 +29,7 @@ final class SymmetricVerifier extends SignatureVerifier
      */
     public function __construct(string $clientSecret)
     {
-        $this->clientSecret = $clientSecret;
+        $this->clientSecret = new Key($clientSecret);
         parent::__construct('HS256');
     }
 


### PR DESCRIPTION
fix: secret key should not be string (trigger errors) but `Key` instances