### PR TITLE
Add static analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ commands:
           key: composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}
           paths:
             - vendor
+  run-static-analysis:
+    steps:
+      - run: composer static-analysis
   run-unit-tests:
     steps:
       - run: composer test-unit-ci
@@ -37,6 +40,7 @@ jobs:
       - image: circleci/php:7.1
     steps:
       - prepare
+      - run-static-analysis
       - run-unit-tests
       - run:
           command: bash <(curl -s https://codecov.io/bash)
@@ -46,6 +50,7 @@ jobs:
       - image: circleci/php:7.2
     steps:
       - prepare
+      - run-static-analysis
       - run-unit-tests
       - run:
           command: bash <(curl -s https://codecov.io/bash)
@@ -55,6 +60,7 @@ jobs:
       - image: circleci/php:7.3
     steps:
       - prepare
+      - run-static-analysis
       - run-unit-tests
       - run:
           command: bash <(curl -s https://codecov.io/bash)
@@ -64,6 +70,7 @@ jobs:
       - image: circleci/php:7.4
     steps:
       - prepare
+      - run-static-analysis
       - run-unit-tests
       - run:
           command: bash <(curl -s https://codecov.io/bash)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,12 @@ echo '#!/bin/sh' > .git/hooks/pre-commit && echo 'composer pre-commit' >> .git/h
 - Run `composer phpcs` for the changed PHP files before submitting your PR for review (optional). 
 - Keep PRs focused and change the minimum number of lines to achieve your goal.
 
+### Running static analysis
+
+Prior to making a PR, make sure the static analysis suite detects no defects:
+
+`composer static-analysis`
+
 ### Running unit tests
 
 Prior to making a PR, ensure that the unit tests pass:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "squizlabs/php_codesniffer": "^3.2",
     "phpcompatibility/php-compatibility": "^8.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "cache/array-adapter": "^1.0"
+    "cache/array-adapter": "^1.0",
+    "phpstan/phpstan": "^0.12.64"
   },
   "autoload": {
     "psr-4": {
@@ -42,12 +43,14 @@
     "test-unit-ci": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --stop-on-failure --coverage-clover=build/coverage.xml --testsuite=unit",
     "test-integration": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text --testsuite=integration",
     "test-integration-ci": "\"vendor/bin/phpunit\" --stop-on-failure --coverage-clover=build/coverage.xml --testsuite=integration",
+    "static-analysis": "\"vendor/bin/phpstan\" analyze",
     "phpcs": "\"vendor/bin/phpcs\"",
     "phpcbf": "\"vendor/bin/phpcbf\"",
     "compat": "\"vendor/bin/phpcs\" --standard=.phpcs-compat.xml.dist",
     "sniffs": "\"vendor/bin/phpcs\" -e",
     "config-phpcs": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
     "pre-commit": [
+      "@static-analysis",
       "@test",
       "@compat",
       "@phpcbf"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    checkGenericClassInNonGenericObjectType: false
+    level: 1
+    paths:
+        - src


### PR DESCRIPTION
### Description

There are no source code changes in this PR.

PHPStan is a static analysis tool for PHP. By adding this tool to the project, a quality standard of code can be maintained over time automatically.

Currently, the configured level of strictness is configured to 1 (see `phpstan.neon`). This can be increased all the way to 8. I suggest making these increments a PR at the time, as some code will need to be fixed to get to those levels.

I also suggest in time adding the following plugins to the PHPStan configuration:
* phpstan/phpstan-deprecation-rules
* phpstan/phpstan-strict-rules

As you can see, I have also updated the circle-ci config to include this tool in to the CI flow.

### Testing

You can manually run PHPStan by executing `composer static-analysis`

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
