### PR TITLE
Release 7.6.1

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -20,7 +20,7 @@
     PHPCompatibility sniffs to check for PHP cross-version incompatible code.
     https://github.com/PHPCompatibility/PHPCompatibility
     -->
-    <config name="testVersion" value="7.1-"/>
+    <config name="testVersion" value="7.3-"/>
     <rule ref="PHPCompatibility"/>
 
     <!--

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [7.6.1](https://github.com/auth0/auth0-PHP/tree/7.6.0) (2021-01-01)
+
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.6.0...7.6.1)
+
+This hotfix addresses an issue with a dependency reference.
+
 ## [7.6.0](https://github.com/auth0/auth0-PHP/tree/7.6.0) (2021-01-01)
 
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.5.0...7.6.0)

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,6 @@
       "homepage": "http://www.auth0.com/"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/auth0/php-jwt.git"
-    }
-  ],
   "require": {
     "php": "^7.3 | ^8.0",
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": "^7.3 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
+    "auth0/php-jwt": "3.3.4",
     "guzzlehttp/guzzle": "^7.2",
-    "lcobucci/jwt": "dev-3.3-php8-compatibility#daa6aff67a22bf737504143ae55a6913d9ff484d",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -12,7 +12,7 @@ use Auth0\SDK\API\Header\Telemetry;
 class ApiClient
 {
 
-    const API_VERSION = '7.6.0';
+    const API_VERSION = '7.6.1';
 
     /**
      * Flag to turn telemetry headers off.


### PR DESCRIPTION
This is a bugfix release:
- Addressed an issue with a forked repo dependency to avoid Packagist collisions.
- Bumps compatibility testing to 7.3+.