### PR TITLE
Only mark stale if waiting for response

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,12 +5,10 @@ daysUntilStale: 120
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 21
-
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-  - no-stalebot
-  - enhancement
-  - work in progress
+  
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - 'Waiting for Response'
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true


### PR DESCRIPTION
This PR aligns the stale config with our Angular and SPA JS SDK. I do not think the alignment is required, but I noticed an issue got marked as stale even tho we where the last one commenting, we even marked the issue as "needs investigation", see : https://github.com/auth0/auth0-PHP/issues/442

I think this is not what we want. It can help to only mark issues as stale if we are waiting for response.

Just a proposal, please feel free to close/modify.