### PR TITLE
Ensure ?include_totals are handled on GET /users and GET /roles requests for Management API

### DIFF
--- a/src/API/Management/Roles.php
+++ b/src/API/Management/Roles.php
@@ -28,8 +28,11 @@ class Roles extends GenericResource
      */
     public function getAll(array $params = [])
     {
+        $params = $this->normalizePagination( $params );
+        $params = $this->normalizeIncludeTotals( $params );
+
         return $this->apiClient->method('get')
-            ->withDictParams($this->normalizePagination( $params ))
+            ->withDictParams($params)
             ->addPath('roles')
             ->call();
     }

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -142,6 +142,7 @@ class Users extends GenericResource
         }
 
         $params = $this->normalizePagination( $params, $page, $per_page );
+        $params = $this->normalizeIncludeTotals( $params );
 
         return $this->apiClient->method('get')
             ->addPath('users')

--- a/tests/unit/API/Management/RolesMockedTest.php
+++ b/tests/unit/API/Management/RolesMockedTest.php
@@ -529,7 +529,10 @@ class RolesTestMocked extends TestCase
      */
     public function testThatGetUsersRequestIsFormattedProperly()
     {
-        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+        $api = new MockManagementApi( [
+            new Response( 200, self::$headers ),
+            new Response( 200, self::$headers )
+        ] );
 
         $api->call()->roles()->getUsers( '__test_role_id__', [ 'per_page' => 6, 'include_totals' => 1 ] );
 

--- a/tests/unit/API/Management/RolesMockedTest.php
+++ b/tests/unit/API/Management/RolesMockedTest.php
@@ -543,9 +543,15 @@ class RolesTestMocked extends TestCase
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
         $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
 
-        $query = $api->getHistoryQuery();
-        $this->assertStringContainsString( 'page=6', $query );
-        $this->assertStringContainsString( 'include_totals=true', $query );
+        $query = '&' . $api->getHistoryQuery();
+        $this->assertStringContainsString( '&per_page=6', $query );
+        $this->assertStringContainsString( '&include_totals=true', $query );
+
+        $api->call()->roles()->getUsers( '__test_role_id__', [ 'per_page' => 12 ] );
+
+        $query = '&' . $api->getHistoryQuery();
+        $this->assertStringContainsString( '&per_page=12', $query );
+        $this->assertStringContainsString( '&include_totals=false', $query );
     }
 
     /**

--- a/tests/unit/API/Management/UsersMockedTest.php
+++ b/tests/unit/API/Management/UsersMockedTest.php
@@ -205,7 +205,10 @@ class UsersMockedTest extends TestCase
         $api->call()->users()->getAll();
 
         $this->assertEquals( 'GET', $api->getHistoryMethod() );
-        $this->assertEquals( 'https://api.test.local/api/v2/users', $api->getHistoryUrl() );
+        $this->assertStringStartsWith( 'https://api.test.local/api/v2/users', $api->getHistoryUrl() );
+
+        $query = '&'.$api->getHistoryQuery();
+        $this->assertStringContainsString( '&include_totals=false', $query );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -225,8 +228,8 @@ class UsersMockedTest extends TestCase
 
         $api->call()->users()->getAll( [ '__test_parameter__' => '__test_value__' ] );
 
-        $query = $api->getHistoryQuery();
-        $this->assertEquals( '__test_parameter__=__test_value__', $query );
+        $query = '&'.$api->getHistoryQuery();
+        $this->assertStringContainsString( '&__test_parameter__=__test_value__', $query );
     }
 
     /**
@@ -242,8 +245,8 @@ class UsersMockedTest extends TestCase
 
         $api->call()->users()->getAll( [ 'fields' => 'field1,field2' ], 'field3' );
 
-        $query = $api->getHistoryQuery();
-        $this->assertEquals( 'fields=field1,field2', $query );
+        $query = '&'.$api->getHistoryQuery();
+        $this->assertStringContainsString( '&fields=field1,field2', $query );
     }
 
     /**
@@ -262,13 +265,13 @@ class UsersMockedTest extends TestCase
 
         $api->call()->users()->getAll( [ 'fields' => 'field1,field2' ] );
 
-        $query = $api->getHistoryQuery();
-        $this->assertEquals( 'fields=field1,field2', $query );
+        $query = '&'.$api->getHistoryQuery();
+        $this->assertStringContainsString( '&fields=field1,field2', $query );
 
         $api->call()->users()->getAll( [ 'fields' => [ 'field1', 'field2' ] ] );
 
-        $query = $api->getHistoryQuery();
-        $this->assertEquals( 'fields=field1,field2', $query );
+        $query = '&'.$api->getHistoryQuery();
+        $this->assertStringContainsString( '&fields=field1,field2', $query );
     }
 
     /**


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR addresses a bug reported in #475 in which we aren't handling the ?include_totals query param with GET /users and GET /roles Management API endpoints in certain circumstances. This PR also updates our tests to accommodate this param's presence.

### References

- Closes #475 

### Testing

This PR updates the Roles and Users tests to reflect the presence of the ?include_totals query param. The changes can be tested locally with `composer test`, or observed by the CircleCI test result on this PR.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
