### PR TITLE
[SDK-2407] Support client_id on /tickets/password-change

### DIFF
--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -3,6 +3,7 @@
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
+use GuzzleHttp\Exception\RequestException;
 
 class Tickets extends GenericResource
 {
@@ -56,6 +57,8 @@ class Tickets extends GenericResource
      * @param  null|string $new_password
      * @param  null|string $result_url
      * @param  null|string $connection_id
+     * @param  null|string $ttl
+     * @param  null|string $client_id
      * @return mixed
      */
     public function createPasswordChangeTicket(
@@ -63,10 +66,11 @@ class Tickets extends GenericResource
         $new_password = null,
         $result_url = null,
         $connection_id = null,
-        $ttl = null
+        $ttl = null,
+        $client_id = null
     )
     {
-        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id, $ttl);
+        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id, $ttl, $client_id);
     }
 
     /**
@@ -83,10 +87,11 @@ class Tickets extends GenericResource
         $new_password = null,
         $result_url = null,
         $connection_id = null,
-        $ttl = null
+        $ttl = null,
+        $client_id = null
     )
     {
-        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id, $ttl);
+        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id, $ttl, $client_id);
     }
 
     /**
@@ -105,7 +110,8 @@ class Tickets extends GenericResource
         $new_password = null,
         $result_url = null,
         $connection_id = null,
-        $ttl = null
+        $ttl = null,
+        $client_id = null
     )
     {
         $body = [];
@@ -132,6 +138,10 @@ class Tickets extends GenericResource
 
         if ($ttl) {
             $body['ttl_sec'] = $ttl;
+        }
+
+        if ($client_id) {
+            $body['client_id'] = $client_id;
         }
 
         return $this->apiClient->method('post')

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -3,7 +3,6 @@
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
-use GuzzleHttp\Exception\RequestException;
 
 class Tickets extends GenericResource
 {

--- a/tests/unit/API/Management/TicketsTest.php
+++ b/tests/unit/API/Management/TicketsTest.php
@@ -71,7 +71,7 @@ class TicketsTest extends ApiTests
     {
         $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
 
-        $api->call()->tickets()->createPasswordChangeTicket( '__test_user_id__', '__test_password__', '__test_result_url__', '__test_connection_id__', 8675309 );
+        $api->call()->tickets()->createPasswordChangeTicket( '__test_user_id__', '__test_password__', '__test_result_url__', '__test_connection_id__', 8675309, '__test_client_id__' );
 
         $this->assertEquals( 'POST', $api->getHistoryMethod() );
         $this->assertEquals( 'https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl() );
@@ -88,6 +88,8 @@ class TicketsTest extends ApiTests
         $this->assertEquals( '__test_connection_id__', $body['connection_id'] );
         $this->assertArrayHasKey( 'ttl_sec', $body );
         $this->assertEquals( 8675309, $body['ttl_sec'] );
+        $this->assertArrayHasKey( 'client_id', $body );
+        $this->assertEquals( '__test_client_id__', $body['client_id'] );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );


### PR DESCRIPTION
Closes #480 — We do not currently allow passage of a [client_id parameter to the /tickets/password-change endpoint](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification) of the Management API. This PR resolves this discrepancy and updates the related unit test.