### PR TITLE
Release 7.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## [7.7.0](https://github.com/auth0/auth0-PHP/tree/7.6.2) (2021-03-19)
+
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.6.2...7.7.0)
+
+This release includes initial support for Organizations, a new featur from Auth0 currently in closed beta testing. Please see the updated README for usage instructions.
+
+**Added**
+
+- Add Organizations support to Authentication API Client [\#482](https://github.com/auth0/auth0-PHP/pull/482) ([evansims](https://github.com/evansims))
+
+**Changes**
+
+- Support client_id on /tickets/password-change [\#481](https://github.com/auth0/auth0-PHP/pull/481) ([evansims](https://github.com/evansims))
+
 ## [7.6.2](https://github.com/auth0/auth0-PHP/tree/7.6.2) (2021-01-01)
 
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.6.1...7.6.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release includes initial support for Organizations, a new featur from Auth0
 
 - Add Organizations support to Authentication API Client [\#482](https://github.com/auth0/auth0-PHP/pull/482) ([evansims](https://github.com/evansims))
 
-**Changes**
+**Changed**
 
 - Support client_id on /tickets/password-change [\#481](https://github.com/auth0/auth0-PHP/pull/481) ([evansims](https://github.com/evansims))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/7.6.2...7.7.0)
 
-This release includes initial support for Organizations, a new featur from Auth0 currently in closed beta testing. Please see the updated README for usage instructions.
+This release includes initial support for Organizations, a new feature from Auth0 currently in closed beta testing. Please see the updated README for usage instructions.
 
 **Added**
 

--- a/src/API/Helpers/ApiClient.php
+++ b/src/API/Helpers/ApiClient.php
@@ -12,7 +12,7 @@ use Auth0\SDK\API\Header\Telemetry;
 class ApiClient
 {
 
-    const API_VERSION = '7.6.2';
+    const API_VERSION = '7.7.0';
 
     /**
      * Flag to turn telemetry headers off.


### PR DESCRIPTION
**Added**

- Add Organizations support to Authentication API Client [\#482](https://github.com/auth0/auth0-PHP/pull/482) ([evansims](https://github.com/evansims))

**Changed**

- Support client_id on /tickets/password-change [\#481](https://github.com/auth0/auth0-PHP/pull/481) ([evansims](https://github.com/evansims))