### PR TITLE
Add support for guzzle ^6.0 (or ^7.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "auth0/php-jwt": "3.3.4",
-    "guzzlehttp/guzzle": "^6.5|^7.2",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "auth0/php-jwt": "3.3.4",
-    "guzzlehttp/guzzle": "^7.2",
+    "guzzlehttp/guzzle": "^6.5|^7.2",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This PR adds support for guzzle 6.0. 
Forcing guzzle 7.2 can be a problem in different libs, and version 6.x works fine with php 8