### PR TITLE
[SDK-2486] Allow overriding 0.2 delay in integration testing API requests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,8 +6,6 @@ require_once $tests_dir.'../vendor/autoload.php';
 ini_set('session.use_cookies', false);
 ini_set('session.cache_limiter', false);
 
-define( 'AUTH0_PHP_TEST_INTEGRATION_SLEEP', 200000 );
-
 if (! defined( 'AUTH0_PHP_TEST_JSON_DIR' )) {
     define( 'AUTH0_PHP_TEST_JSON_DIR', $tests_dir.'json/' );
 }

--- a/tests/integration/API/Management/BlacklistsIntegrationTest.php
+++ b/tests/integration/API/Management/BlacklistsIntegrationTest.php
@@ -24,10 +24,10 @@ class BlacklistsIntegrationTest extends ApiTests
         $test_jti = uniqid().uniqid().uniqid();
 
         $api->blacklists()->blacklist($env['APP_CLIENT_ID'], $test_jti);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $blacklisted = $api->blacklists()->getAll($env['APP_CLIENT_ID']);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertGreaterThan( 0, count( $blacklisted ) );
         $this->assertEquals( $env['APP_CLIENT_ID'], $blacklisted[0]['aud'] );

--- a/tests/integration/API/Management/ClientGrantsIntegrationTest.php
+++ b/tests/integration/API/Management/ClientGrantsIntegrationTest.php
@@ -56,7 +56,7 @@ class ClientGrantsIntegrationTest extends ApiTests
 
         self::$apiIdentifier = 'TEST_PHP_SDK_CLIENT_GRANT_API_'.uniqid();
         $api->resourceServers()->create(self::$apiIdentifier, $create_data);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        self::sleep();
     }
 
     public function setUp(): void
@@ -73,7 +73,7 @@ class ClientGrantsIntegrationTest extends ApiTests
         parent::tearDownAfterClass();
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $api->resourceServers()->delete( self::$apiIdentifier );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        self::sleep();
     }
 
     /**
@@ -87,7 +87,7 @@ class ClientGrantsIntegrationTest extends ApiTests
     public function testGet()
     {
         $all_results = self::$api->getAll();
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($all_results);
 
         $expected_client_id = $all_results[0]['client_id'] ?: null;
@@ -97,12 +97,12 @@ class ClientGrantsIntegrationTest extends ApiTests
         $this->assertNotNull($expected_audience);
 
         $audience_results = self::$api->getByAudience($expected_audience);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($audience_results);
         $this->assertEquals($expected_audience, $audience_results[0]['audience']);
 
         $client_id_results = self::$api->getByClientId($expected_client_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($client_id_results);
         $this->assertEquals($expected_client_id, $client_id_results[0]['client_id']);
     }
@@ -119,12 +119,12 @@ class ClientGrantsIntegrationTest extends ApiTests
         $expected_count = 2;
 
         $results_1 = self::$api->getAll([], 0, $expected_count);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertCount($expected_count, $results_1);
 
         $expected_page = 1;
         $results_2     = self::$api->getAll([], $expected_page, 1);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertCount(1, $results_2);
         $this->assertEquals($results_1[$expected_page]['client_id'], $results_2[0]['client_id']);
         $this->assertEquals($results_1[$expected_page]['audience'], $results_2[0]['audience']);
@@ -143,7 +143,8 @@ class ClientGrantsIntegrationTest extends ApiTests
         $expected_count = 2;
 
         $results = self::$api->getAll(['include_totals' => true], $expected_page, $expected_count);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
+
         $this->assertArrayHasKey('total', $results);
         $this->assertEquals($expected_page * $expected_count, $results['start']);
         $this->assertEquals($expected_count, $results['limit']);
@@ -165,7 +166,8 @@ class ClientGrantsIntegrationTest extends ApiTests
 
         // Create a Client Grant with just one of the testing scopes.
         $create_result = self::$api->create($client_id, $audience, [self::$scopes[0]]);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
+
         $this->assertArrayHasKey('id', $create_result);
         $this->assertEquals($client_id, $create_result['client_id']);
         $this->assertEquals($audience, $create_result['audience']);
@@ -175,12 +177,13 @@ class ClientGrantsIntegrationTest extends ApiTests
 
         // Test patching the created Client Grant.
         $update_result = self::$api->update($grant_id, self::$scopes);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
+
         $this->assertEquals(self::$scopes, $update_result['scope']);
 
         // Test deleting the created Client Grant.
         $delete_result = self::$api->delete($grant_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNull($delete_result);
     }
 

--- a/tests/integration/API/Management/ClientsIntegrationTest.php
+++ b/tests/integration/API/Management/ClientsIntegrationTest.php
@@ -34,7 +34,7 @@ class ClientsIntegrationTest extends ApiTests
         ];
 
         $created_client = $api->clients()->create($create_body);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertNotEmpty($created_client['client_id']);
         $this->assertEquals($create_body['name'], $created_client['name']);
@@ -42,7 +42,7 @@ class ClientsIntegrationTest extends ApiTests
 
         $created_client_id = $created_client['client_id'];
         $got_entity        = $api->clients()->get($created_client_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         // Make sure what we got matches what we created.
         $this->assertEquals($created_client_id, $got_entity['client_id']);
@@ -53,14 +53,14 @@ class ClientsIntegrationTest extends ApiTests
         ];
 
         $updated_client = $api->clients()->update($created_client_id, $update_body );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals($created_client_id, $updated_client['client_id']);
         $this->assertEquals($update_body['name'], $updated_client['name']);
         $this->assertEquals($update_body['app_type'], $updated_client['app_type']);
 
         $api->clients()->delete($created_client_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
     }
 
     /**
@@ -80,7 +80,7 @@ class ClientsIntegrationTest extends ApiTests
 
         // Get the second page of Clients with 1 per page (second result).
         $paged_results = $api->clients()->getAll($fields, true, $page_num, 1);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         // Make sure we only have one result, as requested.
         $this->assertEquals(1, count($paged_results));
@@ -91,7 +91,7 @@ class ClientsIntegrationTest extends ApiTests
         // Get many results (needs to include the created result if self::findCreatedItem === true).
         $many_results_per_page = 50;
         $many_results          = $api->clients()->getAll($fields, true, 0, $many_results_per_page);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         // Make sure we have at least as many results as we requested.
         $this->assertLessThanOrEqual($many_results_per_page, count($many_results));

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -40,7 +40,7 @@ class JobsIntegrationTest extends ApiTests
         // Get a single, active database connection.
         $default_db_name       = 'Username-Password-Authentication';
         $get_connection_result = $api->connections()->getAll( 'auth0', ['id'], true, 0, 1, ['name' => $default_db_name] );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $conn_id            = $get_connection_result[0]['id'];
         $import_user_params = [
@@ -50,7 +50,7 @@ class JobsIntegrationTest extends ApiTests
         ];
 
         $import_job_result = $api->jobs()->importUsers(self::$testImportUsersJsonPath, $conn_id, $import_user_params);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals( $conn_id, $import_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $import_job_result['connection'] );
@@ -58,7 +58,7 @@ class JobsIntegrationTest extends ApiTests
         $this->assertEquals( 'users_import', $import_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($import_job_result['id']);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals( $conn_id, $get_job_result['connection_id'] );
         $this->assertEquals( $default_db_name, $get_job_result['connection'] );
@@ -86,21 +86,21 @@ class JobsIntegrationTest extends ApiTests
             'password' => uniqid().'&*@'.uniqid().uniqid(),
         ];
         $create_user_result = $api->users()->create( $create_user_data );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $user_id = $create_user_result['user_id'];
 
         $email_job_result = $api->jobs()->sendVerificationEmail($user_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals( 'verification_email', $email_job_result['type'] );
 
         $get_job_result = $api->jobs()->get($email_job_result['id']);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals( 'verification_email', $get_job_result['type'] );
 
         $api->users()->delete( $user_id );
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
     }
 }

--- a/tests/integration/API/Management/LogsIntegrationTest.php
+++ b/tests/integration/API/Management/LogsIntegrationTest.php
@@ -47,7 +47,8 @@ class LogsIntegrationTest extends ApiTests
             'fields' => '_id,log_id,date',
             'include_fields' => true,
         ]);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
+
         $this->assertNotEmpty($search_results);
         $this->assertNotEmpty($search_results[0]['_id']);
         $this->assertNotEmpty($search_results[0]['log_id']);
@@ -56,7 +57,7 @@ class LogsIntegrationTest extends ApiTests
 
         // Test getting a single log result with a valid ID from above.
         $one_log = self::$api->get($search_results[0]['log_id']);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($one_log);
         $this->assertEquals($search_results[0]['log_id'], $one_log['log_id']);
     }
@@ -81,7 +82,7 @@ class LogsIntegrationTest extends ApiTests
             // Include totals to check pagination.
             'include_totals' => true,
         ]);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertCount($expected_count, $search_results['logs']);
         $this->assertEquals($expected_count, $search_results['length']);

--- a/tests/integration/API/Management/OrganizationsIntegrationTest.php
+++ b/tests/integration/API/Management/OrganizationsIntegrationTest.php
@@ -18,7 +18,6 @@ use Auth0\Tests\API\ApiTests;
 */
 class OrganizationsIntegrationTest extends ApiTests
 {
-
   /**
    * Management API client.
    * @var Management
@@ -85,35 +84,36 @@ class OrganizationsIntegrationTest extends ApiTests
 
     // Create a new organization for our tests
     $this->organization = $this->api->create($this->resources['name'], $this->resources['display_name']);
+    $this->sleep();
 
     // Create a new connection for our tests
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->connection = $this->management->connections()->create([
       'name'            => uniqid('php-sdk-test-connection-'),
       'strategy'        => 'auth0',
       'enabled_clients' => [ $env['APP_CLIENT_ID'] ]
     ]);
+    $this->sleep();
 
     // Enable new connection with the organization for our tests
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->api->addEnabledConnection($this->organization['id'], $this->connection['id']);
+    $this->sleep();
 
     // Create a new user for our tests
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->user = $this->management->users()->create([
       'email'          => uniqid('php-sdk-test-user-') . '@test.com',
       'connection'     => $this->connection['name'],
       'email_verified' => true,
       'password'       => password_hash(uniqid('php-sdk-test-password-'), PASSWORD_DEFAULT)
     ]);
+    $this->sleep();
 
     // Add the new user to the organization as a member for our tests
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->api->addMembers($this->organization['id'], [ $this->user['user_id'] ]);
+    $this->sleep();
 
     // Add a role to the new member of the organization for our tests
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->role = $this->management->roles()->create(uniqid('php-sdk-test-role-'));
+    $this->sleep();
   }
 
   public function tearDown(): void
@@ -121,21 +121,25 @@ class OrganizationsIntegrationTest extends ApiTests
     // Cleanup our test role, if it's creation was successful
     if ($this->role) {
       $this->management->roles()->delete($this->role['id']);
+      $this->sleep();
     }
 
     // Cleanup our test user, if it's creation was successful
     if ($this->user) {
       $this->management->users()->delete($this->user['user_id']);
+      $this->sleep();
     }
 
     // Cleanup our test connection, if it's creation was successful
     if ($this->connection) {
       $this->management->connections()->delete($this->connection['id']);
+      $this->sleep();
     }
 
     // Cleanup our test organization, if it's creation was successful
     if ($this->organization) {
       $this->api->delete($this->organization['id']);
+      $this->sleep();
     }
   }
 
@@ -152,12 +156,13 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testUpdate()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+    $this->sleep();
     $this->resources['display_name'] .= ' (UPDATED)';
     $this->api->update($this->organization['id'], $this->resources['display_name']);
+    $this->sleep();
 
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->organization = $this->api->get($this->organization['id']);
+    $this->sleep();
 
     $this->assertArrayHasKey('name', $this->organization);
     $this->assertEquals($this->organization['name'], $this->resources['name']);
@@ -165,8 +170,8 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testGetAll()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getAll();
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -174,18 +179,18 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testGetAllSupportsPagination()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getAll([
       'page' => 1
     ]);
+    $this->sleep();
 
     $this->assertIsArray($response);
   }
 
   public function testGet()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->get($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -194,8 +199,8 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testGetByName()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getByName($this->organization['name']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -204,8 +209,8 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testGetEnabledConnections()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getEnabledConnections($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
   }
@@ -213,18 +218,18 @@ class OrganizationsIntegrationTest extends ApiTests
   public function testEnabledConnections()
   {
     // Confirm 'assign_membership_on_login' is currently false on the organization connection.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getEnabledConnection($this->organization['id'], $this->connection['id']);
+    $this->sleep();
 
     $this->assertFalse($response['assign_membership_on_login']);
 
     // Change the 'assign_membership_on_login' property on the organization connection.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->api->updateEnabledConnection($this->organization['id'], $this->connection['id'], [ 'assign_membership_on_login' => true ]);
+    $this->sleep();
 
     // Confirm the change was recorded.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getEnabledConnection($this->organization['id'], $this->connection['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertArrayHasKey('connection_id', $response);
@@ -234,8 +239,8 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testRetrieveMembers()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getMembers($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -243,10 +248,10 @@ class OrganizationsIntegrationTest extends ApiTests
 
   public function testRetrieveMembersPaginated()
   {
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getMembers($this->organization['id'], [
       'page' => 1
     ]);
+    $this->sleep();
 
     $this->assertIsArray($response);
   }
@@ -254,19 +259,19 @@ class OrganizationsIntegrationTest extends ApiTests
   public function testMemberRoles()
   {
     // Confirm that the organization member has no roles.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getMemberRoles($this->organization['id'], $this->user['user_id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertEmpty($response);
 
     // Add our role to the organization member.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->api->addMemberRoles($this->organization['id'], $this->user['user_id'], [ $this->role['id'] ]);
+    $this->sleep();
 
     // Confirm that the organization member now has the role.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getMemberRoles($this->organization['id'], $this->user['user_id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -274,12 +279,12 @@ class OrganizationsIntegrationTest extends ApiTests
     $this->assertContainsEquals($this->role['id'], $response[0]);
 
     // Remove the role from the organization member.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->removeMemberRoles($this->organization['id'], $this->user['user_id'], [ $this->role['id'] ]);
+    $this->sleep();
 
     // Confirm that the organization member once again has no roles.
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getMemberRoles($this->organization['id'], $this->user['user_id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertEmpty($response);
@@ -290,14 +295,13 @@ class OrganizationsIntegrationTest extends ApiTests
     $env = self::getEnv();
 
     // Confirm there are no invitations
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getInvitations($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertEmpty($response);
 
     // Create an invitation
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->createInvitation(
       $this->organization['id'],
       $env['APP_CLIENT_ID'],
@@ -308,6 +312,7 @@ class OrganizationsIntegrationTest extends ApiTests
         'email' => uniqid('php-sdk-test-user-') . '@test.com'
       ]
     );
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertArrayHasKey('organization_id', $response);
@@ -318,15 +323,15 @@ class OrganizationsIntegrationTest extends ApiTests
     $this->assertArrayHasKey('ticket_id', $response);
 
     // Confirm pagination works
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getInvitations($this->organization['id'], [ 'page' => 1 ]);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertEmpty($response);
 
     // Confirm there is one invitation
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getInvitations($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertNotEmpty($response);
@@ -340,8 +345,8 @@ class OrganizationsIntegrationTest extends ApiTests
     $this->assertArrayHasKey('ticket_id', $response[0]);
 
     // Confirm invitation querying works
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getInvitation($this->organization['id'], $response[0]['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertArrayHasKey('organization_id', $response);
@@ -352,12 +357,12 @@ class OrganizationsIntegrationTest extends ApiTests
     $this->assertArrayHasKey('ticket_id', $response);
 
     // Confirm invitation deletion works
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $this->api->deleteInvitation($this->organization['id'], $response['id']);
+    $this->sleep();
 
     // Confirm no invitations remain
-    usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
     $response = $this->api->getInvitations($this->organization['id']);
+    $this->sleep();
 
     $this->assertIsArray($response);
     $this->assertEmpty($response);

--- a/tests/integration/API/Management/ResourceServersIntegrationTest.php
+++ b/tests/integration/API/Management/ResourceServersIntegrationTest.php
@@ -80,7 +80,7 @@ class ResourceServersIntegrationTest extends ApiTests
         ];
 
         $response = self::$api->create(self::$serverIdentifier, $create_data);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertNotEmpty($response);
         $this->assertNotEmpty($response['id']);
@@ -102,7 +102,7 @@ class ResourceServersIntegrationTest extends ApiTests
     public function testGet()
     {
         $response = self::$api->get(self::$serverIdentifier);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($response);
         $this->assertEquals(self::$serverIdentifier, $response['identifier']);
     }
@@ -117,7 +117,7 @@ class ResourceServersIntegrationTest extends ApiTests
     public function testGetAll()
     {
         $response = self::$api->getAll();
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         // Should have at least the one we created and the management API.
         $this->assertGreaterThanOrEqual(2, count($response));
@@ -135,7 +135,7 @@ class ResourceServersIntegrationTest extends ApiTests
 
         // Test pagination.
         $response_paged = self::$api->getAll(1, 1);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($response_paged);
         $this->assertEquals($response[1]['id'], $response_paged[0]['id']);
     }
@@ -158,7 +158,7 @@ class ResourceServersIntegrationTest extends ApiTests
         ];
 
         $response = self::$api->update(self::$serverIdentifier, $update_data);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         $this->assertEquals($update_data['name'], $response['name']);
         $this->assertEquals($update_data['token_lifetime'], $response['token_lifetime']);
@@ -177,13 +177,13 @@ class ResourceServersIntegrationTest extends ApiTests
     public function testDelete()
     {
         $response = self::$api->delete(self::$serverIdentifier);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
 
         // Look for the resource server we just deleted.
         $get_server_throws_error = false;
         try {
             self::$api->get(self::$serverIdentifier);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (ClientException $e) {
             $get_server_throws_error = (404 === $e->getCode());
         }
@@ -205,7 +205,7 @@ class ResourceServersIntegrationTest extends ApiTests
         $caught_get_no_id_exception = false;
         try {
             self::$api->get(null);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (CoreException $e) {
             $caught_get_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -216,7 +216,7 @@ class ResourceServersIntegrationTest extends ApiTests
         $caught_delete_no_id_exception = false;
         try {
             self::$api->delete(null);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (CoreException $e) {
             $caught_delete_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -227,7 +227,7 @@ class ResourceServersIntegrationTest extends ApiTests
         $caught_update_no_id_exception = false;
         try {
             self::$api->update(null, []);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (CoreException $e) {
             $caught_update_no_id_exception = $this->errorHasString($e, 'Invalid "id" parameter');
         }
@@ -238,7 +238,7 @@ class ResourceServersIntegrationTest extends ApiTests
         $caught_create_empty_identifier_param_exception = false;
         try {
             self::$api->create(null, []);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (CoreException $e) {
             $caught_create_empty_identifier_param_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }
@@ -248,7 +248,7 @@ class ResourceServersIntegrationTest extends ApiTests
         $caught_create_invalid_identifier_field_exception = false;
         try {
             self::$api->create('identifier', ['identifier' => 1234]);
-            usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+            $this->sleep();
         } catch (CoreException $e) {
             $caught_create_invalid_identifier_field_exception = $this->errorHasString($e, 'Invalid "identifier" field');
         }

--- a/tests/integration/API/Management/RulesIntegrationTest.php
+++ b/tests/integration/API/Management/RulesIntegrationTest.php
@@ -46,13 +46,13 @@ class RulesIntegrationTest extends ApiTests
         $api = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
 
         $results = $api->rules()->getAll();
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($results);
 
         // Check getting a single rule by a known ID.
         $get_rule_id = $results[0]['id'];
         $result      = $api->rules()->get($get_rule_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($result);
         $this->assertEquals($results[0]['id'], $get_rule_id);
 
@@ -69,7 +69,7 @@ class RulesIntegrationTest extends ApiTests
 
         // Check enabled rules.
         $enabled_results = $api->rules()->getAll(true);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         if ($has_enabled) {
             $this->assertNotEmpty($enabled_results);
         } else {
@@ -78,7 +78,7 @@ class RulesIntegrationTest extends ApiTests
 
         // Check disabled rules.
         $disabled_results = $api->rules()->getAll(false);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         if ($has_disabled) {
             $this->assertNotEmpty($disabled_results);
         } else {
@@ -101,13 +101,13 @@ class RulesIntegrationTest extends ApiTests
         $fields = ['id', 'name'];
 
         $fields_results = $api->rules()->getAll(null, $fields, true);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($fields_results);
         $this->assertCount(count($fields), $fields_results[0]);
 
         $get_rule_id   = $fields_results[0]['id'];
         $fields_result = $api->rules()->get($get_rule_id, $fields, true);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($fields_result);
         $this->assertCount(count($fields), $fields_result);
     }
@@ -123,12 +123,12 @@ class RulesIntegrationTest extends ApiTests
     {
         $api           = new Management(self::$env['API_TOKEN'], self::$env['DOMAIN']);
         $paged_results = $api->rules()->getAll(null, null, null, 0, 2);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertCount(2, $paged_results);
 
         // Second page of 1 result.
         $paged_results_2 = $api->rules()->getAll(null, null, null, 1, 1);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertCount(1, $paged_results_2);
         $this->assertEquals($paged_results[1]['id'], $paged_results_2[0]['id']);
     }
@@ -151,7 +151,7 @@ class RulesIntegrationTest extends ApiTests
         ];
 
         $create_result = $api->rules()->create($create_data);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNotEmpty($create_result['id']);
         $this->assertEquals($create_data['enabled'], $create_result['enabled']);
         $this->assertEquals($create_data['name'], $create_result['name']);
@@ -165,13 +165,13 @@ class RulesIntegrationTest extends ApiTests
         ];
 
         $update_result = $api->rules()->update($test_rule_id, $update_data);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertEquals($update_data['enabled'], $update_result['enabled']);
         $this->assertEquals($update_data['name'], $update_result['name']);
         $this->assertEquals($update_data['script'], $update_result['script']);
 
         $delete_result = $api->rules()->delete($test_rule_id);
-        usleep(AUTH0_PHP_TEST_INTEGRATION_SLEEP);
+        $this->sleep();
         $this->assertNull($delete_result);
     }
 


### PR DESCRIPTION
In order to avoid hitting API rate limits, we use `usleep()` to artificially throttle our integration tests. Currently, this value is hardcoded to 0.2 seconds. We need a bit more control over this value. I'm adding an environment variable to allow overriding this 0.2 default value.