### PR TITLE
[SDK-2464] Add guidance for org validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ After successful authentication via the Universal Login Page, the user will arri
 
 #### Validation guidance
 
-In the examples above, our application is operating with a single, configured Organization. In this case, the SDK automatically handles token validation for you: it will ensure the user's JWT has an `org_id` claim and that it matches.
+In the examples above, our application is operating with a single, configured Organization. By initializing the SDK with the `organization` option, we are telling the internal ID Token verifier (`IdTokenVerifier`) to validate an `org_id` claim's presence, and that it matches what we provided.
 
-However, if your application requires more flexibility (such as an API supporting multiple tenants, and therefore multiple organizations) then your application should validate the `org_id` claim itself to ensure the value received is expected and known.
+Your application might not have the Organization ID ahead of time, or potentially needs to support multiple organizations. Your application should validate the `org_id` claim itself to ensure the value received is expected and known.
 
 This could be achieved by reading the value of "org_id" returned by the `getUser()` method. An example might look like this:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is [one of many libraries we offer](https://auth0.com/docs/libraries) suppo
   - [Organizations](#organizations)
     - [Logging in with an Organization](#logging-in-with-an-organization)
     - [Accepting user invitations](#accepting-user-invitations)
-    - [Token validation guidance](#token-validation-guidance)
+    - [Validation guidance](#validation-guidance)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Support + Feedback](#support--feedback)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ In the examples above, our application is operating with a single, configured Or
 
 Your application might not have the Organization ID ahead of time, or potentially needs to support multiple organizations.
 
-Your application should validate any `org_id` claim itself to ensure the value received is expected and known by your application.
+Your application should validate an `org_id` claim itself to ensure the value received is expected and known by your application.
 
 This could be achieved by reading the value of "org_id" returned by the `getUser()` method. An example might look like this:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ After successful authentication via the Universal Login Page, the user will arri
 
 In the examples above, our application is operating with a single, configured Organization. By initializing the SDK with the `organization` option, we are telling the internal ID Token verifier (`IdTokenVerifier`) to validate an `org_id` claim's presence, and that it matches what we provided.
 
-Your application might not have the Organization ID ahead of time, or potentially needs to support multiple organizations.
+Your application might not know the Organization ID ahead of time, or potentially need to support multiple organizations.
 
 Your application should validate an `org_id` claim itself to ensure the value received is expected and known by your application.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ After successful authentication via the Universal Login Page, the user will arri
 
 In the examples above, our application is operating with a single, configured Organization. In this case, the SDK automatically handles token validation for you: it will ensure the user's JWT has an `org_id` claim and that it matches.
 
-However, if your application requires more flexibility (such as an API supporting multiple tenants, and therefor multiple organizations) then your application should validate the `org_id` claim itself to ensure the value received is expected and known.
+However, if your application requires more flexibility (such as an API supporting multiple tenants, and therefore multiple organizations) then your application should validate the `org_id` claim itself to ensure the value received is expected and known.
 
 This could be achieved by reading the value of "org_id" returned by the `getUser()` method. An example might look like this:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ After successful authentication via the Universal Login Page, the user will arri
 
 In the examples above, our application is operating with a single, configured Organization. By initializing the SDK with the `organization` option, we are telling the internal ID Token verifier (`IdTokenVerifier`) to validate an `org_id` claim's presence, and that it matches what we provided.
 
-Your application might not have the Organization ID ahead of time, or potentially needs to support multiple organizations. Your application should validate the `org_id` claim itself to ensure the value received is expected and known.
+Your application might not have the Organization ID ahead of time, or potentially needs to support multiple organizations.
+
+Your application should validate any `org_id` claim itself to ensure the value received is expected and known by your application.
 
 This could be achieved by reading the value of "org_id" returned by the `getUser()` method. An example might look like this:
 


### PR DESCRIPTION
This PR updates the README to include additional information about Organizations validation and adds an example of how an application can handle this logic itself where a customer needs more flexibility, such as a multi-tenant/organization scenario.