### PR TITLE
tests: Remove Snyk from CircleCI flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
           root: .
           paths:
             - composer.*
+            - .snyk
       - save_cache:
           key: composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}
           paths:
@@ -61,6 +62,20 @@ jobs:
     steps:
       - prepare
       - run-integration-tests
+  snyk:
+    docker:
+      - image: snyk/snyk-cli:composer
+    steps:
+      - attach_workspace:
+          at: .
+      - run: snyk test
+      - run:
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]
+            then
+            snyk monitor --org=auth0-sdks
+            fi
+          when: always
 
 workflows:
   build-and-test:
@@ -68,6 +83,15 @@ workflows:
       - php_7_3
       - php_7_4
       - php_8_0
+      - hold:
+          type: approval
+          requires:
+            - php_7_3
+      - snyk:
+          context: snyk-env
+          requires:
+            - hold
+            - php_7_3
   integration-tests:
     jobs:
       - php_7_integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,10 @@ workflows:
       - php_7_3
       - php_7_4
       - php_8_0
-      - hold:
-          type: approval
-          requires:
-            - php_7_3
       - snyk:
+          type: approval
           context: snyk-env
           requires:
-            - hold
             - php_7_3
   integration-tests:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ commands:
           root: .
           paths:
             - composer.*
-            - .snyk
       - save_cache:
           key: composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}
           paths:
@@ -62,20 +61,6 @@ jobs:
     steps:
       - prepare
       - run-integration-tests
-  snyk:
-    docker:
-      - image: snyk/snyk-cli:composer
-    steps:
-      - attach_workspace:
-          at: .
-      - run: snyk test
-      - run:
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]
-            then
-            snyk monitor --org=auth0-sdks
-            fi
-          when: always
 
 workflows:
   build-and-test:
@@ -83,11 +68,6 @@ workflows:
       - php_7_3
       - php_7_4
       - php_8_0
-      - snyk:
-          # Must define SNYK_TOKEN env
-          context: snyk-env
-          requires:
-            - php_7_3
   integration-tests:
     jobs:
       - php_7_integration_tests:


### PR DESCRIPTION
This PR removes Snyk from the CircleCI flow and tests using the GitHub bot instead for branch protection.

> Currently working on this one, not quite ready to merge but for testing purposes not making it a draft.