### PR TITLE
update lcobucci jwt to 4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,6 @@ commands:
           path: build/coverage.xml
 
 jobs:
-  php_7_3:
-    docker:
-      - image: circleci/php:7.3
-    steps:
-      - prepare
-      - run-static-analysis
-      - run-unit-tests
   php_7_4:
     docker:
       - image: circleci/php:7.4
@@ -58,7 +51,7 @@ jobs:
       - run-unit-tests
   php_7_integration_tests:
     docker:
-      - image: circleci/php:7.3
+      - image: circleci/php:7.4
     steps:
       - prepare
       - run-integration-tests
@@ -80,14 +73,13 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - php_7_3
       - php_7_4
       - php_8_0
       - snyk:
           # Must define SNYK_TOKEN env
           context: snyk-env
           requires:
-            - php_7_3
+            - php_7_4
   integration-tests:
     jobs:
       - php_7_integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,13 @@ commands:
           path: build/coverage.xml
 
 jobs:
+  php_7_3:
+    docker:
+      - image: circleci/php:7.3
+    steps:
+      - prepare
+      - run-static-analysis
+      - run-unit-tests
   php_7_4:
     docker:
       - image: circleci/php:7.4
@@ -51,7 +58,7 @@ jobs:
       - run-unit-tests
   php_7_integration_tests:
     docker:
-      - image: circleci/php:7.4
+      - image: circleci/php:7.3
     steps:
       - prepare
       - run-integration-tests
@@ -73,13 +80,14 @@ jobs:
 workflows:
   build-and-test:
     jobs:
+      - php_7_3
       - php_7_4
       - php_8_0
       - snyk:
           # Must define SNYK_TOKEN env
           context: snyk-env
           requires:
-            - php_7_4
+            - php_7_3
   integration-tests:
     jobs:
       - php_7_integration_tests:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor
 .phpcs.xml
 phpcs.xml
 .phpunit.result.cache
+.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     }
   ],
   "require": {
-    "php": "^7.3 | ^8.0",
+    "php": "^7.4 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^6.0|^7.0",
     "psr/simple-cache": "^1.0",
-    "lcobucci/jwt": "^3.4.|^4.0"
+    "lcobucci/jwt": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     }
   ],
   "require": {
-    "php": "^7.3 | ^8.0",
+    "php": "^7.4 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
-    "auth0/php-jwt": "3.3.4",
     "guzzlehttp/guzzle": "^6.0|^7.0",
-    "psr/simple-cache": "^1.0"
+    "psr/simple-cache": "^1.0",
+    "lcobucci/jwt": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     }
   ],
   "require": {
-    "php": "^7.4 | ^8.0",
+    "php": "^7.3 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^6.0|^7.0",
     "psr/simple-cache": "^1.0",
-    "lcobucci/jwt": "^4.0"
+    "lcobucci/jwt": "^3.4.|^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "cache/adapter-common": "^1.2",
     "cache/hierarchical-cache": "^1.1",
     "cache/array-adapter": "^1.1",
-    "phpstan/phpstan": "^0.12.64"
+    "phpstan/phpstan": "^0.12.64",
+    "firebase/php-jwt": "^5.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -67,13 +67,6 @@ class Authentication
     private $scope;
 
     /**
-     * Options for the Guzzle HTTP client.
-     *
-     * @var array
-     */
-    private $guzzleOptions;
-
-    /**
      * ApiClient instance.
      *
      * @var ApiClient
@@ -109,7 +102,6 @@ class Authentication
         $this->client_secret = $client_secret;
         $this->audience      = $audience;
         $this->scope         = $scope;
-        $this->guzzleOptions = $guzzleOptions;
         $this->organization  = $organization;
 
         $this->apiClient = new ApiClient( [

--- a/src/API/Helpers/RequestBuilder.php
+++ b/src/API/Helpers/RequestBuilder.php
@@ -218,7 +218,7 @@ class RequestBuilder
 
         if (! empty($this->files)) {
             $data['multipart'] = $this->buildMultiPart();
-        } else if (! empty($this->form_params)) {
+        } elseif (! empty($this->form_params)) {
             $data['form_params'] = $this->form_params;
         }
 

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -5,7 +5,6 @@
  */
 namespace Auth0\SDK\API\Management;
 
-use \Auth0\SDK\Exception\CoreException;
 
 /**
  * Class EmailTemplates.

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -329,7 +329,7 @@ class Auth0
         if (empty($this->persistantMap)) {
             // No need for storage, nothing to persist.
             $this->store = new EmptyStore();
-        } else if (! $this->store instanceof StoreInterface) {
+        } elseif (! $this->store instanceof StoreInterface) {
             // Need to have some kind of storage if user data needs to be persisted.
             $this->store = new SessionStore();
         }
@@ -699,7 +699,7 @@ class Auth0
             $jwksHttpOptions = array_merge( $this->guzzleOptions, [ 'base_uri' => $this->jwksUri ] );
             $jwksFetcher     = new JWKFetcher($this->cacheHandler, $jwksHttpOptions);
             $sigVerifier     = new AsymmetricVerifier($jwksFetcher);
-        } else if ('HS256' === $this->idTokenAlg) {
+        } elseif ('HS256' === $this->idTokenAlg) {
             $sigVerifier = new SymmetricVerifier($this->clientSecret);
         }
 
@@ -743,7 +743,7 @@ class Auth0
         $code = null;
         if ($this->responseMode === 'query' && isset($_GET['code'])) {
             $code = $_GET['code'];
-        } else if ($this->responseMode === 'form_post' && isset($_POST['code'])) {
+        } elseif ($this->responseMode === 'form_post' && isset($_POST['code'])) {
             $code = $_POST['code'];
         }
 
@@ -762,7 +762,7 @@ class Auth0
         $state = null;
         if ($this->responseMode === 'query' && isset($_GET[self::TRANSIENT_STATE_KEY])) {
             $state = $_GET[self::TRANSIENT_STATE_KEY];
-        } else if ($this->responseMode === 'form_post' && isset($_POST[self::TRANSIENT_STATE_KEY])) {
+        } elseif ($this->responseMode === 'form_post' && isset($_POST[self::TRANSIENT_STATE_KEY])) {
             $state = $_POST[self::TRANSIENT_STATE_KEY];
         }
 

--- a/src/Helpers/Tokens/AsymmetricVerifier.php
+++ b/src/Helpers/Tokens/AsymmetricVerifier.php
@@ -6,10 +6,10 @@ namespace Auth0\SDK\Helpers\Tokens;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Helpers\JWKFetcher;
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256 as RsSigner;
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
 
 /**
  * Class AsymmetricVerifier
@@ -55,6 +55,7 @@ final class AsymmetricVerifier extends SignatureVerifier
         }
 
         $config = Configuration::forAsymmetricSigner(new RsSigner(), InMemory::plainText($signingKey), InMemory::plainText($tokenKid));
+        $config->setValidationConstraints(new SignedWith($config->signer(), $config->signingKey()));
 
         return $config->validator()->validate($token, ...$config->validationConstraints());
     }

--- a/src/Helpers/Tokens/IdTokenVerifier.php
+++ b/src/Helpers/Tokens/IdTokenVerifier.php
@@ -50,7 +50,7 @@ final class IdTokenVerifier extends TokenVerifier
         $leeway = $options['leeway'] ?? $this->leeway;
 
         $tokenIat = $verifiedToken['iat'] ?? null;
-        if (! $tokenIat || ! is_int($tokenIat)) {
+        if (! $tokenIat instanceof \DateTimeImmutable) {
             throw new InvalidTokenException('Issued At (iat) claim must be a number present in the ID token');
         }
 

--- a/src/Helpers/Tokens/SignatureVerifier.php
+++ b/src/Helpers/Tokens/SignatureVerifier.php
@@ -5,8 +5,9 @@ namespace Auth0\SDK\Helpers\Tokens;
 
 use Auth0\SDK\Exception\InvalidTokenException;
 use InvalidArgumentException;
-use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\Parser;
 
 /**
  * Class SignatureVerifier
@@ -47,7 +48,7 @@ abstract class SignatureVerifier
     public function __construct(string $alg)
     {
         $this->alg    = $alg;
-        $this->parser = new Parser();
+        $this->parser = new Parser(new JoseEncoder());
     }
 
     /**
@@ -69,7 +70,7 @@ abstract class SignatureVerifier
             throw new InvalidTokenException( 'ID token could not be decoded' );
         }
 
-        $tokenAlg = $parsedToken->getHeader('alg', false);
+        $tokenAlg = $parsedToken->headers()->get('alg', false);
         if ($tokenAlg !== $this->alg) {
             throw new InvalidTokenException( sprintf(
                 'Signature algorithm of "%s" is not supported. Expected the ID token to be signed with "%s".',

--- a/src/Helpers/Tokens/SymmetricVerifier.php
+++ b/src/Helpers/Tokens/SymmetricVerifier.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\Helpers\Tokens;
 
+use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token;
 
 /**
@@ -41,7 +43,9 @@ final class SymmetricVerifier extends SignatureVerifier
      */
     protected function checkSignature(Token $token) : bool
     {
-        return $token->verify(new HsSigner(), $this->clientSecret);
+        $config = Configuration::forSymmetricSigner(new HsSigner(), InMemory::plainText($this->clientSecret));
+
+        return $config->validator()->validate($token, ...$config->validationConstraints());
     }
 
     /**

--- a/src/Helpers/Tokens/SymmetricVerifier.php
+++ b/src/Helpers/Tokens/SymmetricVerifier.php
@@ -7,6 +7,7 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
 
 /**
  * Class SymmetricVerifier
@@ -44,6 +45,7 @@ final class SymmetricVerifier extends SignatureVerifier
     protected function checkSignature(Token $token) : bool
     {
         $config = Configuration::forSymmetricSigner(new HsSigner(), InMemory::plainText($this->clientSecret));
+        $config->setValidationConstraints(new SignedWith($config->signer(), $config->signingKey()));
 
         return $config->validator()->validate($token, ...$config->validationConstraints());
     }

--- a/src/Helpers/Tokens/TokenVerifier.php
+++ b/src/Helpers/Tokens/TokenVerifier.php
@@ -95,7 +95,7 @@ class TokenVerifier
          * Issuer checks
          */
 
-        $tokenIss = $verifiedToken->getClaim('iss', false);
+        $tokenIss = $verifiedToken->claims()->get('iss', false);
         if (! $tokenIss || ! is_string($tokenIss)) {
             throw new InvalidTokenException('Issuer (iss) claim must be a string present in the ID token');
         }
@@ -110,7 +110,7 @@ class TokenVerifier
          * Audience checks
          */
 
-        $tokenAud = $verifiedToken->getClaim('aud', false);
+        $tokenAud = $verifiedToken->claims()->get('aud', false);
         if (! $tokenAud || (! is_string($tokenAud) && ! is_array($tokenAud))) {
             throw new InvalidTokenException(
                 'Audience (aud) claim must be a string or array of strings present in the ID token'
@@ -136,7 +136,7 @@ class TokenVerifier
         $now    = $options['time'] ?? time();
         $leeway = $options['leeway'] ?? $this->leeway;
 
-        $tokenExp = $verifiedToken->getClaim('exp', false);
+        $tokenExp = $verifiedToken->claims()->get('exp', false);
         if (! $tokenExp || ! is_int($tokenExp)) {
             throw new InvalidTokenException('Expiration Time (exp) claim must be a number present in the ID token');
         }
@@ -151,7 +151,7 @@ class TokenVerifier
         }
 
         $profile = [];
-        foreach ($verifiedToken->getClaims() as $claim => $value) {
+        foreach ($verifiedToken->claims() as $claim => $value) {
             $profile[$claim] = $value->getValue();
         }
 

--- a/tests/API/ApiTests.php
+++ b/tests/API/ApiTests.php
@@ -2,7 +2,7 @@
 namespace Auth0\Tests\API;
 
 use Auth0\SDK\API\Authentication;
-use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\Tests\traits\ErrorHelpers;
 use josegonzalez\Dotenv\Loader;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/integration/API/Management/BlacklistsIntegrationTest.php
+++ b/tests/integration/API/Management/BlacklistsIntegrationTest.php
@@ -1,10 +1,8 @@
 <?php
 namespace Auth0\Tests\integration\API\Management;
 
-use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
 use Auth0\Tests\API\ApiTests;
-use GuzzleHttp\Psr7\Response;
 
 class BlacklistsIntegrationTest extends ApiTests
 {

--- a/tests/integration/API/Management/JobsIntegrationTest.php
+++ b/tests/integration/API/Management/JobsIntegrationTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Auth0\Tests\integration\API\Management;
 
-use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
 use Auth0\Tests\API\ApiTests;
 

--- a/tests/unit/API/Management/BlacklistsTest.php
+++ b/tests/unit/API/Management/BlacklistsTest.php
@@ -2,7 +2,6 @@
 namespace Auth0\Tests\unit\API\Management;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
-use Auth0\SDK\API\Management;
 use Auth0\Tests\API\ApiTests;
 use GuzzleHttp\Psr7\Response;
 

--- a/tests/unit/API/Management/ConnectionsMockedTest.php
+++ b/tests/unit/API/Management/ConnectionsMockedTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @package Auth0\Tests\unit\API\Management
  */
-class ConnectionsTestMocked extends TestCase
+class ConnectionsMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/unit/API/Management/EmailTemplatesMockedTest.php
+++ b/tests/unit/API/Management/EmailTemplatesMockedTest.php
@@ -4,7 +4,7 @@ namespace Auth0\Tests\unit\API\Management;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
-use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\Tests\traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/API/Management/GrantsMockedTest.php
+++ b/tests/unit/API/Management/GrantsMockedTest.php
@@ -4,7 +4,7 @@ namespace Auth0\Tests\unit\API\Management;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Management;
 use Auth0\SDK\Exception\CoreException;
-use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\Tests\traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @package Auth0\Tests\unit\API\Management
  */
-class GrantsTestMocked extends TestCase
+class GrantsMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/unit/API/Management/GuardianTest.php
+++ b/tests/unit/API/Management/GuardianTest.php
@@ -3,7 +3,7 @@ namespace Auth0\Tests\unit\API\Management;
 
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\Tests\API\ApiTests;
-use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\Tests\traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
 
 /**

--- a/tests/unit/API/Management/RolesMockedTest.php
+++ b/tests/unit/API/Management/RolesMockedTest.php
@@ -4,7 +4,7 @@ namespace Auth0\Tests\unit\API\Management;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 use Auth0\SDK\Exception\InvalidPermissionsArrayException;
-use Auth0\Tests\Traits\ErrorHelpers;
+use Auth0\Tests\traits\ErrorHelpers;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @package Auth0\Tests\unit\API\Management
  */
-class RolesTestMocked extends TestCase
+class RolesMockedTest extends TestCase
 {
 
     use ErrorHelpers;

--- a/tests/unit/Auth0StoreTest.php
+++ b/tests/unit/Auth0StoreTest.php
@@ -4,11 +4,8 @@ namespace Auth0\Tests\unit;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Exception\ApiException;
 use Auth0\SDK\Exception\CoreException;
-use Auth0\SDK\Exception\InvalidTokenException;
-use Auth0\SDK\Store\CookieStore;
 use Auth0\SDK\Store\EmptyStore;
 use Auth0\SDK\Store\SessionStore;
-use Auth0\SDK\Store\StoreInterface;
 use Auth0\Tests\Traits\ErrorHelpers;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
This pull request adds support for lcobucci/jwt 4.x and removes drop-in replacement (auth0/php-jwt) for lcobucci/jwt 3.3.4.
**BC - php 7.3 is not supported anymore** (because lcobucci/jwt does not support php 7.3 from the version 4.0)

Upgrading to the new version of lcobucci/jwt opens a possibility to improve validation using the existing validation constraints or creating the new ones, but that has not been done in the scope of this PR. What is more, I think that it's not a good idea to validate the token at the client's side at all.

The package firebase/php-jwt is added as dev dependency, because with the new lcobucci/jwt it is not possible to create all necessary non-valid tokens in functional tests.