### PR TITLE
[SDK-2552] Change method visibility of getState to public

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,4 +97,4 @@ workflows:
                 - master
           context: snyk-env
           requires:
-            - php_7_3
+            - php_7_integration_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,6 @@ workflows:
       - php_7_3
       - php_7_4
       - php_8_0
-      - snyk:
-          # Must define SNYK_TOKEN env
-          context: snyk-env
-          requires:
-            - php_7_3
   integration-tests:
     jobs:
       - php_7_integration_tests:
@@ -95,3 +90,11 @@ workflows:
             branches:
               only:
                 - master
+      - snyk:
+          filters:
+            branches:
+              only:
+                - master
+          context: snyk-env
+          requires:
+            - php_7_3

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -757,7 +757,7 @@ class Auth0
      *
      * @see https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
      */
-    protected function getState()
+    public function getState()
     {
         $state = null;
         if ($this->responseMode === 'query' && isset($_GET[self::TRANSIENT_STATE_KEY])) {


### PR DESCRIPTION
### Description

This PR changes the visibility of the Auth0\SDK\Auth0::getState method from protected to public. This change was requested by the community. This could be useful for client applications in troubleshooting invalid state CoreExceptions.

Closes #495

### References

- #495 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
