### PR TITLE
Replace deprated/removed GuzzleHttp\Psr7\build_query

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "ext-openssl": "*",
     "auth0/php-jwt": "3.3.4",
     "guzzlehttp/guzzle": "^6.0|^7.0",
-    "psr/simple-cache": "^1.0"
+    "psr/simple-cache": "^1.0",
+    "guzzlehttp/psr7": "^1.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -155,7 +155,7 @@ class Authentication
         return sprintf(
             'https://%s/authorize?%s',
             $this->domain,
-            Psr7\build_query($params)
+            Psr7\Query::build($params)
         );
     }
 
@@ -218,7 +218,7 @@ class Authentication
             'https://%s/wsfed/%s?%s',
             $this->domain,
             $client_id ?? $this->client_id,
-            Psr7\build_query($params)
+            Psr7\Query::build($params)
         );
     }
 
@@ -258,7 +258,7 @@ class Authentication
         return sprintf(
             'https://%s/v2/logout?%s',
             $this->domain,
-            Psr7\build_query($params)
+            Psr7\Query::build($params)
         );
     }
 


### PR DESCRIPTION
### Description
This PR replaces the `Psr7\build_query()` calls with `Psr7\Query::build()`.
`Psr7\build_query()` [is deprecated](https://github.com/guzzle/psr7/blob/1.x/src/functions.php#L318) in version `1.x` of `guzzlehttp/psr7` and will be [removed](https://github.com/guzzle/psr7/blob/2.0.0-rc1/CHANGELOG.md#200beta-1---2021-03-21) in `2.0`.

This also lead me to see that this project doesn't explicitely require guzzlehttp/psr7 as a dependency, but instead relies on guzzlehttp/guzzle to supply it, which is not safe to assume. Because methods of `guzzlehttp/psr7` are used in this package, you *should* explicitely require `guzzlehttp/psr7` as a dependency in this package. 

Guzzlehttp/guzzle [changed their requirement of `guzzlehttp/psr7` to `^1.7 || ^2.0`](https://github.com/guzzle/guzzle/commit/0103c786af75da1dab4e8adfc785d6581c86352a#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34). 
After 2.0 will be stable, if you `composer require auth0/auth0-php`, it will break because auth0-php will require guzzlehttp/guzzle which in turn will install guzzlehttp/psr7 version 2, which will not have the build_query function that auth0-php uses.
You can already see this behaviour by setting your composer minimum stability to dev.

To mitigate this, this PR also explicitely requires `guzzlehttp/psr7` 1.x as a dependency in composer.json. 

### References
psr7^2.0 added to guzzle: https://github.com/guzzle/guzzle/commit/0103c786af75da1dab4e8adfc785d6581c86352a#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34

### Testing
Any static analysis tool will tell you it doesn't use deprecated methods anymore.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
