### PR TITLE
[SDK-2587] Autopagination for Management SDK

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -112,7 +112,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
-    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
@@ -149,7 +148,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
     <!-- Code > Functions -->
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
@@ -164,11 +162,9 @@
     <rule ref="Generic.Files.OneClassPerFile"/>
     <rule ref="PSR1.Classes.ClassDeclaration"/>
     <rule ref="Squiz.Classes.ValidClassName"/>
-    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
-    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
 
     <!-- Architecture > Files -->
-    <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+    <!-- -->
 
     <!-- Architecture > Functions -->
     <!-- -->

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -27,7 +27,6 @@ use Auth0\SDK\API\Management\UserBlocks;
 use Auth0\SDK\API\Management\Users;
 use Auth0\SDK\API\Management\UsersByEmail;
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Exception\ConfigurationException;
 use Auth0\SDK\Utility\HttpClient;
 use Auth0\SDK\Utility\HttpRequest;
 use Auth0\SDK\Utility\HttpResponse;
@@ -198,7 +197,7 @@ final class Management
 
         // No management token could be acquired.
         if ($managementToken === null) {
-            throw ConfigurationException::requiresManagementToken();
+            throw \Auth0\SDK\Exception\ConfigurationException::requiresManagementToken();
         }
 
         // Build the API client using the management token.

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -29,7 +29,9 @@ use Auth0\SDK\API\Management\UsersByEmail;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Exception\ConfigurationException;
 use Auth0\SDK\Utility\HttpClient;
+use Auth0\SDK\Utility\HttpRequest;
 use Auth0\SDK\Utility\HttpResponse;
+use Auth0\SDK\Utility\HttpResponsePaginator;
 
 /**
  * Class Management
@@ -209,6 +211,22 @@ final class Management
     public function getHttpClient(): HttpClient
     {
         return $this->httpClient;
+    }
+
+    /**
+     * Return an instance of HttpRequest representing the last issued request.
+     */
+    public function getLastRequest(): HttpRequest
+    {
+        return $this->httpClient->getLastRequest();
+    }
+
+    /**
+     * Return a ResponsePaginator instance configured for the last HttpRequest.
+     */
+    public function getResponsePaginator(): HttpResponsePaginator
+    {
+        return new HttpResponsePaginator($this->httpClient);
     }
 
     /**

--- a/src/API/Management/Blacklists.php
+++ b/src/API/Management/Blacklists.php
@@ -41,7 +41,7 @@ final class Blacklists extends ManagementEndpoint
             $request['aud'] = $aud;
         }
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('blacklists', 'tokens')
             ->withBody((object) $request)
             ->withOptions($options)
@@ -65,7 +65,7 @@ final class Blacklists extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($aud, 'aud');
 
-        $client = $this->apiClient->method('get')
+        $client = $this->getHttpClient()->method('get')
             ->addPath('blacklists', 'tokens');
 
         if ($aud !== null) {

--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -37,7 +37,7 @@ final class ClientGrants extends ManagementEndpoint
         $this->validateString($clientId, 'clientId');
         $this->validateString($audience, 'audience');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('client-grants')
             ->withBody(
                 (object) [
@@ -65,7 +65,7 @@ final class ClientGrants extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('client-grants')
             ->withParams($parameters)
             ->withOptions($options)
@@ -145,7 +145,7 @@ final class ClientGrants extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('client-grants', $id)
             ->withBody(
                 (object) [
@@ -173,7 +173,7 @@ final class ClientGrants extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('client-grants', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -38,7 +38,7 @@ final class Clients extends ManagementEndpoint
             'name' => $name,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('clients')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -62,7 +62,7 @@ final class Clients extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('clients')
             ->withParams($parameters)
             ->withOptions($options)
@@ -88,7 +88,7 @@ final class Clients extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('clients', $id)
             ->withOptions($options)
             ->call();
@@ -115,7 +115,7 @@ final class Clients extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('clients', $id)
             ->withBody($body)
             ->withOptions($options)
@@ -139,7 +139,7 @@ final class Clients extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('clients', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -42,7 +42,7 @@ final class Connections extends ManagementEndpoint
             'strategy' => $strategy,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('connections')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -64,7 +64,7 @@ final class Connections extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('connections')
             ->withParams($parameters)
             ->withOptions($options)
@@ -88,7 +88,7 @@ final class Connections extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('connections', $id)
             ->withOptions($options)
             ->call();
@@ -113,7 +113,7 @@ final class Connections extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('connections', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -137,7 +137,7 @@ final class Connections extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('connections', $id)
             ->withOptions($options)
             ->call();
@@ -163,7 +163,7 @@ final class Connections extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateEmail($email, 'email');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('connections', $id, 'users')
             ->withParam('email', $email)
             ->withOptions($options)

--- a/src/API/Management/DeviceCredentials.php
+++ b/src/API/Management/DeviceCredentials.php
@@ -49,7 +49,7 @@ final class DeviceCredentials extends ManagementEndpoint
             'device_id' => $deviceId,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('device-credentials')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -89,7 +89,7 @@ final class DeviceCredentials extends ManagementEndpoint
             $payload['type'] = $type;
         }
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('device-credentials')
             ->withParams($payload)
             ->withOptions($options)
@@ -113,7 +113,7 @@ final class DeviceCredentials extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('device-credentials', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -58,7 +58,7 @@ final class EmailTemplates extends ManagementEndpoint
             'enabled' => $enabled,
         ] + $additional;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('email-templates')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -83,7 +83,7 @@ final class EmailTemplates extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($templateName, 'templateName');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('email-templates', $templateName)
             ->withOptions($options)
             ->call();
@@ -111,7 +111,7 @@ final class EmailTemplates extends ManagementEndpoint
         $this->validateString($templateName, 'templateName');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('put')
+        return $this->getHttpClient()->method('put')
             ->addPath('email-templates', $templateName)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -140,7 +140,7 @@ final class EmailTemplates extends ManagementEndpoint
         $this->validateString($templateName, 'templateName');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('email-templates', $templateName)
             ->withBody((object) $body)
             ->withOptions($options)

--- a/src/API/Management/Emails.php
+++ b/src/API/Management/Emails.php
@@ -42,7 +42,7 @@ final class Emails extends ManagementEndpoint
             'credentials' => (object) $credentials,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('emails', 'provider')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -62,7 +62,7 @@ final class Emails extends ManagementEndpoint
     public function getProvider(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('emails', 'provider')
             ->withOptions($options)
             ->call();
@@ -95,7 +95,7 @@ final class Emails extends ManagementEndpoint
             'credentials' => (object) $credentials,
         ] + $body;
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('emails', 'provider')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -115,7 +115,7 @@ final class Emails extends ManagementEndpoint
     public function deleteProvider(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('emails', 'provider')
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Grants.php
+++ b/src/API/Management/Grants.php
@@ -30,7 +30,7 @@ final class Grants extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('grants')
             ->withParams($parameters)
             ->withOptions($options)
@@ -132,7 +132,7 @@ final class Grants extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('grants', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Guardian.php
+++ b/src/API/Management/Guardian.php
@@ -28,7 +28,7 @@ final class Guardian extends ManagementEndpoint
     public function getFactors(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('guardian', 'factors')
             ->withOptions($options)
             ->call();
@@ -51,7 +51,7 @@ final class Guardian extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('guardian', 'enrollments', $id)
             ->withOptions($options)
             ->call();
@@ -74,7 +74,7 @@ final class Guardian extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('guardian', 'enrollments', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -39,7 +39,7 @@ final class Jobs extends ManagementEndpoint
         $this->validateString($filePath, 'filePath');
         $this->validateString($connectionId, 'connectionId');
 
-        $request = $this->apiClient->method('post')
+        $request = $this->getHttpClient()->method('post')
             ->addPath('jobs', 'users-imports')
             ->addFile('users', $filePath)
             ->withFormParam('connection_id', $connectionId);
@@ -69,7 +69,7 @@ final class Jobs extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('jobs', 'users-exports')
             ->withBody((object) $body)
             ->withOptions($options)
@@ -99,7 +99,7 @@ final class Jobs extends ManagementEndpoint
             'user_id' => $userId,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('jobs', 'verification-email')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -125,7 +125,7 @@ final class Jobs extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('jobs', $id)
             ->withOptions($options)
             ->call();
@@ -150,7 +150,7 @@ final class Jobs extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('jobs', $id, 'errors')
             ->withOptions($options)
             ->call();

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -46,7 +46,7 @@ final class LogStreams extends ManagementEndpoint
             $payload['name'] = $name;
         }
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('log-streams')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -66,7 +66,7 @@ final class LogStreams extends ManagementEndpoint
     public function getAll(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('log-streams')
             ->withOptions($options)
             ->call();
@@ -89,7 +89,7 @@ final class LogStreams extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('log-streams', $id)
             ->withOptions($options)
             ->call();
@@ -115,7 +115,7 @@ final class LogStreams extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('log-streams', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -139,7 +139,7 @@ final class LogStreams extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('log-streams', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Logs.php
+++ b/src/API/Management/Logs.php
@@ -30,7 +30,7 @@ final class Logs extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('logs')
             ->withParams($parameters)
             ->withOptions($options)
@@ -54,7 +54,7 @@ final class Logs extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('logs', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/ManagementEndpoint.php
+++ b/src/API/Management/ManagementEndpoint.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\HttpClient;
+use Auth0\SDK\Utility\HttpRequest;
+use Auth0\SDK\Utility\HttpResponsePaginator;
 
 /**
  * Class ManagementEndpoint.
@@ -13,27 +15,43 @@ use Auth0\SDK\Utility\HttpClient;
 abstract class ManagementEndpoint
 {
     /**
-     * Injected ApiClient instance to use.
+     * Injected HttpClient instance to use.
      */
-    protected HttpClient $apiClient;
+    private HttpClient $httpClient;
 
     /**
      * ManagementEndpoint constructor.
      *
-     * @param ApiClient $apiClient ApiClient instance to use.
+     * @param HttpClient $httpClient HttpClient instance to use.
      */
     public function __construct(
-        HttpClient $apiClient
+        HttpClient $httpClient
     ) {
-        $this->apiClient = $apiClient;
+        $this->httpClient = $httpClient;
     }
 
     /**
-     * Get the injected ApiClient instance.
+     * Get the injected HttpClient instance.
      */
-    public function getApiClient(): HttpClient
+    public function getHttpClient(): HttpClient
     {
-        return $this->apiClient;
+        return $this->httpClient;
+    }
+
+    /**
+     * Return an instance of HttpRequest representing the last issued request.
+     */
+    public function getLastRequest(): HttpRequest
+    {
+        return $this->httpClient->getLastRequest();
+    }
+
+    /**
+     * Return a ResponsePaginator instance configured for the last HttpRequest.
+     */
+    public function getResponsePaginator(): HttpResponsePaginator
+    {
+        return new HttpResponsePaginator($this->httpClient);
     }
 
     /**

--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -48,7 +48,7 @@ final class Organizations extends ManagementEndpoint
             ] + $body
         );
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('organizations')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -66,7 +66,7 @@ final class Organizations extends ManagementEndpoint
     public function getAll(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations')
             ->withOptions($options)
             ->call();
@@ -87,7 +87,7 @@ final class Organizations extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id)
             ->withOptions($options)
             ->call();
@@ -108,7 +108,7 @@ final class Organizations extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($name, 'name');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', 'name', $name)
             ->withOptions($options)
             ->call();
@@ -146,7 +146,7 @@ final class Organizations extends ManagementEndpoint
             ] + $body
         );
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('organizations', $id)
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -166,7 +166,7 @@ final class Organizations extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id)
             ->withOptions($options)
             ->call();
@@ -196,7 +196,7 @@ final class Organizations extends ManagementEndpoint
             'connection_id' => $connectionId,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('organizations', $id, 'enabled_connections')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -218,7 +218,7 @@ final class Organizations extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'enabled_connections')
             ->withOptions($options)
             ->call();
@@ -242,7 +242,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($connectionId, 'connectionId');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
             ->withOptions($options)
             ->call();
@@ -268,7 +268,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($connectionId, 'connectionId');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -293,7 +293,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($connectionId, 'connectionId');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
             ->withOptions($options)
             ->call();
@@ -321,7 +321,7 @@ final class Organizations extends ManagementEndpoint
             'members' => $members,
         ];
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('organizations', $id, 'members')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -343,7 +343,7 @@ final class Organizations extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'members')
             ->withOptions($options)
             ->call();
@@ -371,7 +371,7 @@ final class Organizations extends ManagementEndpoint
             'members' => $members,
         ];
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'members')
             ->withBody($payload)
             ->withOptions($options)
@@ -403,7 +403,7 @@ final class Organizations extends ManagementEndpoint
             'roles' => $roles,
         ];
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('organizations', $id, 'members', $userId, 'roles')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -428,7 +428,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($userId, 'userId');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'members', $userId, 'roles')
             ->withOptions($options)
             ->call();
@@ -459,7 +459,7 @@ final class Organizations extends ManagementEndpoint
             'roles' => $roles,
         ];
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'members', $userId, 'roles')
             ->withBody($payload)
             ->withOptions($options)
@@ -510,7 +510,7 @@ final class Organizations extends ManagementEndpoint
             ] + $body
         );
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('organizations', $id, 'invitations')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -532,7 +532,7 @@ final class Organizations extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'invitations')
             ->withOptions($options)
             ->call();
@@ -556,7 +556,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($invitationId, 'invitationId');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'invitations', $invitationId)
             ->withOptions($options)
             ->call();
@@ -580,7 +580,7 @@ final class Organizations extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($invitationId, 'invitation');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'invitations', $invitationId)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/ResourceServers.php
+++ b/src/API/Management/ResourceServers.php
@@ -39,7 +39,7 @@ final class ResourceServers extends ManagementEndpoint
             'identifier' => $identifier,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('resource-servers')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -59,7 +59,7 @@ final class ResourceServers extends ManagementEndpoint
     public function getAll(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('resource-servers')
             ->withOptions($options)
             ->call();
@@ -82,7 +82,7 @@ final class ResourceServers extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('resource-servers', $id)
             ->withOptions($options)
             ->call();
@@ -108,7 +108,7 @@ final class ResourceServers extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('resource-servers', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -132,7 +132,7 @@ final class ResourceServers extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('resource-servers', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Roles.php
+++ b/src/API/Management/Roles.php
@@ -38,7 +38,7 @@ final class Roles extends ManagementEndpoint
             'name' => $name,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('roles')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -60,7 +60,7 @@ final class Roles extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('roles')
             ->withParams($parameters)
             ->withOptions($options)
@@ -84,7 +84,7 @@ final class Roles extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('roles', $id)
             ->withOptions($options)
             ->call();
@@ -110,7 +110,7 @@ final class Roles extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('roles', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -134,7 +134,7 @@ final class Roles extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('roles', $id)
             ->withOptions($options)
             ->call();
@@ -169,7 +169,7 @@ final class Roles extends ManagementEndpoint
             $payload['permissions'][] = (object) $permission;
         }
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('roles', $id, 'permissions')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -193,7 +193,7 @@ final class Roles extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('roles', $id, 'permissions')
             ->withOptions($options)
             ->call();
@@ -228,7 +228,7 @@ final class Roles extends ManagementEndpoint
             $payload['permissions'][] = (object) $permission;
         }
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('roles', $id, 'permissions')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -255,7 +255,7 @@ final class Roles extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($users, 'users');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('roles', $id, 'users')
             ->withBody(
                 (object) [
@@ -286,7 +286,7 @@ final class Roles extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('roles', $id, 'users')
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -40,7 +40,7 @@ final class Rules extends ManagementEndpoint
             'script' => $script,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('rules')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -62,7 +62,7 @@ final class Rules extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('rules')
             ->withParams($parameters)
             ->withOptions($options)
@@ -86,7 +86,7 @@ final class Rules extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('rules', $id)
             ->withOptions($options)
             ->call();
@@ -112,7 +112,7 @@ final class Rules extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('rules', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -136,7 +136,7 @@ final class Rules extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('rules', $id)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/Stats.php
+++ b/src/API/Management/Stats.php
@@ -28,7 +28,7 @@ final class Stats extends ManagementEndpoint
     public function getActiveUsers(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('stats', 'active-users')
             ->withOptions($options)
             ->call();
@@ -51,7 +51,7 @@ final class Stats extends ManagementEndpoint
         ?string $to = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        $client = $this->apiClient->method('get')
+        $client = $this->getHttpClient()->method('get')
             ->addPath('stats', 'daily');
 
         if ($from !== null) {

--- a/src/API/Management/Tenants.php
+++ b/src/API/Management/Tenants.php
@@ -28,7 +28,7 @@ final class Tenants extends ManagementEndpoint
     public function get(
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('tenants', 'settings')
             ->withOptions($options)
             ->call();
@@ -49,7 +49,7 @@ final class Tenants extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('tenants', 'settings')
             ->withBody((object) $body)
             ->withOptions($options)

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -38,7 +38,7 @@ final class Tickets extends ManagementEndpoint
             'user_id' => $userId,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('tickets', 'email-verification')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -58,7 +58,7 @@ final class Tickets extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('tickets', 'password-change')
             ->withBody((object) $body)
             ->withOptions($options)

--- a/src/API/Management/UserBlocks.php
+++ b/src/API/Management/UserBlocks.php
@@ -30,7 +30,7 @@ final class UserBlocks extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('user-blocks', $id)
             ->withOptions($options)
             ->call();
@@ -51,7 +51,7 @@ final class UserBlocks extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('user-blocks', $id)
             ->withOptions($options)
             ->call();
@@ -72,7 +72,7 @@ final class UserBlocks extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($identifier, 'identifier');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('user-blocks')
             ->withParam('identifier', $identifier)
             ->withOptions($options)
@@ -94,7 +94,7 @@ final class UserBlocks extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($identifier, 'identifier');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('user-blocks')
             ->withParam('identifier', $identifier)
             ->withOptions($options)

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -39,7 +39,7 @@ final class Users extends ManagementEndpoint
             'connection' => $connection,
         ] + $body;
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -64,7 +64,7 @@ final class Users extends ManagementEndpoint
         array $parameters = [],
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users')
             ->withParams($parameters)
             ->withOptions($options)
@@ -88,7 +88,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id)
             ->withOptions($options)
             ->call();
@@ -115,7 +115,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('patch')
+        return $this->getHttpClient()->method('patch')
             ->addPath('users', $id)
             ->withBody((object) $body)
             ->withOptions($options)
@@ -139,7 +139,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('users', $id)
             ->withOptions($options)
             ->call();
@@ -165,7 +165,7 @@ final class Users extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($body, 'body');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'identities')
             ->withBody((object) $body)
             ->withOptions($options)
@@ -195,7 +195,7 @@ final class Users extends ManagementEndpoint
         $this->validateString($provider, 'provider');
         $this->validateString($identityId, 'identityId');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'identities', $provider, $identityId)
             ->withOptions($options)
             ->call();
@@ -223,7 +223,7 @@ final class Users extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($roles, 'roles');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'roles')
             ->withBody(
                 (object) [
@@ -253,7 +253,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'roles')
             ->withOptions($options)
             ->call();
@@ -279,7 +279,7 @@ final class Users extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateArray($roles, 'roles');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'roles')
             ->withBody(
                 (object) [
@@ -320,7 +320,7 @@ final class Users extends ManagementEndpoint
             $payload['permissions'][] = (object) $permission;
         }
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'permissions')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -344,7 +344,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'permissions')
             ->withOptions($options)
             ->call();
@@ -380,7 +380,7 @@ final class Users extends ManagementEndpoint
             $payload['permissions'][] = (object) $permission;
         }
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'permissions')
             ->withBody((object) $payload)
             ->withOptions($options)
@@ -405,7 +405,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'logs')
             ->withOptions($options)
             ->call();
@@ -429,7 +429,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'organizations')
             ->withOptions($options)
             ->call();
@@ -452,7 +452,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'enrollments')
             ->withOptions($options)
             ->call();
@@ -476,7 +476,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'recovery-code-regeneration')
             ->withOptions($options)
             ->call();
@@ -500,7 +500,7 @@ final class Users extends ManagementEndpoint
     ): ResponseInterface {
         $this->validateString($id, 'id');
 
-        return $this->apiClient->method('post')
+        return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'multifactor', 'actions', 'invalidate-remember-browser')
             ->withOptions($options)
             ->call();
@@ -527,7 +527,7 @@ final class Users extends ManagementEndpoint
         $this->validateString($id, 'id');
         $this->validateString($provider, 'provider');
 
-        return $this->apiClient->method('delete')
+        return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'multifactor', $provider)
             ->withOptions($options)
             ->call();

--- a/src/API/Management/UsersByEmail.php
+++ b/src/API/Management/UsersByEmail.php
@@ -28,7 +28,7 @@ final class UsersByEmail extends ManagementEndpoint
         string $email,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        return $this->apiClient->method('get')
+        return $this->getHttpClient()->method('get')
             ->addPath('users-by-email')
             ->withParam('email', $email)
             ->withOptions($options)

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -157,7 +157,7 @@ final class Auth0
         ?int $tokenNow = null
     ): Token {
         // instantiate Token handler using the provided JWT, expecting an ID token, using the SDK configuration.
-        $token = new Token($token, Token::TYPE_ID_TOKEN, $this->configuration);
+        $token = new Token($this->configuration, $token, Token::TYPE_ID_TOKEN);
 
         // Verify token signature.
         $token->verify();

--- a/src/Exception/PaginatorException.php
+++ b/src/Exception/PaginatorException.php
@@ -7,9 +7,9 @@ namespace Auth0\SDK\Exception;
 final class PaginatorException extends \Auth0\SDK\Exception\SdkException implements \Throwable
 {
     public const MSG_HTTP_METHOD_UNSUPPORTED = 'This request type is not supported. You can only paginate GET requests.';
-    public const MSG_HTTP_BAD_RESPONSE = 'Unable to paginate request.';
-    public const MSG_HTTP_ENDPOINT_UNSUPPORTED = 'The requested endpoint "%s" is not supported for pagination.';
-    public const MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION = 'This requested endpoint "%s" does not support checkpoint-based pagination.';
+    public const MSG_HTTP_BAD_RESPONSE = 'Unable to paginate request. Please ensure the endpoint you are using supports pagination, and that you are using the include_totals params.';
+    public const MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION = 'The requested endpoint "%s" does not support checkpoint pagination.';
+    public const MSG_HTTP_CANNOT_COUNT_CHECKPOINT_PAGINATION = 'Cannot receive counts when using checkpoint pagination.';
 
     public static function httpMethodUnsupported(): self
     {
@@ -21,15 +21,14 @@ final class PaginatorException extends \Auth0\SDK\Exception\SdkException impleme
         return new self(self::MSG_HTTP_BAD_RESPONSE);
     }
 
-    public static function httpEndpointUnsupported(
-        string $endpoint
-    ): self {
-        return new self(sprintf(self::MSG_HTTP_ENDPOINT_UNSUPPORTED, $endpoint));
-    }
-
     public static function httpEndpointUnsupportedCheckpoints(
         string $endpoint
     ): self {
         return new self(sprintf(self::MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION, $endpoint));
+    }
+
+    public static function httpCheckpointCannotBeCounted(): self
+    {
+        return new self(self::MSG_HTTP_CANNOT_COUNT_CHECKPOINT_PAGINATION);
     }
 }

--- a/src/Exception/PaginatorException.php
+++ b/src/Exception/PaginatorException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Exception;
+
+final class PaginatorException extends \Auth0\SDK\Exception\SdkException implements \Throwable
+{
+    public const MSG_HTTP_METHOD_UNSUPPORTED = 'This request type is not supported. You can only paginate GET requests.';
+
+    public static function httpMethodUnsupported(): self
+    {
+        return new self(self::MSG_HTTP_METHOD_UNSUPPORTED);
+    }
+}

--- a/src/Exception/PaginatorException.php
+++ b/src/Exception/PaginatorException.php
@@ -7,9 +7,29 @@ namespace Auth0\SDK\Exception;
 final class PaginatorException extends \Auth0\SDK\Exception\SdkException implements \Throwable
 {
     public const MSG_HTTP_METHOD_UNSUPPORTED = 'This request type is not supported. You can only paginate GET requests.';
+    public const MSG_HTTP_BAD_RESPONSE = 'Unable to paginate request.';
+    public const MSG_HTTP_ENDPOINT_UNSUPPORTED = 'The requested endpoint "%s" is not supported for pagination.';
+    public const MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION = 'This requested endpoint "%s" does not support checkpoint-based pagination.';
 
     public static function httpMethodUnsupported(): self
     {
         return new self(self::MSG_HTTP_METHOD_UNSUPPORTED);
+    }
+
+    public static function httpBadResponse(): self
+    {
+        return new self(self::MSG_HTTP_BAD_RESPONSE);
+    }
+
+    public static function httpEndpointUnsupported(
+        string $endpoint
+    ): self {
+        return new self(sprintf(self::MSG_HTTP_ENDPOINT_UNSUPPORTED, $endpoint));
+    }
+
+    public static function httpEndpointUnsupportedCheckpoints(
+        string $endpoint
+    ): self {
+        return new self(sprintf(self::MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION, $endpoint));
     }
 }

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -93,7 +93,10 @@ trait ConfigurableMixin
     ): self {
         $this->configuredState = [];
 
+        // phpcs:ignore
         // TODO: Replace get_class() w/ ::class when 7.x support is dropped.
+
+        // phpcs:ignore
         $constructor = new \ReflectionMethod(get_class($this) . '::__construct');
         $parameters = $constructor->getParameters();
         $arguments = $args[0];

--- a/src/Token.php
+++ b/src/Token.php
@@ -49,9 +49,9 @@ final class Token
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token parsing fails. See the exception message for further details.
      */
     public function __construct(
+        SdkConfiguration &$configuration,
         string $jwt,
-        int $type = self::TYPE_ID_TOKEN,
-        SdkConfiguration &$configuration
+        int $type = self::TYPE_ID_TOKEN
     ) {
         // Store the type of token we're working with.
         $this->type = $type;

--- a/src/Token.php
+++ b/src/Token.php
@@ -51,13 +51,13 @@ final class Token
     public function __construct(
         string $jwt,
         int $type = self::TYPE_ID_TOKEN,
-        ?SdkConfiguration $configuration = null
+        SdkConfiguration &$configuration
     ) {
         // Store the type of token we're working with.
         $this->type = $type;
 
         // Store the configuration internally.
-        $this->configuration = $configuration;
+        $this->configuration = & $configuration;
 
         // Create a transient storage handler using the configured transientStorage medium.
         $this->transient = new TransientStoreHandler($configuration->getTransientStorage());
@@ -76,7 +76,7 @@ final class Token
     public function parse(
         string $jwt
     ): self {
-        $this->parser = (new Parser($jwt, $this->configuration));
+        $this->parser = new Parser($jwt, $this->configuration);
         return $this;
     }
 

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -32,9 +32,9 @@ final class Parser
      */
     public function __construct(
         string $jwt,
-        SdkConfiguration $configuration
+        SdkConfiguration &$configuration
     ) {
-        $this->configuration = $configuration;
+        $this->configuration = & $configuration;
         $this->parse($jwt);
     }
 

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -72,7 +72,7 @@ final class Verifier
      * @param CacheInterface|null $cache        Optional. A PSR-6 ("SimpleCache") CacheInterface instance to cache JWKS results within.
      */
     public function __construct(
-        SdkConfiguration $configuration,
+        SdkConfiguration &$configuration,
         string $payload,
         string $signature,
         array $headers,
@@ -82,7 +82,7 @@ final class Verifier
         ?int $cacheExpires = null,
         ?CacheInterface $cache = null
     ) {
-        $this->configuration = $configuration;
+        $this->configuration = & $configuration;
         $this->payload = $payload;
         $this->signature = $signature;
         $this->headers = $headers;

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -242,6 +242,7 @@ final class Verifier
             return;
         }
 
+        // phpcs:ignore
         // TODO: Remove when PHP 7.x support is EOL
         openssl_free_key($key);
     }

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -179,7 +179,7 @@ final class Verifier
             }
         }
 
-        $keys = (new HttpRequest($this->configuration, 'get', $path, [], null, $scheme . '://' . $jwksUri['host']))->call();
+        $keys = (new HttpRequest($this->configuration, 'get', $path, [], $scheme . '://' . $jwksUri['host']))->call();
 
         if (is_array($keys) && isset($keys['keys']) && count($keys['keys'])) {
             foreach ($keys['keys'] as $key) {

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -8,7 +8,7 @@ use Auth0\SDK\Configuration\SdkConfiguration;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Class ApiClient
+ * Class HttpClient
  */
 final class HttpClient
 {
@@ -38,16 +38,16 @@ final class HttpClient
     private array $mockedResponses = [];
 
     /**
-     * ApiClient constructor.
+     * HttpClient constructor.
      *
      * @param array $config Configuration for this client.
      */
     public function __construct(
-        SdkConfiguration $configuration,
+        SdkConfiguration &$configuration,
         string $basePath = '/',
         array $headers = []
     ) {
-        $this->configuration = $configuration;
+        $this->configuration = & $configuration;
 
         $this->basePath = $basePath;
         $this->headers = $headers;

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -63,13 +63,7 @@ final class HttpClient
         string $method
     ): HttpRequest {
         $method = strtolower($method);
-        $nextMockedResponse = null;
-
-        if (count($this->mockedResponses)) {
-            $nextMockedResponse = array_shift($this->mockedResponses);
-        }
-
-        $builder = new HttpRequest($this->configuration, $method, $this->basePath, $this->headers, $nextMockedResponse);
+        $builder = new HttpRequest($this->configuration, $method, $this->basePath, $this->headers, null, $this->mockedResponses);
 
         if (in_array($method, ['post', 'put', 'patch', 'delete'])) {
             $builder->withHeader('Content-Type', 'application/json');
@@ -85,12 +79,37 @@ final class HttpClient
      */
     public function mockResponse(
         ResponseInterface $response,
-        ?callable $callback = null
+        ?callable $callback = null,
+        ?\Exception $exception = null
     ): self {
         $this->mockedResponses[] = (object) [
             'response' => $response,
             'callback' => $callback,
+            'exception' => $exception
         ];
+
+        return $this;
+    }
+
+    /**
+     * Inject a series of Psr\Http\Message\ResponseInterface objects into created HttpRequest clients.
+     */
+    public function mockResponses(
+        array $responses
+    ): self {
+        foreach ($responses as $response) {
+            if ($response instanceof ResponseInterface) {
+                $response = [ 'response' => $response ];
+            }
+
+            if (! isset($response['response'])) {
+                continue;
+            }
+
+            if ($response['response'] instanceof ResponseInterface) {
+                $this->mockResponse($response['response'], $response['callback'] ?? null);
+            }
+        }
 
         return $this;
     }

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -85,7 +85,7 @@ final class HttpClient
         $this->mockedResponses[] = (object) [
             'response' => $response,
             'callback' => $callback,
-            'exception' => $exception
+            'exception' => $exception,
         ];
 
         return $this;

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -89,14 +89,14 @@ final class HttpRequest
      * @param array $config Configuration array passed to \Auth0\SDK\API\Management constructor.
      */
     public function __construct(
-        SdkConfiguration $configuration,
+        SdkConfiguration &$configuration,
         string $method,
         string $basePath = '/',
         array $headers = [],
         ?string $domain = null,
         ?array &$mockedResponses = null
     ) {
-        $this->configuration = $configuration;
+        $this->configuration = & $configuration;
         $this->method = $method;
         $this->basePath = $basePath;
         $this->headers = $headers;

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -101,7 +101,7 @@ final class HttpRequest
         $this->basePath = $basePath;
         $this->headers = $headers;
         $this->domain = $domain;
-        $this->mockedResponses =& $mockedResponses;
+        $this->mockedResponses = & $mockedResponses;
     }
 
     /**

--- a/src/Utility/HttpResponse.php
+++ b/src/Utility/HttpResponse.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\Utility;
 
-use Iterator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 

--- a/src/Utility/HttpResponse.php
+++ b/src/Utility/HttpResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\Utility;
 
+use Iterator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Utility;
+
+use Auth0\SDK\Exception\NetworkException;
+use Auth0\SDK\Exception\PaginatorException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class HttpResponsePaginator.
+ */
+final class HttpResponsePaginator implements \Countable, \Iterator
+{
+    private HttpClient $httpClient;
+
+    private int $position = 0;
+    private int $requestLimit = 0;
+    private int $requestTotal = 0;
+    private int $requestCount = 0;
+    private array $results = [];
+
+    public function __construct(
+        HttpClient $httpClient
+    )
+    {
+        $this->httpClient = $httpClient;
+        $this->processLastResponse();
+    }
+
+    public function countNetworkRequests(): int
+    {
+        return $this->requestCount;
+    }
+
+    /**
+     * Return the total number of results available, according to the API.
+     */
+    public function count(): int
+    {
+        return $this->requestTotal;
+    }
+
+    /**
+     * Return the current result at our position, if available.
+     */
+    public function current()
+    {
+        return $this->valid() ? $this->result() : false;
+    }
+
+    /**
+     * Retrieve the current position, if valid.
+     */
+    public function key(): int
+    {
+        return $this->valid() ? $this->position : null;
+    }
+
+    /**
+     * Increase our position cursor.
+     */
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    /**
+     * Return true if a result is available. If a result is not immediately available (cached) but the current position is less than the API-reported total results, a paginated network request will be attempted to get the next results. Returns false when no results are available at the current position.
+     */
+    public function valid(): bool
+    {
+        // A cached result is available.
+        if ($this->result()) {
+            return true;
+        }
+
+        // No cached result available; is our position beyond the API's reported total?
+        if ($this->position < $this->requestTotal) {
+            // No, there should be more results available for request. Do that.
+            return $this->getNextResults();
+        }
+
+        return false;
+    }
+
+    /**
+     * Reset position to 0.
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Return the current result at our position, if available.
+     */
+    private function result()
+    {
+        return $this->results[$this->position] ?? null;
+    }
+
+    /**
+     * Set an HttpRequest's pagination params to safe defaults. Triggered when a HttpResponse is provided that isn't paginated, or doesn't have include_totals set (required for iteration.)
+     */
+    private function resetResults(): bool
+    {
+        if ($this->lastBuilder()) {
+            // Retrieve the active HttpRequest instance to repeat the request.
+            $lastBuilder = $this->lastBuilder();
+
+            // Get the current HttpRequest parameters.
+            $params = $lastBuilder->getParams();
+
+            // Ensure basic pagination details are included in the request.
+
+            // Is ?page= present? If not, request the first page.
+            if (! mb_strstr($params, 'page=')) {
+                $lastBuilder->withParam('page', 0);
+            }
+
+            // Is ?per_page present? If not, set a sane default.
+            if (! mb_strstr($params, 'per_page=')) {
+                $lastBuilder->withParam('per_page', 100);
+            }
+
+            // Ensure ?include_totals=true is present, required to iterate using this class.
+            $lastBuilder->withParam('include_totals', true);
+
+            // Increment our network request tracker for reference.
+            ++$this->requestCount;
+
+            // Issue next paged request.
+            try {
+                $response = $lastBuilder->call();
+            } catch (NetworkException $exception) {
+                return false;
+            }
+
+            // Process the response.
+            return $this->processLastResponse();
+        }
+
+        return false;
+    }
+
+    /**
+     * Make a network request for the next page of results.
+     */
+    private function getNextResults(): bool
+    {
+        if ($this->lastBuilder() && $this->lastResponse()) {
+            // Retrieve the active HttpRequest instance to repeat the request.
+            $lastBuilder = $this->lastBuilder();
+
+            // Get the next page.
+            $page = ceil($this->position / $this->requestLimit);
+
+            // Set the next page.
+            $lastBuilder->withParam('page', $page);
+
+            // Increment our network request tracker for reference.
+            ++$this->requestCount;
+
+            // Issue next paged request.
+            try {
+                $response = $lastBuilder->call();
+            } catch (NetworkException $exception) {
+                return false;
+            }
+
+            // Process the response.
+            return $this->processLastResponse();
+        }
+
+        return false;
+    }
+
+    /**
+     * Process the previous HttpResponse results and cache them for iterator content.
+     */
+    private function processLastResponse(): bool
+    {
+        $lastRequest = $this->lastRequest();
+        $lastResponse = $this->lastResponse();
+
+        if ($lastRequest && $lastResponse) {
+            // We can only paginate GET requests.
+            if (mb_strtolower($lastRequest->getMethod()) !== 'get') {
+                throw PaginatorException::httpMethodUnsupported();
+            }
+
+            // Was the HTTP request successful?
+            if (HttpResponse::wasSuccessful($lastResponse)) {
+                // Decode the response.
+                $results = HttpResponse::decodeContent($lastResponse);
+
+                // No results, abort processing.
+                if (! is_array($results) || ! count($results)) {
+                    return false;
+                }
+
+                // There is no 'start' key, the request was probably made without the include_totals param. Try again using safe pagination defaults.
+                if (! isset($results['start'])) {
+                    return $this->resetResults();
+                }
+
+                $start = $results['start'] ?? $this->position;
+                $hadResults = false;
+
+                foreach ($results as $resultKey => $result) {
+                    if ($resultKey === 'limit') {
+                        $this->requestLimit = (int) $result;
+                        continue;
+                    }
+
+                    if ($resultKey === 'total') {
+                        $this->requestTotal = (int) $result;
+                        continue;
+                    }
+
+                    if ($resultKey === 'length') {
+                        $hadResults = true;
+                        continue;
+                    }
+
+                    if ($resultKey !== 'start') {
+                        for ($i=0; $i < count($result); $i++) {
+                            $this->results[$start + $i] = $result[$i];
+                        }
+                    }
+                }
+
+                if ($hadResults) {
+                    // We successfully retrieved results.
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // No request has been issued yet; do we at least have a builder?
+        if ($this->lastBuilder()) {
+            // Try issuing the request.
+            return $this->resetResults();
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the current instance of the HttpRequest.
+     */
+    private function lastBuilder(): ?HttpRequest
+    {
+        return $this->httpClient->getLastRequest();
+    }
+
+    /**
+     * Return a RequestInterface representing the most recent sent HTTP request.
+     */
+    private function lastRequest(): ?RequestInterface
+    {
+        if ($this->lastBuilder()) {
+            return $this->lastBuilder()->getLastRequest();
+        }
+
+        return null;
+    }
+
+    /**
+     * Return a ResponseInterface representing the most recently returned HTTP response.
+     */
+    private function lastResponse(): ?ResponseInterface
+    {
+        if ($this->lastBuilder()) {
+            return $this->lastBuilder()->getLastResponse();
+        }
+
+        return null;
+    }
+}

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -24,8 +24,7 @@ final class HttpResponsePaginator implements \Countable, \Iterator
 
     public function __construct(
         HttpClient $httpClient
-    )
-    {
+    ) {
         $this->httpClient = $httpClient;
         $this->processLastResponse();
     }
@@ -227,7 +226,7 @@ final class HttpResponsePaginator implements \Countable, \Iterator
                     }
 
                     if ($resultKey !== 'start') {
-                        for ($i=0; $i < count($result); $i++) {
+                        for ($i = 0; $i < count($result); $i++) {
                             $this->results[$start + $i] = $result[$i];
                         }
                     }

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -133,7 +133,7 @@ final class HttpResponsePaginator implements \Countable, \Iterator
 
             // Issue next paged request.
             try {
-                $response = $lastBuilder->call();
+                $lastBuilder->call();
             } catch (NetworkException $exception) {
                 return false;
             }
@@ -165,7 +165,7 @@ final class HttpResponsePaginator implements \Countable, \Iterator
 
             // Issue next paged request.
             try {
-                $response = $lastBuilder->call();
+                $lastBuilder->call();
             } catch (NetworkException $exception) {
                 return false;
             }

--- a/tests/Unit/Store/SessionStoreTest.php
+++ b/tests/Unit/Store/SessionStoreTest.php
@@ -54,7 +54,7 @@ class SessionStoreTest extends TestCase
     public function testInitSession(): void
     {
         // Suppressing "headers already sent" warning related to cookies.
-        @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE);
+        @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE); // phpcs:ignore
 
         // Make sure we have a session to check.
         $this->assertNotEmpty(session_id());
@@ -118,7 +118,7 @@ class SessionStoreTest extends TestCase
         $this->assertEquals($test_base_name . '_' . self::TEST_KEY, $test_this_key_name);
 
         // Suppressing "headers already sent" warning related to cookies.
-        @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE);
+        @self::$sessionStore->set(self::TEST_KEY, self::TEST_VALUE); // phpcs:ignore
 
         $this->assertEquals(self::TEST_VALUE, self::$sessionStore->get(self::TEST_KEY));
     }

--- a/tests/Unit/Utility/HttpResponsePaginatorTest.php
+++ b/tests/Unit/Utility/HttpResponsePaginatorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Exception\NetworkException;
+use Auth0\Tests\Utilities\HttpResponseGenerator;
+use Auth0\Tests\Utilities\MockManagementApi;
+
+uses()->group('network')->group('pagination');
+
+test('returns a count of 0 when there are no results', function(): void {
+    $sdk = (new MockManagementApi())->mock();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    $this->assertEquals(0, count($this->paginator));
+});
+
+test('returns a count when there are results', function(): void {
+    $sdk = (new MockManagementApi([
+        HttpResponseGenerator::create(json_encode([
+            'start' => 0,
+            'total' => 2,
+            'limit' => 2,
+            'length' => 2,
+            'users' => ['user1', 'user2']
+        ]))
+    ]))->mock();
+
+    $sdk->users()->getAll();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    $this->assertEquals(2, count($this->paginator));
+});
+
+test('fails when used with a non-GET api request', function(): void {
+    $sdk = (new MockManagementApi())->mock();
+    $sdk->users()->create(uniqid(), [uniqid()]);
+
+    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_METHOD_UNSUPPORTED);
+
+    $this->paginator = $sdk->getResponsePaginator();
+});
+
+test('returns loaded results', function(): void {
+    $sdk = (new MockManagementApi([
+        HttpResponseGenerator::create(json_encode([
+            'start' => 0,
+            'total' => 3,
+            'limit' => 3,
+            'length' => 3,
+            'users' => ['user1', 'user2', 'user3']
+        ]))
+    ]))->mock();
+
+    $sdk->users()->getAll();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    $this->assertEquals(3, count($this->paginator));
+
+    foreach ($this->paginator as $index => $result) {
+        $this->assertEquals('user' . $index + 1, $result);
+    }
+});
+
+test('sends network requests for paginated results', function(): void {
+    $sdk = (new MockManagementApi([
+        HttpResponseGenerator::create(json_encode([
+            'start' => 0,
+            'total' => 4,
+            'limit' => 2,
+            'length' => 2,
+            'users' => ['user1', 'user2']
+        ])),
+        HttpResponseGenerator::create(json_encode([
+            'start' => 2,
+            'total' => 4,
+            'limit' => 2,
+            'length' => 2,
+            'users' => ['user3', 'user4']
+        ])),
+    ]))->mock();
+
+    $sdk->users()->getAll();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    $this->assertEquals(4, count($this->paginator));
+
+    foreach ($this->paginator as $index => $result) {
+        $this->assertEquals('user' . $index + 1, $result);
+    }
+
+    $this->assertEquals(1, $this->paginator->countNetworkRequests());
+});
+
+test('recreates an http request that was issued without pagination', function(): void {
+    $sdk = (new MockManagementApi([
+        HttpResponseGenerator::create(json_encode([
+            'user1', 'user2'
+        ])),
+        HttpResponseGenerator::create(json_encode([
+            'start' => 0,
+            'total' => 2,
+            'limit' => 2,
+            'length' => 2,
+            'users' => ['user1', 'user2']
+        ]))
+    ]))->mock();
+
+    $sdk->users()->getAll();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    $this->assertEquals(2, count($this->paginator));
+
+    foreach ($this->paginator as $index => $result) {
+        $this->assertEquals('user' . $index + 1, $result);
+    }
+
+    $this->assertEquals(1, $this->paginator->countNetworkRequests());
+});
+
+test('silently exits iteration after network error', function(): void {
+    $sdk = new MockManagementApi([
+        HttpResponseGenerator::create(json_encode([
+            'start' => 0,
+            'total' => 200,
+            'limit' => 1,
+            'length' => 1,
+            'users' => ['user1']
+        ]))
+    ]);
+
+    $sdk->getHttpClient()->mockResponse(
+        HttpResponseGenerator::create('', 500),
+        null,
+        NetworkException::requestFailed('Mocked network failure.')
+    );
+
+    $sdk = $sdk->mock();
+
+    $sdk->users()->getAll();
+    $this->paginator = $sdk->getResponsePaginator();
+
+    foreach ($this->paginator as $index => $result) {
+        $this->assertEquals('user' . $index + 1, $result);
+    }
+
+    $this->assertEquals(200, count($this->paginator));
+    $this->assertEquals(1, $this->paginator->countNetworkRequests());
+});

--- a/tests/Unit/Utility/HttpResponsePaginatorTest.php
+++ b/tests/Unit/Utility/HttpResponsePaginatorTest.php
@@ -59,7 +59,7 @@ test('returns loaded results', function(): void {
     $this->assertEquals(3, count($this->paginator));
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . $index + 1, $result);
+        $this->assertEquals('user' . ($index + 1), $result);
     }
 });
 
@@ -87,7 +87,7 @@ test('sends network requests for paginated results', function(): void {
     $this->assertEquals(4, count($this->paginator));
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . $index + 1, $result);
+        $this->assertEquals('user' . ($index + 1), $result);
     }
 
     $this->assertEquals(1, $this->paginator->countNetworkRequests());
@@ -113,7 +113,7 @@ test('recreates an http request that was issued without pagination', function():
     $this->assertEquals(2, count($this->paginator));
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . $index + 1, $result);
+        $this->assertEquals('user' . ($index + 1), $result);
     }
 
     $this->assertEquals(1, $this->paginator->countNetworkRequests());
@@ -142,7 +142,7 @@ test('silently exits iteration after network error', function(): void {
     $this->paginator = $sdk->getResponsePaginator();
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . $index + 1, $result);
+        $this->assertEquals('user' . ($index + 1), $result);
     }
 
     $this->assertEquals(200, count($this->paginator));

--- a/tests/Unit/Utility/TransientStoreHandlerTest.php
+++ b/tests/Unit/Utility/TransientStoreHandlerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Unit\Utility;
 
-use Auth0\SDK\Utility\TransientStoreHandler;
 use Auth0\SDK\Store\SessionStore;
+use Auth0\SDK\Utility\TransientStoreHandler;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Utilities/HttpResponseGenerator.php
+++ b/tests/Utilities/HttpResponseGenerator.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 class HttpResponseGenerator
 {
     public static function create(
-        string $body,
+        string $body = '',
         int $statusCode = 200
     ): ResponseInterface {
         $response = Mockery::mock(ResponseInterface::class);

--- a/tests/Utilities/MockApi.php
+++ b/tests/Utilities/MockApi.php
@@ -23,23 +23,26 @@ abstract class MockApi
     /**
      * MockApi constructor.
      *
-     * @param array $responses Array of mock Psr\Http\Message\ResponseInterface objects.
+     * @param array|null $responses Array of mock Psr\Http\Message\ResponseInterface objects. If an empty array, an empty successful response will be mocked. If null, nothing will be mocked.
      */
-    public function __construct(array $responses = [])
-    {
+    public function __construct(
+        ?array $responses = []
+    ) {
         // Allow mock HttpClient to be auto-discovered for use in testing.
         Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);
 
         // Create an instance of the intended API.
         $this->setClient();
 
-        if (! $responses) {
+        if ($responses !== null && ! count($responses)) {
             $responses[] = HttpResponseGenerator::create();
         }
 
         // Setup the API class' mock httpClient with the response payload.
-        foreach ($responses as $response) {
-            $this->client->getHttpClient()->mockResponse($response, [$this, 'onFetch']);
+        if ($responses !== null && count($responses)) {
+            foreach ($responses as $response) {
+                $this->client->getHttpClient()->mockResponse($response, [$this, 'onFetch']);
+            }
         }
     }
 

--- a/tests/Utilities/MockApi.php
+++ b/tests/Utilities/MockApi.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Utilities;
 
+use Auth0\SDK\Utility\HttpClient;
 use Http\Discovery\Psr18ClientDiscovery;
 use Http\Discovery\Strategy\MockClientStrategy;
-use Mockery;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -34,7 +34,7 @@ abstract class MockApi
         $this->setClient();
 
         if (! $responses) {
-            $responses[] = Mockery::mock(ResponseInterface::class);
+            $responses[] = HttpResponseGenerator::create();
         }
 
         // Setup the API class' mock httpClient with the response payload.
@@ -52,6 +52,22 @@ abstract class MockApi
      * Returns an instance of the configured API class.
      */
     abstract public function mock();
+
+    /**
+     * Returns the current client.
+     */
+    public function getClient(): MockApi
+    {
+        return $this->client;
+    }
+
+    /**
+     * Returns the current HTTPClient.
+     */
+    public function getHttpClient(): HttpClient
+    {
+        return $this->client->getHttpClient();
+    }
 
     /**
      * Callback fired whenever the HttpClient instance of an API class would use sendRequest.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 declare(strict_types=1);
 


### PR DESCRIPTION
## Itemized changes:
- Adds HttpResponsePaginator class, which returns a Countable and Iterable type suitable within foreach() loops.
- Adds PaginatorException type for pagination-specific error trapping.
- Renames instances of apiClient to httpClient within the Management classes.
- Moves httpClient into private scope and adds a getter, getHttpClient().
- Updates Management classes to use new getter.
- Adds mocking improvements to HttpClient and HttpRequest for unit testing purposes.
- Adds the ability to throwing exceptions within mock HttpRequests.
- $mockResponses are now passed by reference from HttpClient to HttpRequest for easier handling of mock ResponseInterface types.
- Adds new HttpResponsePaginatorTest to unit tests within the 'pagination' and 'network' groups.

## Overview of new Autopagination feature:
This PR adds a new utility class, HttpResponsePaginator, which can be optionally applied to Management API endpoints that support pagination to create auto-paginated iterators of API results. This is provided as an opt-in for developers who want this behavior.

For example:

```php
<?php
// Retrieve an instance of the Management SDK class:
$sdk = $auth0->management();

// We'll be using the users endpoint to get a list of all users:
$sdk->users()->getAll([], new RequestOptions(
  new FilteredRequest(['user_id'], true),
  new PaginatedRequest(0, 5, true)
));

// We're requesting an HttpResponsePaginator instance of those results:
$paginator = $sdk->getResponsePaginator();

// This uses the 'total' indicated by the API response, so it represents all available results from the API rather than what we have cached so far:
var_dump('There are ' . count($paginator) . ' available results from the API.');

// This will automatically page through results, requesting 5 at a time as defined by our PaginatedRequest settings above.
foreach ($paginator as $user) {
  var_dump($user);
}

// For a user list of 26 w/ 5 per page, this would result in 5 network requests. The first request made by the getAll() is not counted, as it was fetched prior.
var_dump('Made ' . $paginator->countNetworkRequests() . ' network requests.');
```

An additional example, of when a user does not manually specify their pagination conditions:

```php
<?php
// Retrieve an instance of the Management SDK class:
$sdk = $auth0->management();

// We'll be using the users endpoint to get a list of all users:
$sdk->users()->getAll();

// We're requesting an HttpResponsePaginator instance of those results:
$paginator = $sdk->getResponsePaginator();

// "There are 26 available results from the API."
var_dump('There are ' . count($paginator) . ' available results from the API.');

// As the original request did not specify pagination conditions, the first time we invoke the iterator it will recreate that request with page, per_page and include_total params added.
foreach ($paginator as $user) {
  var_dump($user);
}

// "Made 1 network requests." Only one request is made as, when left up to the HttpResponsePaginator, it will try to fetch 50 results at a time by default, more than the user-conditioned example above.
var_dump('Made ' . $paginator->countNetworkRequests() . ' network requests.');
```

Note that this PR does not address the issue of potentially hitting rate limits as a result of this pagination, outside of silently exiting the iterator early. I'll be tackling rate limiting and request backoffs in a further PR as part of an whole-SDK approach to that.