### PR TITLE
[8.x] Make SdkException an interface

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,7 +35,6 @@ parameters:
         - '#Call to function method_exists\(\) with \$this\(Auth0\\SDK\\Configuration\\(.*)\) and (.*) will always evaluate to true.#'
         - '#Class "Auth0\\SDK\\Exception\\(.*)" is not allowed to extend "Exception".#'
         - '#Class "Auth0\\SDK\\API\\Management\\(.*)" is not allowed to extend "Auth0\\SDK\\API\\Management\\ManagementEndpoint".#'
-        - '#Class "Auth0\\SDK\\Exception\\(.*)" is not allowed to extend "Auth0\\SDK\\Exception\\SdkException".#'
         - '#Cannot call method getName\(\) on ReflectionType\|null.#'
         - '#Cannot call method createRequest\(\) on Psr\\Http\\Message\\RequestFactoryInterface\|null.#'
         - '#Parameter \#1 \$object of function method_exists expects object\|string, Psr\\Http\\Client\\ClientInterface\|null given.#'

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -323,7 +323,7 @@ final class Auth0
      * Get ID token from persisted session or from a code exchange
      *
      * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\SdkException (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
      */
     public function getIdToken(): ?string
     {
@@ -340,7 +340,7 @@ final class Auth0
      * @return array<string,array|int|string>|null
      *
      * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\SdkException (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
      */
     public function getUser(): ?array
     {
@@ -355,7 +355,7 @@ final class Auth0
      * Get access token from persisted session or from a code exchange
      *
      * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\SdkException (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
      */
     public function getAccessToken(): ?string
     {
@@ -370,7 +370,7 @@ final class Auth0
      * Get refresh token from persisted session or from a code exchange
      *
      * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\SdkException (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
      */
     public function getRefreshToken(): ?string
     {
@@ -385,7 +385,7 @@ final class Auth0
      * Get token expiration from persisted session or from a code exchange
      *
      * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\SdkException (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
      */
     public function getAccessTokenExpiration(): ?int
     {

--- a/src/Exception/ArgumentException.php
+++ b/src/Exception/ArgumentException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class ArgumentException extends SdkException
+final class ArgumentException extends \Exception implements Auth0Exception
 {
     public const MSG_VALUE_CANNOT_BE_EMPTY = 'A value for `%s` must be provided';
     public const MSG_PKCE_CODE_VERIFIER_LENGTH = 'Code verifier must be created with a minimum length of 43 characters and a maximum length of 128 characters.';

--- a/src/Exception/Auth0Exception.php
+++ b/src/Exception/Auth0Exception.php
@@ -9,6 +9,6 @@ namespace Auth0\SDK\Exception;
  *
  * @codeCoverageIgnore
  */
-abstract class SdkException extends \Exception
+interface Auth0Exception extends \Throwable
 {
 }

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class AuthenticationException extends SdkException
+final class AuthenticationException extends \Exception implements Auth0Exception
 {
     public const MSG_REQUIRES_CLIENT_SECRET = 'A client secret must be configured for this request';
     public const MSG_REQUIRES_GRANT_TYPE = 'A grant type must be specified for this request';

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class ConfigurationException extends SdkException
+final class ConfigurationException extends \Exception implements Auth0Exception
 {
     public const MSG_CONFIGURATION_REQUIRED = 'The Auth0 SDK requires an SdkConfiguration be provided at initialization';
     public const MSG_MISSING_MANAGEMENT_KEY = 'A Management API token was not configured';

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class InvalidTokenException extends SdkException
+final class InvalidTokenException extends \Exception implements Auth0Exception
 {
     public const MSG_BAD_SEPARATORS = 'The JWT string must contain two dots';
     public const MSG_BAD_SIGNATURE = 'Cannot verify signature';

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class NetworkException extends SdkException
+final class NetworkException extends \Exception implements Auth0Exception
 {
     public const MSG_NETWORK_REQUEST_FAILED = 'Unable to complete network request; %s';
 

--- a/src/Exception/PaginatorException.php
+++ b/src/Exception/PaginatorException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class PaginatorException extends SdkException
+final class PaginatorException extends \Exception implements Auth0Exception
 {
     public const MSG_HTTP_METHOD_UNSUPPORTED = 'This request type is not supported. You can only paginate GET requests.';
     public const MSG_HTTP_BAD_RESPONSE = 'Unable to paginate request. Please ensure the endpoint you are using supports pagination, and that you are using the include_totals params.';

--- a/src/Exception/StateException.php
+++ b/src/Exception/StateException.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK\Exception;
 /**
  * @codeCoverageIgnore
  */
-final class StateException extends SdkException
+final class StateException extends \Exception implements Auth0Exception
 {
     public const MSG_INVALID_STATE = 'Invalid state';
     public const MSG_MISSING_CODE_VERIFIER = 'Missing code_verifier';


### PR DESCRIPTION
This will allow our exceptions to extend `\LogicException` and `\RuntimeException`. I also decided to be very forward and rename `SdkException` to `Auth0Exception`. It makes more sense when I, as a user, catches the exception. 


```php
try {
  $this->loginUser($user)
} catch (Auth0Exception $e) {
  // ...
} catch (InvalidEmailException $e) {
  // ...
}
```