### PR TITLE
[8.x] Use PSR-6 cache from Symfony instead of PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,10 @@
     "php-http/multipart-stream-builder": "^1.1",
     "psr/http-client-implementation": "^1.0",
     "psr/http-message": "^1.0",
-    "psr/simple-cache": "^1.0"
+    "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
-    "cache/adapter-common": "^1.0",
-    "cache/array-adapter": "^1.0",
-    "cache/hierarchical-cache": "^1.0",
+    "symfony/cache": "^4.4 || ^5.2",
     "ergebnis/phpstan-rules": "^0.15",
     "firebase/php-jwt": "^5.0",
     "infection/infection": "^0.23",

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -13,11 +13,11 @@ use Auth0\SDK\Store\SessionStore;
 use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Psr\SimpleCache\CacheInterface;
 
 /**
  * Configuration container for use with Auth0\SDK
@@ -40,7 +40,7 @@ use Psr\SimpleCache\CacheInterface;
  * @method SdkConfiguration setSessionStorage(?StoreInterface $sessionStorage = null)
  * @method SdkConfiguration setScope(?array $scope = null)
  * @method SdkConfiguration setTokenAlgorithm(string $tokenAlgorithm = 'RS256')
- * @method SdkConfiguration setTokenCache(?CacheInterface $cache = null)
+ * @method SdkConfiguration setTokenCache(?CacheItemPoolInterface $cache = null)
  * @method SdkConfiguration setTokenCacheTtl(int $tokenCacheTtl = 60)
  * @method SdkConfiguration setTokenJwksUri(?string $tokenJwksUri = null)
  * @method SdkConfiguration setTokenLeeway(int $tokenLeeway = 60)
@@ -70,7 +70,7 @@ use Psr\SimpleCache\CacheInterface;
  * @method StoreInterface|null getSessionStorage()
  * @method array<string> getScope()
  * @method string getTokenAlgorithm()
- * @method CacheInterface|null getTokenCache()
+ * @method CacheItemPoolInterface|null getTokenCache()
  * @method int getTokenCacheTtl()
  * @method string|null getTokenJwksUri()
  * @method int|null getTokenLeeway()
@@ -133,7 +133,7 @@ final class SdkConfiguration implements ConfigurableContract
      * @param string|null                   $tokenJwksUri         Optional. URI to the JWKS when verifying RS256 tokens.
      * @param int|null                      $tokenMaxAge          Optional. Maximum window of time (in seconds) since the 'auth_time' to accept during Token validation.
      * @param int                           $tokenLeeway          Optional. Defaults to 60. Leeway (in seconds) to allow during time calculations with Token validation.
-     * @param CacheInterface|null           $tokenCache           Optional. A PSR-16 compatible cache adapter for storing JSON Web Key Sets (JWKS).
+     * @param CacheItemPoolInterface|null   $tokenCache           Optional. A PSR-6 compatible cache adapter for storing JSON Web Key Sets (JWKS).
      * @param int                           $tokenCacheTtl        Optional. How long (in seconds) to keep a JWKS cached.
      * @param ClientInterface|null          $httpClient           Optional. A PSR-18 compatible HTTP client to use for API requests.
      * @param RequestFactoryInterface|null  $httpRequestFactory   Optional. A PSR-17 compatible request factory to generate HTTP requests.
@@ -165,7 +165,7 @@ final class SdkConfiguration implements ConfigurableContract
         ?string $tokenJwksUri = null,
         ?int $tokenMaxAge = null,
         int $tokenLeeway = 60,
-        ?CacheInterface $tokenCache = null,
+        ?CacheItemPoolInterface $tokenCache = null,
         int $tokenCacheTtl = 60,
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $httpRequestFactory = null,

--- a/src/Token.php
+++ b/src/Token.php
@@ -7,7 +7,7 @@ namespace Auth0\SDK;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Token\Parser;
 use Auth0\SDK\Utility\TransientStoreHandler;
-use Psr\SimpleCache\CacheInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Class Token.
@@ -84,11 +84,11 @@ final class Token
     /**
      * Verify the signature of the Token using either RS256 or HS256.
      *
-     * @param string|null         $tokenAlgorithm Optional. Algorithm to use for verification. Expects either RS256 or HS256.
-     * @param string|null         $tokenJwksUri   Optional. URI to the JWKS when verifying RS256 tokens.
-     * @param string|null         $clientSecret   Optional. Client Secret found in the Application settings for verifying HS256 tokens.
-     * @param int|null            $tokenCacheTtl  Optional. Time in seconds to keep JWKS records cached.
-     * @param CacheInterface|null $tokenCache     Optional. A PSR-16 ("SimpleCache") CacheInterface instance to cache JWKS results within.
+     * @param string|null                 $tokenAlgorithm Optional. Algorithm to use for verification. Expects either RS256 or HS256.
+     * @param string|null                 $tokenJwksUri   Optional. URI to the JWKS when verifying RS256 tokens.
+     * @param string|null                 $clientSecret   Optional. Client Secret found in the Application settings for verifying HS256 tokens.
+     * @param int|null                    $tokenCacheTtl  Optional. Time in seconds to keep JWKS records cached.
+     * @param CacheItemPoolInterface|null $tokenCache     Optional. A PSR-6 CacheItemPoolInterface instance to cache JWKS results within.
      *
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token signature verification fails. See the exception message for further details.
      */
@@ -97,7 +97,7 @@ final class Token
         ?string $tokenJwksUri = null,
         ?string $clientSecret = null,
         ?int $tokenCacheTtl = null,
-        ?CacheInterface $tokenCache = null
+        ?CacheItemPoolInterface $tokenCache = null
     ): self {
         $tokenAlgorithm = $tokenAlgorithm ?? $this->configuration->getTokenAlgorithm();
         $tokenJwksUri = $tokenJwksUri ?? $this->configuration->getTokenJwksUri() ?? null;

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -6,7 +6,7 @@ namespace Auth0\SDK\Token;
 
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Token;
-use Psr\SimpleCache\CacheInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Class Parser.
@@ -103,11 +103,11 @@ final class Parser
     /**
      * Verify the signature of the Token using either RS256 or HS256.
      *
-     * @param string|null         $algorithm    Optional. Algorithm to use for verification. Expects either RS256 or HS256. Defaults to RS256.
-     * @param string|null         $jwksUri      Optional. URI to the JWKS when verifying RS256 tokens.
-     * @param string|null         $clientSecret Optional. Client Secret found in the Application settings for verifying HS256 tokens.
-     * @param int|null            $cacheExpires Optional. Time in seconds to keep JWKS records cached.
-     * @param CacheInterface|null $cache        Optional. A PSR-16 ("SimpleCache") CacheInterface instance to cache JWKS results within.
+     * @param string|null                 $algorithm    Optional. Algorithm to use for verification. Expects either RS256 or HS256. Defaults to RS256.
+     * @param string|null                 $jwksUri      Optional. URI to the JWKS when verifying RS256 tokens.
+     * @param string|null                 $clientSecret Optional. Client Secret found in the Application settings for verifying HS256 tokens.
+     * @param int|null                    $cacheExpires Optional. Time in seconds to keep JWKS records cached.
+     * @param CacheItemPoolInterface|null $cache        Optional. A PSR-6 CacheItemPoolInterface instance to cache JWKS results within.
      *
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token signature verification fails. See the exception message for further details.
      */
@@ -116,7 +116,7 @@ final class Parser
         ?string $jwksUri = null,
         ?string $clientSecret = null,
         ?int $cacheExpires = null,
-        ?CacheInterface $cache = null
+        ?CacheItemPoolInterface $cache = null
     ): self {
         $parts = $this->getParts();
         $signature = $this->getSignature() ?? '';

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -10,8 +10,8 @@ use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Utility\Shortcut;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Auth0\Tests\Utilities\TokenGenerator;
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Class Auth0Test.
@@ -683,14 +683,16 @@ class Auth0Test extends TestCase
             ],
         ];
 
-        $pool = new ArrayCachePool();
-        $pool->set($cacheKey, $mockJwks);
+        $pool = new ArrayAdapter();
+        $item = $pool->getItem($cacheKey);
+        $item->set($mockJwks);
+        $pool->save($item);
 
         $auth0 = new Auth0(self::$baseConfig + [
             'tokenCache' => $pool,
         ]);
 
-        $cachedJwks = $pool->get($cacheKey);
+        $cachedJwks = $pool->getItem($cacheKey)->get();
         $this->assertNotEmpty($cachedJwks);
         $this->assertArrayHasKey('__test_kid__', $cachedJwks);
         $this->assertEquals($mockJwks, $cachedJwks);


### PR DESCRIPTION
I have not checked, but it might have been me that was adding the `cache/*` packages years ago. They are no longer actively maintained (by me or anyone). The Symfony cache is more feature rich and stable. There is also a team of 20+ developers that is actively maintaining that package (myself included). 

I also use PSR-6 instead of PSR-16. As you can see, the diff is very very small. PSR-6 is way more powerful than PSR-16.