### PR TITLE
[8.x] Remove redirecrUri from "required" config

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -48,7 +48,7 @@ final class Auth0
      *
      * @param SdkConfiguration|array<mixed> $configuration Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      *
-     * @throws \Auth0\SDK\Exception\ConfigurationException When `domain`, `clientId`, or `redirectUri` are not provided.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When `domain` or `clientId` are not provided.
      * @throws \Auth0\SDK\Exception\ConfigurationException When `tokenAlgorithm` is provided but the value is not supported.
      * @throws \Auth0\SDK\Exception\ConfigurationException When `tokenMaxAge` or `tokenLeeway` are provided but the value is not numeric.
      */

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -186,7 +186,6 @@ final class SdkConfiguration implements ConfigurableContract
         $this->setValidations([
             'getDomain',
             'getClientId',
-            'getRedirectUri',
         ]);
 
         $this->setupConfiguration();

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -64,7 +64,7 @@ use Psr\SimpleCache\CacheInterface;
  * @method string|null getManagementToken()
  * @method array<string>|null getOrganization()
  * @method bool getQueryUserInfo()
- * @method string getRedirectUri()
+ * @method string|null getRedirectUri()
  * @method string getResponseMode()
  * @method string getResponseType()
  * @method StoreInterface|null getSessionStorage()
@@ -118,10 +118,10 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * SdkConfiguration Constructor
      *
-     * @param array<mixed>|null      $configuration        Optional. An array of parameter keys (matching this constructor's arguments) and values. Overrides any passed arguments with the same key name.
+     * @param array<mixed>|null             $configuration        Optional. An array of parameter keys (matching this constructor's arguments) and values. Overrides any passed arguments with the same key name.
      * @param string|null                   $domain               Required, if not specified in $configuration. Auth0 domain for your tenant.
      * @param string|null                   $clientId             Required, if not specified in $configuration. Client ID, found in the Auth0 Application settings.
-     * @param string|null                   $redirectUri          Required, if not specified in $configuration. Authentication callback uri, as defined in your Auth0 Application settings.
+     * @param string|null                   $redirectUri          Optional, if not specified in $configuration. Authentication callback uri, as defined in your Auth0 Application settings.
      * @param string|null                   $clientSecret         Optional. Client Secret, found in the Auth0 Application settings.
      * @param array<string>|null            $audience             Optional. One or more API identifiers, found in your Auth0 API settings. The first supplied identifier will be used when generating links. If provided, at least one of these values must match the 'aud' claim to successfully validate an ID Token.
      * @param array<string>|null            $organization         Optional. One or more Organization IDs, found in your Auth0 Organization settings. The first supplied identifier will be used when generating links. If provided, at least one of these values must match the 'org_id' claim to successfully validate an ID Token.

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -11,6 +11,7 @@ final class AuthenticationException extends SdkException
 {
     public const MSG_REQUIRES_CLIENT_SECRET = 'A client secret must be configured for this request';
     public const MSG_REQUIRES_GRANT_TYPE = 'A grant type must be specified for this request';
+    public const MSG_REQUIRES_RETURN_URI = 'A return uri must be configured for this request';
 
     public static function requiresClientSecret(
         ?\Throwable $previous = null
@@ -22,5 +23,11 @@ final class AuthenticationException extends SdkException
         ?\Throwable $previous = null
     ): self {
         return new self(self::MSG_REQUIRES_GRANT_TYPE, 0, $previous);
+    }
+
+    public static function requiresReturnUri(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_RETURN_URI, 0, $previous);
     }
 }

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -24,19 +24,6 @@ test('__construct() throws an error when clientId is not configured', function()
     ]);
 });
 
-test('__construct() throws an error when redirectUri is not configured', function(): void {
-    $domain = uniqid();
-    $clientId = uniqid();
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_MISSING_REDIRECT_URI);
-
-    new SdkConfiguration([
-        'domain' => $domain,
-        'clientId' => $clientId,
-    ]);
-});
-
 test('__construct() accepts a configuration array', function(): void {
     $domain = uniqid();
     $clientId = uniqid();


### PR DESCRIPTION
There are many many API endpoint you can call that do not require the `redirectUri`. I don't think it should be a requirement to creating a `Management` object. 