### PR TITLE
HTTP verbs should always be upper case

### DIFF
--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -115,7 +115,7 @@ final class HttpRequest
         ?array &$mockedResponses = null
     ) {
         $this->configuration = & $configuration;
-        $this->method = mb_strtolower($method);
+        $this->method = mb_strtoupper($method);
         $this->basePath = $basePath;
         $this->headers = $headers;
         $this->domain = $domain;


### PR DESCRIPTION
Verbs are case sensitive and all defined verbs are upper case. 


https://datatracker.ietf.org/doc/html/rfc7231#section-4.1