### PR TITLE
[SDK-2662] Add missing API2 POST /tickets/password-change params.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  lint:
+    image: composer:2.1
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: >
+      sh -c "rm -f ./composer.lock &&
+             composer validate &&
+             composer install &&
+             php ./vendor/bin/phpcbf &&
+             php ./vendor/bin/phpcs"
+
+  tests:
+    image: composer:2.1
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: >
+      sh -c "rm -f ./composer.lock &&
+             composer validate &&
+             composer install &&
+             php ./vendor/bin/phpstan analyse --ansi --debug --memory-limit 512M &&
+             php ./vendor/bin/phpunit --stop-on-failure --testsuite=unit"
+
+  tests-failing:
+    image: composer:2.1
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: >
+      sh -c "rm -f ./composer.lock &&
+              composer validate &&
+              composer install &&
+              php ./vendor/bin/phpunit --stop-on-failure --testsuite=unit --group failing"

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -63,13 +63,15 @@ class Tickets extends GenericResource
 
     /**
      *
-     * @param null|string  $user_id         User for whom the ticket should be created. Conflicts with: $connection_id
-     * @param null|string  $new_password    New password to assign to the user.
-     * @param null|string  $result_url      URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
-     * @param null|string  $connection_id   Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
-     * @param null|integer $ttl             Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
-     * @param null|string  $client_id       If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
-     * @param null|string  $organization_id If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $user_id                User for whom the ticket should be created. Conflicts with: $connection_id
+     * @param null|string  $new_password           New password to assign to the user.
+     * @param null|string  $result_url             URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
+     * @param null|string  $connection_id          Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
+     * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
+     * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
+     * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -80,21 +82,25 @@ class Tickets extends GenericResource
         $connection_id = null,
         $ttl = null,
         $client_id = null,
-        $organization_id = null
+        $organization_id = null,
+        $mark_email_as_verified = null,
+        $includeEmailInRedirect = null
     )
     {
-        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id, $ttl, $client_id, $organization_id);
+        return $this->createPasswordChangeTicketRaw($user_id, null, $new_password, $result_url, $connection_id, $ttl, $client_id, $organization_id, $mark_email_as_verified, $includeEmailInRedirect);
     }
 
     /**
      *
-     * @param null|string  $email           Email address of the user for whom the ticket should be created. Requires $connection_id.
-     * @param null|string  $new_password    New password to assign to the user.
-     * @param null|string  $result_url      URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
-     * @param null|string  $connection_id   Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
-     * @param null|integer $ttl             Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
-     * @param null|string  $client_id       If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
-     * @param null|string  $organization_id If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $email                  Email address of the user for whom the ticket should be created. Requires $connection_id.
+     * @param null|string  $new_password           New password to assign to the user.
+     * @param null|string  $result_url             URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
+     * @param null|string  $connection_id          Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
+     * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
+     * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
+     * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -105,22 +111,26 @@ class Tickets extends GenericResource
         $connection_id = null,
         $ttl = null,
         $client_id = null,
-        $organization_id = null
+        $organization_id = null,
+        $mark_email_as_verified = null,
+        $includeEmailInRedirect = null
     )
     {
-        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id, $ttl, $client_id, $organization_id);
+        return $this->createPasswordChangeTicketRaw(null, $email, $new_password, $result_url, $connection_id, $ttl, $client_id, $organization_id, $mark_email_as_verified, $includeEmailInRedirect);
     }
 
     /**
      *
-     * @param null|string  $user_id         User for whom the ticket should be created. Conflicts with: $connection_id, $email
-     * @param null|string  $email           Email address of the user for whom the ticket should be created. Requires $connection_id. Conflicts with $user_id.
-     * @param null|string  $new_password    New password to assign to the user.
-     * @param null|string  $result_url      URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
-     * @param null|string  $connection_id   Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
-     * @param null|integer $ttl             Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
-     * @param null|string  $client_id       If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
-     * @param null|string  $organization_id If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $user_id                User for whom the ticket should be created. Conflicts with: $connection_id, $email
+     * @param null|string  $email                  Email address of the user for whom the ticket should be created. Requires $connection_id. Conflicts with $user_id.
+     * @param null|string  $new_password           New password to assign to the user.
+     * @param null|string  $result_url             URL the user will be redirected to in the classic Universal Login experience once the ticket is used.
+     * @param null|string  $connection_id          Connection to use, allowing user to be specified using $email, rather than $user_id. Requires $email. Conflicts with $user_id.
+     * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
+     * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
+     * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -132,7 +142,9 @@ class Tickets extends GenericResource
         $connection_id = null,
         $ttl = null,
         $client_id = null,
-        $organization_id = null
+        $organization_id = null,
+        $mark_email_as_verified = null,
+        $includeEmailInRedirect = null
     )
     {
         $body = [];
@@ -167,6 +179,14 @@ class Tickets extends GenericResource
 
         if ($organization_id) {
             $body['organization_id'] = $organization_id;
+        }
+
+        if ($mark_email_as_verified) {
+            $body['mark_email_as_verified'] = $mark_email_as_verified;
+        }
+
+        if ($organization_id) {
+            $body['includeEmailInRedirect'] = $includeEmailInRedirect;
         }
 
         return $this->apiClient->method('post')

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -70,8 +70,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|boolean $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|boolean $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -99,8 +99,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|boolean $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|boolean $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -129,8 +129,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|boolean $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|boolean $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -149,43 +149,43 @@ class Tickets extends GenericResource
     {
         $body = [];
 
-        if ($user_id) {
+        if ($user_id !== null) {
             $body['user_id'] = $user_id;
         }
 
-        if ($email) {
+        if ($email !== null) {
             $body['email'] = $email;
         }
 
-        if ($new_password) {
+        if ($new_password !== null) {
             $body['new_password'] = $new_password;
         }
 
-        if ($result_url) {
+        if ($result_url !== null) {
             $body['result_url'] = $result_url;
         }
 
-        if ($connection_id) {
+        if ($connection_id !== null) {
             $body['connection_id'] = $connection_id;
         }
 
-        if ($ttl) {
+        if ($ttl !== null) {
             $body['ttl_sec'] = $ttl;
         }
 
-        if ($client_id) {
+        if ($client_id !== null) {
             $body['client_id'] = $client_id;
         }
 
-        if ($organization_id) {
+        if ($organization_id !== null) {
             $body['organization_id'] = $organization_id;
         }
 
-        if ($mark_email_as_verified && is_bool($mark_email_as_verified)) {
+        if ($mark_email_as_verified !== null && is_bool($mark_email_as_verified)) {
             $body['mark_email_as_verified'] = $mark_email_as_verified;
         }
 
-        if ($includeEmailInRedirect && is_bool($mark_email_as_verified)) {
+        if ($includeEmailInRedirect !== null && is_bool($includeEmailInRedirect)) {
             $body['includeEmailInRedirect'] = $includeEmailInRedirect;
         }
 

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -70,8 +70,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -99,8 +99,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -129,8 +129,8 @@ class Tickets extends GenericResource
      * @param null|integer $ttl                    Number of seconds this ticket will be valid before expiring. Defaults to 432000 seconds (5 days.)
      * @param null|string  $client_id              If provided for tenants using New Universal Login experience, the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
      * @param null|string  $organization_id        If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
-     * @param null|string  $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
-     * @param null|string  $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
+     * @param null|bool    $mark_email_as_verified Whether to set the email_verified attribute to true (true) or whether it should not be updated (false).
+     * @param null|bool    $includeEmailInRedirect Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false).
      *
      * @return mixed
      */
@@ -181,11 +181,11 @@ class Tickets extends GenericResource
             $body['organization_id'] = $organization_id;
         }
 
-        if ($mark_email_as_verified) {
+        if ($mark_email_as_verified && is_bool($mark_email_as_verified)) {
             $body['mark_email_as_verified'] = $mark_email_as_verified;
         }
 
-        if ($organization_id) {
+        if ($includeEmailInRedirect && is_bool($mark_email_as_verified)) {
             $body['includeEmailInRedirect'] = $includeEmailInRedirect;
         }
 

--- a/tests/unit/API/Management/TicketsTest.php
+++ b/tests/unit/API/Management/TicketsTest.php
@@ -7,7 +7,11 @@ use Auth0\SDK\Exception\EmptyOrInvalidParameterException;
 use Auth0\Tests\API\ApiTests;
 use GuzzleHttp\Psr7\Response;
 
+use function PHPSTORM_META\map;
 
+/**
+ * @group failing
+ */
 class TicketsTest extends ApiTests
 {
 
@@ -60,36 +64,6 @@ class TicketsTest extends ApiTests
             'user_id' => '__test_secondary_user_id__',
             'provider' => '__test_provider__'
         ], $body['identity']);
-
-        $headers = $api->getHistoryHeaders();
-        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
-        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
-        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
-    }
-
-    public function testThatPasswordChangeTicketRequestIsFormedProperly()
-    {
-        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
-
-        $api->call()->tickets()->createPasswordChangeTicket( '__test_user_id__', '__test_password__', '__test_result_url__', '__test_connection_id__', 8675309, '__test_client_id__' );
-
-        $this->assertEquals( 'POST', $api->getHistoryMethod() );
-        $this->assertEquals( 'https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl() );
-        $this->assertEmpty( $api->getHistoryQuery() );
-
-        $body = $api->getHistoryBody();
-        $this->assertArrayHasKey( 'user_id', $body );
-        $this->assertEquals( '__test_user_id__', $body['user_id'] );
-        $this->assertArrayHasKey( 'new_password', $body );
-        $this->assertEquals( '__test_password__', $body['new_password'] );
-        $this->assertArrayHasKey( 'result_url', $body );
-        $this->assertEquals( '__test_result_url__', $body['result_url'] );
-        $this->assertArrayHasKey( 'connection_id', $body );
-        $this->assertEquals( '__test_connection_id__', $body['connection_id'] );
-        $this->assertArrayHasKey( 'ttl_sec', $body );
-        $this->assertEquals( 8675309, $body['ttl_sec'] );
-        $this->assertArrayHasKey( 'client_id', $body );
-        $this->assertEquals( '__test_client_id__', $body['client_id'] );
 
         $headers = $api->getHistoryHeaders();
         $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
@@ -169,5 +143,309 @@ class TicketsTest extends ApiTests
         }
 
         $this->assertStringContainsString( 'Missing required "provider" field of the "identity" object.', $exception_message );
+    }
+
+    public function testThatPasswordChangeTicketRawRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'user_id' => uniqid(),
+            'email' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => true,
+            'includeEmailInRedirect' => true
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicketRaw(
+            $data['user_id'],
+            $data['email'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayHasKey('user_id', $body);
+        $this->assertArrayHasKey('email', $body);
+        $this->assertArrayHasKey('new_password', $body);
+        $this->assertArrayHasKey('connection_id', $body);
+        $this->assertArrayHasKey('ttl_sec', $body);
+        $this->assertArrayHasKey('client_id', $body);
+        $this->assertArrayHasKey('organization_id', $body);
+        $this->assertArrayHasKey('mark_email_as_verified', $body);
+        $this->assertArrayHasKey('includeEmailInRedirect', $body);
+
+        $this->assertEquals($data['user_id'], $body['user_id']);
+        $this->assertEquals($data['email'], $body['email']);
+        $this->assertEquals($data['new_password'], $body['new_password']);
+        $this->assertEquals($data['connection_id'], $body['connection_id']);
+        $this->assertEquals($data['ttl_sec'], $body['ttl_sec']);
+        $this->assertEquals($data['client_id'], $body['client_id']);
+        $this->assertEquals($data['organization_id'], $body['organization_id']);
+        $this->assertEquals($data['mark_email_as_verified'], $body['mark_email_as_verified']);
+        $this->assertEquals($data['includeEmailInRedirect'], $body['includeEmailInRedirect']);
+
+        $headers = $api->getHistoryHeaders();
+
+        $this->assertEquals( 'Bearer __api_token__', $headers['Authorization'][0] );
+        $this->assertEquals( self::$expectedTelemetry, $headers['Auth0-Client'][0] );
+        $this->assertEquals( 'application/json', $headers['Content-Type'][0] );
+    }
+
+    public function testThatPasswordChangeTicketRawIgnoresInvalidMarkEmailAsVerifiedParam()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'user_id' => uniqid(),
+            'email' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => uniqid(),
+            'includeEmailInRedirect' => true
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicketRaw(
+            $data['user_id'],
+            $data['email'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayNotHasKey('mark_email_as_verified', $body);
+    }
+
+    public function testThatPasswordChangeTicketRawIgnoresInvalidIncludeEmailInRedirectParam()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'user_id' => uniqid(),
+            'email' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => true,
+            'includeEmailInRedirect' => uniqid()
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicketRaw(
+            $data['user_id'],
+            $data['email'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayNotHasKey('includeEmailInRedirect', $body);
+    }
+
+    public function testThatPasswordChangeTicketRawTreatsFalseBooleansCorrectly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'user_id' => uniqid(),
+            'email' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => false,
+            'includeEmailInRedirect' => false
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicketRaw(
+            $data['user_id'],
+            $data['email'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayHasKey('mark_email_as_verified', $body);
+        $this->assertArrayHasKey('includeEmailInRedirect', $body);
+
+        $this->assertEquals($data['mark_email_as_verified'], $body['mark_email_as_verified']);
+        $this->assertEquals($data['includeEmailInRedirect'], $body['includeEmailInRedirect']);
+    }
+
+    public function testThatPasswordChangeTicketByEmailRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'email' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => true,
+            'includeEmailInRedirect' => true
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicketByEmail(
+            $data['email'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayNotHasKey('user_id', $body);
+        $this->assertArrayHasKey('email', $body);
+        $this->assertArrayHasKey('new_password', $body);
+        $this->assertArrayHasKey('connection_id', $body);
+        $this->assertArrayHasKey('ttl_sec', $body);
+        $this->assertArrayHasKey('client_id', $body);
+        $this->assertArrayHasKey('organization_id', $body);
+        $this->assertArrayHasKey('mark_email_as_verified', $body);
+        $this->assertArrayHasKey('includeEmailInRedirect', $body);
+
+        $this->assertEquals($data['email'], $body['email']);
+        $this->assertEquals($data['new_password'], $body['new_password']);
+        $this->assertEquals($data['connection_id'], $body['connection_id']);
+        $this->assertEquals($data['ttl_sec'], $body['ttl_sec']);
+        $this->assertEquals($data['client_id'], $body['client_id']);
+        $this->assertEquals($data['organization_id'], $body['organization_id']);
+        $this->assertEquals($data['mark_email_as_verified'], $body['mark_email_as_verified']);
+        $this->assertEquals($data['includeEmailInRedirect'], $body['includeEmailInRedirect']);
+
+        $headers = $api->getHistoryHeaders();
+
+        $this->assertEquals('Bearer __api_token__', $headers['Authorization'][0]);
+        $this->assertEquals(self::$expectedTelemetry, $headers['Auth0-Client'][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    }
+
+    public function testThatPasswordChangeTicketRequestIsFormedProperly()
+    {
+        $api = new MockManagementApi( [ new Response( 200, self::$headers ) ] );
+
+        $data = [
+            'user_id' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+            'organization_id' => uniqid(),
+            'mark_email_as_verified' => true,
+            'includeEmailInRedirect' => true
+        ];
+
+        $api->call()->tickets()->createPasswordChangeTicket(
+            $data['user_id'],
+            $data['new_password'],
+            $data['result_url'],
+            $data['connection_id'],
+            $data['ttl_sec'],
+            $data['client_id'],
+            $data['organization_id'],
+            $data['mark_email_as_verified'],
+            $data['includeEmailInRedirect'],
+        );
+
+        $this->assertEquals('POST', $api->getHistoryMethod());
+        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getHistoryUrl());
+        $this->assertEmpty($api->getHistoryQuery());
+
+        $body = $api->getHistoryBody();
+
+        $this->assertArrayHasKey('user_id', $body);
+        $this->assertArrayNotHasKey('email', $body);
+        $this->assertArrayHasKey('new_password', $body);
+        $this->assertArrayHasKey('connection_id', $body);
+        $this->assertArrayHasKey('ttl_sec', $body);
+        $this->assertArrayHasKey('client_id', $body);
+        $this->assertArrayHasKey('organization_id', $body);
+        $this->assertArrayHasKey('mark_email_as_verified', $body);
+        $this->assertArrayHasKey('includeEmailInRedirect', $body);
+
+        $this->assertEquals($data['user_id'], $body['user_id']);
+        $this->assertEquals($data['new_password'], $body['new_password']);
+        $this->assertEquals($data['connection_id'], $body['connection_id']);
+        $this->assertEquals($data['ttl_sec'], $body['ttl_sec']);
+        $this->assertEquals($data['client_id'], $body['client_id']);
+        $this->assertEquals($data['organization_id'], $body['organization_id']);
+        $this->assertEquals($data['mark_email_as_verified'], $body['mark_email_as_verified']);
+        $this->assertEquals($data['includeEmailInRedirect'], $body['includeEmailInRedirect']);
+
+        $headers = $api->getHistoryHeaders();
+
+        $this->assertEquals('Bearer __api_token__', $headers['Authorization'][0]);
+        $this->assertEquals(self::$expectedTelemetry, $headers['Auth0-Client'][0]);
+        $this->assertEquals('application/json', $headers['Content-Type'][0]);
     }
 }


### PR DESCRIPTION
This PR adds two missing parameters related to API2's POST /tickets/password-change endpoint to the relevant methods within `Auth0\API\Management\Tickets`. Closes #522 