### PR TITLE
[SDK-2690] Update README's Composer beta install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,17 @@ To get started, you'll need to create a [free Auth0 account](https://auth0.com/s
 The supported method of SDK installation is through [Composer](https://getcomposer.org/). From your terminal shell, `cd` into your project directory and issue the following command:
 
 ```bash
-$ composer require auth0/auth0-php
+$ composer require auth0/auth0-php:8.0.0-BETA1
 ```
 
 You can find guidance on installing Composer [here](https://getcomposer.org/doc/00-intro.md).
+
+If you receive a warning regarding 'minimum-stability', you may need to update your `composer.json` file to include the following options:
+
+```
+"minimum-stability": "beta",
+"prefer-stable": true
+```
 
 > ⚠️ Your application must include the Composer autoloader, [as explained here](https://getcomposer.org/doc/01-basic-usage.md#autoloading), for the SDK to be usable within your application.
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ $ composer require auth0/auth0-php:8.0.0-BETA1
 
 You can find guidance on installing Composer [here](https://getcomposer.org/doc/00-intro.md).
 
-If you receive a warning regarding 'minimum-stability', you may need to update your `composer.json` file to include the following options:
+> ⚠️ Your application must include the Composer autoloader, [as explained here](https://getcomposer.org/doc/01-basic-usage.md#autoloading), for the SDK to be usable within your application.
+
+If you receive a warning regarding 'minimum-stability', you may need to update your `composer.json` file to include the following options, and then retry the `require` command above:
 
 ```
 "minimum-stability": "beta",
 "prefer-stable": true
 ```
-
-> ⚠️ Your application must include the Composer autoloader, [as explained here](https://getcomposer.org/doc/01-basic-usage.md#autoloading), for the SDK to be usable within your application.
 
 Next, you will want ensure your application has [PSR-17](https://www.php-fig.org/psr/psr-17/) and [PSR-18](https://www.php-fig.org/psr/psr-18/) compatible libraries installed. These are used for network requests. As an example, let's say you wish to use [Buzz](https://github.com/kriswallsmith/Buzz) and [Nylom's PSR-7 implementation](https://github.com/Nyholm/psr7), which include PSR-18 and PSR-17 factories, respectively:
 


### PR DESCRIPTION
This PR updates the README to include additional configuration options that may in some cases be required to install beta packages, depending on the user's Composer configuration, and if they're adding the SDK to an existing project or starting a fresh one with the install.

It also updates the README to reflect the correct BETA1 version specificity for installing from the main branch.