### PR TITLE
Add a `strategy` flag to SdkConfiguration to determine SDK usage (and run appropriate configuration validations for that use.)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,11 +72,17 @@
     "sort-packages": true
   },
   "scripts": {
-    "phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
-    "phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
-    "psalm": "@php ./vendor/bin/psalm --no-cache",
-    "pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
-    "infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest",
-    "tests": "docker compose run --rm tests"
+    "tests:docker": "docker compose run --rm tests",
+    "tests": [
+      "@tests:phpinsights",
+      "@tests:phpstan",
+      "@tests:psalm",
+      "@tests:pest"
+    ],
+    "tests:phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
+    "tests:phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
+    "tests:psalm": "@php ./vendor/bin/psalm",
+    "tests:pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
+    "tests:infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest"
   }
 }

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -60,6 +60,8 @@ final class Management
      *
      * @param SdkConfiguration|array<mixed> $configuration Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When an invalidation `configuration` is provided.
+     *
      * @psalm-suppress DocblockTypeContradiction
      */
     public function __construct(
@@ -130,6 +132,8 @@ final class Management
 
     /**
      * Return the HttpClient instance being used for management API requests.
+     *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Management Token is not able to be obtained.
      */
     public function getHttpClient(): HttpClient
     {
@@ -154,9 +158,8 @@ final class Management
         }
 
         // If no token was provided or available from cache, try to get one.
-        if ($managementToken === null) {
-            $auth = new Authentication($this->configuration);
-            $response = $auth->clientCredentials(['audience' => $this->configuration->buildDomainUri() . '/api/v2/']);
+        if ($managementToken === null && $this->configuration->hasClientSecret()) {
+            $response = (new Authentication($this->configuration))->clientCredentials(['audience' => $this->configuration->formatDomain() . '/api/v2/']);
 
             if (HttpResponse::wasSuccessful($response)) {
                 $response = HttpResponse::decodeContent($response);

--- a/src/API/Management/Blacklists.php
+++ b/src/API/Management/Blacklists.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Shortcut;
 use Auth0\SDK\Utility\Validate;
 use Psr\Http\Message\ResponseInterface;
 
@@ -24,7 +25,8 @@ final class Blacklists extends ManagementEndpoint
      * @param string|null         $aud     Optional. JWT's aud claim (the client_id to which the JWT was issued).
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `jti` or `aud` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Blacklists/post_tokens
      */
@@ -33,7 +35,8 @@ final class Blacklists extends ManagementEndpoint
         ?string $aud = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($jti, 'jti');
+        $jti = Validate::string($jti, 'jti');
+        $aud = Shortcut::trimNull($aud);
 
         $request = [ 'jti' => $jti ];
 
@@ -64,6 +67,8 @@ final class Blacklists extends ManagementEndpoint
         ?string $aud = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        $aud = Shortcut::trimNull($aud);
+
         $client = $this->getHttpClient()->method('get')
             ->addPath('blacklists', 'tokens');
 

--- a/src/API/Management/ClientGrants.php
+++ b/src/API/Management/ClientGrants.php
@@ -26,7 +26,8 @@ final class ClientGrants extends ManagementEndpoint
      * @param array<string>|null  $scope    Optional. Scopes allowed for this client grant.
      * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `clientId` or `audience` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants
      */
@@ -36,8 +37,8 @@ final class ClientGrants extends ManagementEndpoint
         ?array $scope = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($clientId, 'clientId');
-        Validate::string($audience, 'audience');
+        $clientId = Validate::string($clientId, 'clientId');
+        $audience = Validate::string($audience, 'audience');
 
         return $this->getHttpClient()->method('post')
             ->addPath('client-grants')
@@ -82,7 +83,8 @@ final class ClientGrants extends ManagementEndpoint
      * @param array<int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null         $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `audience` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
      */
@@ -91,7 +93,7 @@ final class ClientGrants extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($audience, 'audience');
+        $audience = Validate::string($audience, 'audience');
 
         $parameters = Shortcut::mergeArrays([
             'audience' => $audience,
@@ -108,7 +110,8 @@ final class ClientGrants extends ManagementEndpoint
      * @param array<int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null         $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `clientId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
      */
@@ -117,7 +120,7 @@ final class ClientGrants extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($clientId, 'clientId');
+        $clientId = Validate::string($clientId, 'clientId');
 
         $parameters = Shortcut::mergeArrays([
             'client_id' => $clientId,
@@ -134,7 +137,8 @@ final class ClientGrants extends ManagementEndpoint
      * @param array<string>|null  $scope   Optional. Array of scopes to update; will replace existing scopes, not merge.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `grantId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/patch_client_grants_by_id
      */
@@ -143,7 +147,7 @@ final class ClientGrants extends ManagementEndpoint
         ?array $scope = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($grantId, 'grantId');
+        $grantId = Validate::string($grantId, 'grantId');
 
         return $this->getHttpClient()->method('patch')
             ->addPath('client-grants', $grantId)
@@ -163,7 +167,8 @@ final class ClientGrants extends ManagementEndpoint
      * @param string              $grantId Grant (by it's ID) to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `grantId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Client_Grants/delete_client_grants_by_id
      */
@@ -171,7 +176,7 @@ final class ClientGrants extends ManagementEndpoint
         string $grantId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($grantId, 'grantId');
+        $grantId = Validate::string($grantId, 'grantId');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('client-grants', $grantId)

--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -25,7 +25,8 @@ final class Clients extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/post_clients
      */
@@ -34,7 +35,7 @@ final class Clients extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
+        $name = Validate::string($name, 'name');
 
         $body = Shortcut::mergeArrays([
             'name' => $name,
@@ -80,7 +81,8 @@ final class Clients extends ManagementEndpoint
      * @param string              $id      Client (by it's ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
      */
@@ -88,7 +90,7 @@ final class Clients extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('clients', $id)
@@ -106,7 +108,8 @@ final class Clients extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/patch_clients_by_id
      */
@@ -115,7 +118,7 @@ final class Clients extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('patch')
             ->addPath('clients', $id)
@@ -131,7 +134,8 @@ final class Clients extends ManagementEndpoint
      * @param string              $id      Client (by it's ID) to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Clients/delete_clients_by_id
      */
@@ -139,7 +143,7 @@ final class Clients extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('clients', $id)

--- a/src/API/Management/Connections.php
+++ b/src/API/Management/Connections.php
@@ -26,7 +26,8 @@ final class Connections extends ManagementEndpoint
      * @param array<string>|null  $body     Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `strategy` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Connections/post_connections
      */
@@ -36,8 +37,8 @@ final class Connections extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
-        Validate::string($strategy, 'strategy');
+        $name = Validate::string($name, 'name');
+        $strategy = Validate::string($strategy, 'strategy');
 
         $body = Shortcut::mergeArrays([
             'name' => $name,
@@ -80,7 +81,8 @@ final class Connections extends ManagementEndpoint
      * @param string              $id      Connection (by it's ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Connections/get_connections_by_id
      */
@@ -88,7 +90,7 @@ final class Connections extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('connections', $id)
@@ -104,7 +106,8 @@ final class Connections extends ManagementEndpoint
      * @param array<mixed>|null   $body    Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id
      */
@@ -113,7 +116,7 @@ final class Connections extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         $body = $body ?? [];
 
@@ -131,7 +134,8 @@ final class Connections extends ManagementEndpoint
      * @param string              $id      Connection (by it's ID) to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Connections/delete_connections_by_id
      */
@@ -139,7 +143,7 @@ final class Connections extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('connections', $id)
@@ -155,7 +159,8 @@ final class Connections extends ManagementEndpoint
      * @param string              $email   Email of the user to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `email` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Connections/delete_users_by_email
      */
@@ -164,8 +169,8 @@ final class Connections extends ManagementEndpoint
         string $email,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::email($email, 'email');
+        $id = Validate::string($id, 'id');
+        $email = Validate::email($email, 'email');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('connections', $id, 'users')

--- a/src/API/Management/DeviceCredentials.php
+++ b/src/API/Management/DeviceCredentials.php
@@ -27,7 +27,8 @@ final class DeviceCredentials extends ManagementEndpoint
      * @param array<mixed>|null   $body       Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `deviceName`, `type`, `value`, or `deviceId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Device_Credentials/post_device_credentials
      */
@@ -39,10 +40,10 @@ final class DeviceCredentials extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($deviceName, 'deviceName');
-        Validate::string($type, 'type');
-        Validate::string($value, 'value');
-        Validate::string($deviceId, 'deviceId');
+        $deviceName = Validate::string($deviceName, 'deviceName');
+        $type = Validate::string($type, 'type');
+        $value = Validate::string($value, 'value');
+        $deviceId = Validate::string($deviceId, 'deviceId');
 
         $body = Shortcut::mergeArrays([
             'device_name' => $deviceName,
@@ -67,7 +68,8 @@ final class DeviceCredentials extends ManagementEndpoint
      * @param string|null         $type     Optional. Type of credentials to retrieve. Must be `public_key`, `refresh_token` or `rotating_refresh_token`. The property will default to `refresh_token` when paging is requested
      * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `userId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Device_Credentials/get_device_credentials
      */
@@ -77,7 +79,9 @@ final class DeviceCredentials extends ManagementEndpoint
         ?string $type = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($userId, 'userId');
+        $userId = Validate::string($userId, 'userId');
+        $clientId = Shortcut::trimNull($clientId);
+        $type = Shortcut::trimNull($type);
 
         $payload = [
             'user_id' => $userId,
@@ -105,7 +109,8 @@ final class DeviceCredentials extends ManagementEndpoint
      * @param string              $id      ID of the device credential to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Device_Credentials/delete_device_credentials_by_id
      */
@@ -113,7 +118,7 @@ final class DeviceCredentials extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('device-credentials', $id)

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -31,7 +31,8 @@ final class EmailTemplates extends ManagementEndpoint
      * @param array<string>|null  $additional Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `template`, `body`, `from`, `subject`, or `syntax` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates
      */
@@ -45,11 +46,11 @@ final class EmailTemplates extends ManagementEndpoint
         ?array $additional = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($template, 'template');
-        Validate::string($body, 'body');
-        Validate::string($from, 'from');
-        Validate::string($subject, 'subject');
-        Validate::string($syntax, 'syntax');
+        $template = Validate::string($template, 'template');
+        $body = Validate::string($body, 'body');
+        $from = Validate::string($from, 'from');
+        $subject = Validate::string($subject, 'subject');
+        $syntax = Validate::string($syntax, 'syntax');
 
         $body = Shortcut::mergeArrays([
             'template' => $template,
@@ -75,7 +76,8 @@ final class EmailTemplates extends ManagementEndpoint
      * @param string              $templateName The email template name. See the @link for a list of templates available.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `templateName` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
      */
@@ -83,7 +85,7 @@ final class EmailTemplates extends ManagementEndpoint
         string $templateName,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($templateName, 'templateName');
+        $templateName = Validate::string($templateName, 'templateName');
 
         return $this->getHttpClient()->method('get')
             ->addPath('email-templates', $templateName)
@@ -101,7 +103,8 @@ final class EmailTemplates extends ManagementEndpoint
      * @param array<mixed>        $body         Replace existing template with this data.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `templateName` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
      */
@@ -110,7 +113,7 @@ final class EmailTemplates extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($templateName, 'templateName');
+        $templateName = Validate::string($templateName, 'templateName');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('put')
@@ -130,6 +133,7 @@ final class EmailTemplates extends ManagementEndpoint
      * @param array<mixed>        $body         Update existing template fields with this data.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `templateName` or `body` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
@@ -139,7 +143,7 @@ final class EmailTemplates extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($templateName, 'templateName');
+        $templateName = Validate::string($templateName, 'templateName');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')

--- a/src/API/Management/Emails.php
+++ b/src/API/Management/Emails.php
@@ -26,7 +26,8 @@ final class Emails extends ManagementEndpoint
      * @param array<mixed>|null   $body        Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `credentials` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Emails/post_provider
      */
@@ -36,7 +37,7 @@ final class Emails extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
+        $name = Validate::string($name, 'name');
         Validate::array($credentials, 'credentials');
 
         $body = Shortcut::mergeArrays([
@@ -79,6 +80,7 @@ final class Emails extends ManagementEndpoint
      * @param array<mixed>|null   $body        Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `credentials` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Emails/patch_provider
@@ -89,7 +91,7 @@ final class Emails extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
+        $name = Validate::string($name, 'name');
         Validate::array($credentials, 'credentials');
 
         $body = Shortcut::mergeArrays([

--- a/src/API/Management/Grants.php
+++ b/src/API/Management/Grants.php
@@ -47,7 +47,8 @@ final class Grants extends ManagementEndpoint
      * @param array<string,int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null                $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `clientId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Grants/get_grants
      */
@@ -56,7 +57,7 @@ final class Grants extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($clientId, 'clientId');
+        $clientId = Validate::string($clientId, 'clientId');
 
         $parameters = Shortcut::mergeArrays([
             'client_id' => $clientId,
@@ -73,7 +74,8 @@ final class Grants extends ManagementEndpoint
      * @param array<string,int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null                $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `audience` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Grants/get_grants
      */
@@ -82,7 +84,7 @@ final class Grants extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($audience, 'audience');
+        $audience = Validate::string($audience, 'audience');
 
         $parameters = Shortcut::mergeArrays([
             'audience' => $audience,
@@ -99,6 +101,7 @@ final class Grants extends ManagementEndpoint
      * @param array<string,int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null                $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `userId` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Grants/get_grants
@@ -108,7 +111,7 @@ final class Grants extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($userId, 'userId');
+        $userId = Validate::string($userId, 'userId');
 
         $parameters = Shortcut::mergeArrays([
             'user_id' => $userId,
@@ -124,6 +127,7 @@ final class Grants extends ManagementEndpoint
      * @param string              $id      Grant ID to delete a single Grant or User ID to delete all Grants for a User.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Grants/delete_grants_by_id
@@ -132,7 +136,7 @@ final class Grants extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('grants', $id)

--- a/src/API/Management/Guardian.php
+++ b/src/API/Management/Guardian.php
@@ -42,6 +42,7 @@ final class Guardian extends ManagementEndpoint
      * @param string              $id      Enrollment (by it's ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Guardian/get_enrollments_by_id
@@ -50,7 +51,7 @@ final class Guardian extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('guardian', 'enrollments', $id)
@@ -65,6 +66,7 @@ final class Guardian extends ManagementEndpoint
      * @param string              $id      Enrollment (by it's ID) to be deleted.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id
@@ -73,7 +75,7 @@ final class Guardian extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('guardian', 'enrollments', $id)

--- a/src/API/Management/Jobs.php
+++ b/src/API/Management/Jobs.php
@@ -28,7 +28,8 @@ final class Jobs extends ManagementEndpoint
      * @param array<string,bool|int|string>|null $parameters   Optional.Additional query parameters to pass with the API request. See @link for supported options.
      * @param RequestOptions|null                $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `filePath` or `connectionId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports
      */
@@ -38,8 +39,8 @@ final class Jobs extends ManagementEndpoint
         ?array $parameters = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($filePath, 'filePath');
-        Validate::string($connectionId, 'connectionId');
+        $filePath = Validate::string($filePath, 'filePath');
+        $connectionId = Validate::string($connectionId, 'connectionId');
 
         $request = $this->getHttpClient()->method('post')
             ->addPath('jobs', 'users-imports')
@@ -88,7 +89,8 @@ final class Jobs extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `userId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
      */
@@ -97,7 +99,7 @@ final class Jobs extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($userId, 'userId');
+        $userId = Validate::string($userId, 'userId');
 
         $body = Shortcut::mergeArrays([
             'user_id' => $userId,
@@ -119,7 +121,8 @@ final class Jobs extends ManagementEndpoint
      * @param string              $id      Job (by it's ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
      */
@@ -127,7 +130,7 @@ final class Jobs extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('jobs', $id)
@@ -144,7 +147,8 @@ final class Jobs extends ManagementEndpoint
      * @param string              $id      Job (by it's ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Jobs/get_errors
      */
@@ -152,7 +156,7 @@ final class Jobs extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('jobs', $id, 'errors')

--- a/src/API/Management/LogStreams.php
+++ b/src/API/Management/LogStreams.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Shortcut;
 use Auth0\SDK\Utility\Validate;
 use Psr\Http\Message\ResponseInterface;
 
@@ -25,7 +26,8 @@ final class LogStreams extends ManagementEndpoint
      * @param string|null         $name    Optional. The name of the log stream.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `type` or `sink` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
      */
@@ -35,8 +37,9 @@ final class LogStreams extends ManagementEndpoint
         ?string $name = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($type, 'type');
+        $type = Validate::string($type, 'type');
         Validate::array($sink, 'sink');
+        $name = Shortcut::trimNull($name);
 
         $payload = [
             'type' => $type,
@@ -80,7 +83,8 @@ final class LogStreams extends ManagementEndpoint
      * @param string              $id      Log Stream ID to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id
      */
@@ -88,7 +92,7 @@ final class LogStreams extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('log-streams', $id)
@@ -104,6 +108,7 @@ final class LogStreams extends ManagementEndpoint
      * @param array<mixed>        $body    Log Stream data to update. Only certain fields are update-able; see the linked documentation.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/patch_log_streams_by_id
@@ -113,7 +118,7 @@ final class LogStreams extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')
@@ -130,7 +135,8 @@ final class LogStreams extends ManagementEndpoint
      * @param string              $id      ID of the Log Stream to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Log_Streams/delete_log_streams_by_id
      */
@@ -138,7 +144,7 @@ final class LogStreams extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('log-streams', $id)

--- a/src/API/Management/Logs.php
+++ b/src/API/Management/Logs.php
@@ -45,6 +45,7 @@ final class Logs extends ManagementEndpoint
      * @param string              $id      Log entry ID to get.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Logs/get_logs_by_id
@@ -53,7 +54,7 @@ final class Logs extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('logs', $id)

--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -28,6 +28,7 @@ final class Organizations extends ManagementEndpoint
      * @param array<mixed>|null   $body        Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `displayName` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function create(
@@ -38,8 +39,8 @@ final class Organizations extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
-        Validate::string($displayName, 'displayName');
+        $name = Validate::string($name, 'name');
+        $displayName = Validate::string($displayName, 'displayName');
 
         $body = Shortcut::mergeArrays([
             'name' => $name,
@@ -79,13 +80,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $id      Organization (by ID) to retrieve details for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function get(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id)
@@ -100,13 +102,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $name    Organization (by name parameter provided during creation) to retrieve details for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getByName(
         string $name,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
+        $name = Validate::string($name, 'name');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', 'name', $name)
@@ -125,6 +128,7 @@ final class Organizations extends ManagementEndpoint
      * @param array<mixed>|null    $body        Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null  $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `displayName` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function update(
@@ -135,8 +139,8 @@ final class Organizations extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($displayName, 'displayName');
+        $id = Validate::string($id, 'id');
+        $displayName = Validate::string($displayName, 'displayName');
 
         $body = Shortcut::mergeArrays([
             'display_name' => $displayName,
@@ -158,13 +162,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $id      Organization (by ID) to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function delete(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id)
@@ -181,7 +186,8 @@ final class Organizations extends ManagementEndpoint
      * @param array<mixed>        $body         Additional body content to send with the API request. See @link for supported options.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function addEnabledConnection(
         string $id,
@@ -189,8 +195,8 @@ final class Organizations extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($connectionId, 'connectionId');
+        $id = Validate::string($id, 'id');
+        $connectionId = Validate::string($connectionId, 'connectionId');
 
         $body = Shortcut::mergeArrays([
             'connection_id' => $connectionId,
@@ -210,13 +216,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $id      Organization (by ID) to list connections of.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getEnabledConnections(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'enabled_connections')
@@ -232,15 +239,16 @@ final class Organizations extends ManagementEndpoint
      * @param string              $connectionId Connection (by ID) to retrieve details for.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getEnabledConnection(
         string $id,
         string $connectionId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($connectionId, 'connectionId');
+        $id = Validate::string($id, 'id');
+        $connectionId = Validate::string($connectionId, 'connectionId');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
@@ -257,7 +265,8 @@ final class Organizations extends ManagementEndpoint
      * @param array<mixed>        $body         Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function updateEnabledConnection(
         string $id,
@@ -265,8 +274,8 @@ final class Organizations extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($connectionId, 'connectionId');
+        $id = Validate::string($id, 'id');
+        $connectionId = Validate::string($connectionId, 'connectionId');
 
         return $this->getHttpClient()->method('patch')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
@@ -283,15 +292,16 @@ final class Organizations extends ManagementEndpoint
      * @param string              $connectionId Connection (by ID) to remove from organization.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function removeEnabledConnection(
         string $id,
         string $connectionId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($connectionId, 'connectionId');
+        $id = Validate::string($id, 'id');
+        $connectionId = Validate::string($connectionId, 'connectionId');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'enabled_connections', $connectionId)
@@ -307,14 +317,15 @@ final class Organizations extends ManagementEndpoint
      * @param array<string>       $members One or more users (by ID) to add from the organization.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `members` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function addMembers(
         string $id,
         array $members,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($members, 'members');
 
         $payload = [
@@ -335,13 +346,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $id      Organization (by ID) to list members of.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getMembers(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'members')
@@ -357,14 +369,15 @@ final class Organizations extends ManagementEndpoint
      * @param array<string>       $members One or more users (by ID) to remove from the organization.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `members` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function removeMembers(
         string $id,
         array $members,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($members, 'members');
 
         $payload = [
@@ -387,7 +400,8 @@ final class Organizations extends ManagementEndpoint
      * @param array<string>       $roles   One or more roles (by ID) to add to the user.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `userId`, or `roles` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function addMemberRoles(
         string $id,
@@ -395,8 +409,8 @@ final class Organizations extends ManagementEndpoint
         array $roles,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($userId, 'userId');
+        $id = Validate::string($id, 'id');
+        $userId = Validate::string($userId, 'userId');
         Validate::array($roles, 'roles');
 
         $payload = [
@@ -418,15 +432,16 @@ final class Organizations extends ManagementEndpoint
      * @param string              $userId  User (by ID) to add role to.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `userId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getMemberRoles(
         string $id,
         string $userId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($userId, 'userId');
+        $id = Validate::string($id, 'id');
+        $userId = Validate::string($userId, 'userId');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'members', $userId, 'roles')
@@ -443,7 +458,8 @@ final class Organizations extends ManagementEndpoint
      * @param array<string>       $roles   One or more roles (by ID) to remove from the user.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `userId`, or `roles` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function removeMemberRoles(
         string $id,
@@ -451,8 +467,8 @@ final class Organizations extends ManagementEndpoint
         array $roles,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($userId, 'userId');
+        $id = Validate::string($id, 'id');
+        $userId = Validate::string($userId, 'userId');
         Validate::array($roles, 'roles');
 
         $payload = [
@@ -479,7 +495,8 @@ final class Organizations extends ManagementEndpoint
      * @param array<mixed>|null       $body     Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null     $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `clientId`, `inviter`, or `invitee` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function createInvitation(
         string $id,
@@ -489,8 +506,8 @@ final class Organizations extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($clientId, 'clientId');
+        $id = Validate::string($id, 'id');
+        $clientId = Validate::string($clientId, 'clientId');
         Validate::array($inviter, 'inviter');
         Validate::array($invitee, 'invitee');
 
@@ -522,13 +539,14 @@ final class Organizations extends ManagementEndpoint
      * @param string              $id      Organization (by ID) to list invitations for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getInvitations(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'invitations')
@@ -544,15 +562,16 @@ final class Organizations extends ManagementEndpoint
      * @param string              $invitationId Invitation (by ID) to request.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `invitationId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getInvitation(
         string $id,
         string $invitationId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($invitationId, 'invitationId');
+        $id = Validate::string($id, 'id');
+        $invitationId = Validate::string($invitationId, 'invitationId');
 
         return $this->getHttpClient()->method('get')
             ->addPath('organizations', $id, 'invitations', $invitationId)
@@ -568,15 +587,16 @@ final class Organizations extends ManagementEndpoint
      * @param string              $invitationId Invitation (by ID) to request.
      * @param RequestOptions|null $options      Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `invitationId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function deleteInvitation(
         string $id,
         string $invitationId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($invitationId, 'invitation');
+        $id = Validate::string($id, 'id');
+        $invitationId = Validate::string($invitationId, 'invitation');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('organizations', $id, 'invitations', $invitationId)

--- a/src/API/Management/ResourceServers.php
+++ b/src/API/Management/ResourceServers.php
@@ -25,7 +25,8 @@ final class ResourceServers extends ManagementEndpoint
      * @param array<mixed> $body     Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null    $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `identifier` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Resource_Servers/post_resource_servers
      */
@@ -34,7 +35,7 @@ final class ResourceServers extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($identifier, 'identifier');
+        $identifier = Validate::string($identifier, 'identifier');
         Validate::array($body, 'body');
 
         $payload = Shortcut::mergeArrays([
@@ -74,7 +75,8 @@ final class ResourceServers extends ManagementEndpoint
      * @param string              $id      Resource Server ID or identifier to get.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers_by_id
      */
@@ -82,7 +84,7 @@ final class ResourceServers extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('resource-servers', $id)
@@ -98,6 +100,7 @@ final class ResourceServers extends ManagementEndpoint
      * @param array<mixed>        $body    Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `body` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Resource_Servers/patch_resource_servers_by_id
@@ -107,7 +110,7 @@ final class ResourceServers extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')
@@ -124,6 +127,7 @@ final class ResourceServers extends ManagementEndpoint
      * @param string              $id      Resource Server ID or identifier to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Resource_Servers/delete_resource_servers_by_id
@@ -132,7 +136,7 @@ final class ResourceServers extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('resource-servers', $id)

--- a/src/API/Management/Roles.php
+++ b/src/API/Management/Roles.php
@@ -25,6 +25,7 @@ final class Roles extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/post_roles
@@ -34,7 +35,7 @@ final class Roles extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($name, 'name');
+        $name = Validate::string($name, 'name');
 
         $body = Shortcut::mergeArrays([
             'name' => $name,
@@ -76,7 +77,8 @@ final class Roles extends ManagementEndpoint
      * @param string              $id      Role ID to get.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/get_roles_by_id
      */
@@ -84,7 +86,7 @@ final class Roles extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('roles', $id)
@@ -100,7 +102,8 @@ final class Roles extends ManagementEndpoint
      * @param array<mixed>        $body    Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/patch_roles_by_id
      */
@@ -109,7 +112,7 @@ final class Roles extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')
@@ -126,7 +129,8 @@ final class Roles extends ManagementEndpoint
      * @param string              $id      Role ID to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/delete_roles_by_id
      */
@@ -134,7 +138,7 @@ final class Roles extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('roles', $id)
@@ -150,8 +154,8 @@ final class Roles extends ManagementEndpoint
      * @param array<array>        $permissions Permissions to add, array of permission arrays.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the permissions parameter is empty or invalid.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `permissions` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/post_role_permission_assignment
      */
@@ -160,7 +164,7 @@ final class Roles extends ManagementEndpoint
         array $permissions,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::permissions($permissions);
 
         $payload = [
@@ -185,7 +189,8 @@ final class Roles extends ManagementEndpoint
      * @param string              $id      Role ID to get permissions.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/get_role_permission
      */
@@ -193,7 +198,7 @@ final class Roles extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('roles', $id, 'permissions')
@@ -209,8 +214,8 @@ final class Roles extends ManagementEndpoint
      * @param array<array>        $permissions Permissions to delete, array of permission arrays.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the permissions parameter is empty or invalid.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `permissions` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/delete_role_permission_assignment
      */
@@ -219,7 +224,7 @@ final class Roles extends ManagementEndpoint
         array $permissions,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::permissions($permissions);
 
         $payload = [
@@ -245,7 +250,8 @@ final class Roles extends ManagementEndpoint
      * @param array<string>       $users   Array of user IDs to add to the role.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `users` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/post_role_users
      */
@@ -254,7 +260,7 @@ final class Roles extends ManagementEndpoint
         array $users,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($users, 'users');
 
         return $this->getHttpClient()->method('post')
@@ -277,8 +283,8 @@ final class Roles extends ManagementEndpoint
      * @param string              $id      Role ID assigned to users.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Roles/get_role_user
      */
@@ -286,7 +292,7 @@ final class Roles extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('roles', $id, 'users')

--- a/src/API/Management/Rules.php
+++ b/src/API/Management/Rules.php
@@ -26,7 +26,8 @@ final class Rules extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `script` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Rules/post_rules
      * @link https://auth0.com/docs/rules/current#create-rules-with-the-management-api
@@ -37,6 +38,9 @@ final class Rules extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        $name = Validate::string($name, 'name');
+        $script = Validate::string($script, 'script');
+
         $body = Shortcut::mergeArrays([
             'name' => $name,
             'script' => $script,
@@ -78,6 +82,7 @@ final class Rules extends ManagementEndpoint
      * @param string              $id      Rule ID to get.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Rules/get_rules_by_id
@@ -86,7 +91,7 @@ final class Rules extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('rules', $id)
@@ -102,6 +107,7 @@ final class Rules extends ManagementEndpoint
      * @param array<mixed>        $body    Rule data to update.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `body` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Rules/patch_rules_by_id
@@ -111,7 +117,7 @@ final class Rules extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')
@@ -128,6 +134,7 @@ final class Rules extends ManagementEndpoint
      * @param string              $id      Rule ID to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Rules/delete_rules_by_id
@@ -136,7 +143,7 @@ final class Rules extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('rules', $id)

--- a/src/API/Management/Stats.php
+++ b/src/API/Management/Stats.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Shortcut;
 use Auth0\SDK\Utility\Validate;
 use Psr\Http\Message\ResponseInterface;
 
@@ -52,6 +53,9 @@ final class Stats extends ManagementEndpoint
         ?string $to = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        $from = Shortcut::trimNull($from);
+        $to = Shortcut::trimNull($to);
+
         $client = $this->getHttpClient()->method('get')
             ->addPath('stats', 'daily');
 

--- a/src/API/Management/Tenants.php
+++ b/src/API/Management/Tenants.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Validate;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -41,7 +42,8 @@ final class Tenants extends ManagementEndpoint
      * @param array<mixed>        $body    Updated settings to send to the API. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `body` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings
      */
@@ -49,6 +51,8 @@ final class Tenants extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        Validate::array($body, 'body');
+
         return $this->getHttpClient()->method('patch')
             ->addPath('tenants', 'settings')
             ->withBody((object) $body)

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -25,7 +25,8 @@ final class Tickets extends ManagementEndpoint
      * @param array<mixed>|null   $body    Optional. Additional body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `userId` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
      */
@@ -34,7 +35,7 @@ final class Tickets extends ManagementEndpoint
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($userId, 'userId');
+        $userId = Validate::string($userId, 'userId');
 
         $body = Shortcut::mergeArrays([
             'user_id' => $userId,
@@ -54,12 +55,15 @@ final class Tickets extends ManagementEndpoint
      * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `body` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function createPasswordChange(
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        Validate::array($body, 'body');
+
         return $this->getHttpClient()->method('post')
             ->addPath('tickets', 'password-change')
             ->withBody((object) $body)

--- a/src/API/Management/UserBlocks.php
+++ b/src/API/Management/UserBlocks.php
@@ -23,13 +23,14 @@ final class UserBlocks extends ManagementEndpoint
      * @param string              $id      User ID to query for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function get(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('user-blocks', $id)
@@ -44,13 +45,14 @@ final class UserBlocks extends ManagementEndpoint
      * @param string              $id      The user_id of the user to update.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function delete(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('user-blocks', $id)
@@ -65,13 +67,14 @@ final class UserBlocks extends ManagementEndpoint
      * @param string              $identifier Should be any of a username, phone number, or email.
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `identifier` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getByIdentifier(
         string $identifier,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($identifier, 'identifier');
+        $identifier = Validate::string($identifier, 'identifier');
 
         return $this->getHttpClient()->method('get')
             ->addPath('user-blocks')
@@ -87,13 +90,14 @@ final class UserBlocks extends ManagementEndpoint
      * @param string              $identifier Should be any of a username, phone number, or email.
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `identifier` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function deleteByIdentifier(
         string $identifier,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($identifier, 'identifier');
+        $identifier = Validate::string($identifier, 'identifier');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('user-blocks')

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -25,7 +25,8 @@ final class Users extends ManagementEndpoint
      * @param array<mixed>        $body       Configuration for the new User. Some parameters are dependent upon the type of connection. See @link for supported options.
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `connection` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_users
      */
@@ -34,7 +35,7 @@ final class Users extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($connection, 'connection');
+        $connection = Validate::string($connection, 'connection');
         Validate::array($body, 'body');
 
         $payload = Shortcut::mergeArrays([
@@ -82,13 +83,14 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User (by their ID) to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function get(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id)
@@ -106,7 +108,8 @@ final class Users extends ManagementEndpoint
      * @param array<mixed>        $body    User data to update. See @link for supported options.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id
      */
@@ -115,7 +118,8 @@ final class Users extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
+        Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('patch')
             ->addPath('users', $id)
@@ -131,7 +135,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to delete.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_users_by_id
      */
@@ -139,7 +144,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('users', $id)
@@ -155,7 +160,8 @@ final class Users extends ManagementEndpoint
      * @param array<mixed>        $body    Additional body content to send with the API request.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `body` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_identities
      */
@@ -164,7 +170,7 @@ final class Users extends ManagementEndpoint
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($body, 'body');
 
         return $this->getHttpClient()->method('post')
@@ -183,7 +189,8 @@ final class Users extends ManagementEndpoint
      * @param string              $identityId ID of the secondary linked account
      * @param RequestOptions|null $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `provider`, or `identityId` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_user_identity_by_user_id
      */
@@ -193,9 +200,9 @@ final class Users extends ManagementEndpoint
         string $identityId,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($provider, 'provider');
-        Validate::string($identityId, 'identityId');
+        $id = Validate::string($id, 'id');
+        $provider = Validate::string($provider, 'provider');
+        $identityId = Validate::string($identityId, 'identityId');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'identities', $provider, $identityId)
@@ -213,7 +220,8 @@ final class Users extends ManagementEndpoint
      * @param array<string>       $roles   Array of roles to add.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `roles` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_user_roles
      */
@@ -222,7 +230,7 @@ final class Users extends ManagementEndpoint
         array $roles,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($roles, 'roles');
 
         return $this->getHttpClient()->method('post')
@@ -245,7 +253,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to get roles for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
      */
@@ -253,7 +262,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'roles')
@@ -269,7 +278,8 @@ final class Users extends ManagementEndpoint
      * @param array<string>       $roles   Array of permissions to remove.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `roles` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_user_roles
      */
@@ -278,7 +288,7 @@ final class Users extends ManagementEndpoint
         array $roles,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::array($roles, 'roles');
 
         return $this->getHttpClient()->method('delete')
@@ -300,9 +310,8 @@ final class Users extends ManagementEndpoint
      * @param array<array>        $permissions Array of permissions to add.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\ArgumentException When the permissions parameter is malformed.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `permissions` are provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_permissions
      */
@@ -311,7 +320,7 @@ final class Users extends ManagementEndpoint
         array $permissions,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::permissions($permissions);
 
         $payload = [
@@ -336,6 +345,7 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to get permissions for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_permissions
@@ -344,7 +354,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'permissions')
@@ -360,8 +370,7 @@ final class Users extends ManagementEndpoint
      * @param array<array>        $permissions Array of permissions to remove.
      * @param RequestOptions|null $options     Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\ArgumentException When the permissions parameter is malformed.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `permissions` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_permissions
@@ -371,7 +380,7 @@ final class Users extends ManagementEndpoint
         array $permissions,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
         Validate::permissions($permissions);
 
         $payload = [
@@ -396,8 +405,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to get logs entries for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_logs_by_user
      */
@@ -405,7 +414,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'logs')
@@ -420,14 +429,14 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to get organization entries for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function getOrganizations(
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'organizations')
@@ -442,7 +451,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID to query.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
      */
@@ -450,7 +460,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('get')
             ->addPath('users', $id, 'enrollments')
@@ -465,8 +475,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID of the user to regenerate a multi-factor authentication recovery code for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
      */
@@ -474,7 +484,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'recovery-code-regeneration')
@@ -489,8 +499,8 @@ final class Users extends ManagementEndpoint
      * @param string              $id      User ID of the user to invalidate all remembered browsers and authentication factors for.
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException When the user_id parameter is empty or is not a string.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
      */
@@ -498,7 +508,7 @@ final class Users extends ManagementEndpoint
         string $id,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
+        $id = Validate::string($id, 'id');
 
         return $this->getHttpClient()->method('post')
             ->addPath('users', $id, 'multifactor', 'actions', 'invalidate-remember-browser')
@@ -515,6 +525,7 @@ final class Users extends ManagementEndpoint
      * @param string              $provider Multifactor provider to delete.
      * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `provider` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api/management/v2#!/Users/delete_multifactor_by_provider
@@ -524,8 +535,8 @@ final class Users extends ManagementEndpoint
         string $provider,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        Validate::string($id, 'id');
-        Validate::string($provider, 'provider');
+        $id = Validate::string($id, 'id');
+        $provider = Validate::string($provider, 'provider');
 
         return $this->getHttpClient()->method('delete')
             ->addPath('users', $id, 'multifactor', $provider)

--- a/src/API/Management/UsersByEmail.php
+++ b/src/API/Management/UsersByEmail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API\Management;
 
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Validate;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -22,12 +23,15 @@ final class UsersByEmail extends ManagementEndpoint
      * @param string              $email   Email address to search for (case-sensitive).
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `email` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      */
     public function get(
         string $email,
         ?RequestOptions $options = null
     ): ResponseInterface {
+        $email = Validate::email($email, 'email');
+
         return $this->getHttpClient()->method('get')
             ->addPath('users-by-email')
             ->withParam('email', $email)

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -49,10 +49,6 @@ final class Auth0
      * Auth0 Constructor.
      *
      * @param SdkConfiguration|array<mixed> $configuration Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
-     *
-     * @throws \Auth0\SDK\Exception\ConfigurationException When `domain` or `clientId` are not provided.
-     * @throws \Auth0\SDK\Exception\ConfigurationException When `tokenAlgorithm` is provided but the value is not supported.
-     * @throws \Auth0\SDK\Exception\ConfigurationException When `tokenMaxAge` or `tokenLeeway` are provided but the value is not numeric.
      */
     public function __construct(
         $configuration
@@ -111,6 +107,9 @@ final class Auth0
      * @param string|null                 $redirectUrl Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.
      * @param array<int|string|null>|null $params Additional parameters to include with the request.
      *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When `redirectUri` is not specified, and supplied SdkConfiguration does not have a default redirectUri configured.
+     *
      * @link https://auth0.com/docs/api/authentication#login
      */
     public function login(
@@ -144,6 +143,9 @@ final class Auth0
      * @param string|null                 $redirectUrl Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.
      * @param array<int|string|null>|null $params Additional parameters to include with the request.
      *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When `redirectUri` is not specified, and supplied SdkConfiguration does not have a default redirectUri configured.
+     *
      * @link https://auth0.com/docs/universal-login/new-experience
      * @link https://auth0.com/docs/api/authentication#login
      */
@@ -163,6 +165,9 @@ final class Auth0
      *
      * @param string|null                 $returnUri Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.
      * @param array<int|string|null>|null $params    Optional. Additional parameters to include with the request.
+     *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When `returnUri` is not specified, and supplied SdkConfiguration does not have a default redirectUri configured.
      *
      * @link https://auth0.com/docs/api/authentication#logout
      */
@@ -202,7 +207,7 @@ final class Auth0
      * @param int|null           $tokenLeeway       Optional. Leeway in seconds to allow during time calculations. Defaults to 60.
      * @param int|null           $tokenNow          Optional. Optional. Unix timestamp representing the current point in time to use for time calculations.
      *
-     * @throws \Auth0\SDK\Exception\InvalidTokenException
+     * @throws \Auth0\SDK\Exception\InvalidTokenException When token validation fails. See the exception message for further details.
      */
     public function decode(
         string $token,
@@ -249,9 +254,8 @@ final class Auth0
      *
      * @param string|null $redirectUri  Optional. Redirect URI sent with authorize request. Defaults to the SDK's configured redirectUri.
      *
-     * @throws \Auth0\SDK\Exception\StateException If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException If there is already an active session.
-     * @throws \Auth0\SDK\Exception\StateException If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
@@ -342,9 +346,12 @@ final class Auth0
      *
      * @param array<int|string|null>|null $params Optional. Additional parameters to include with the request.
      *
-     * @throws \Auth0\SDK\Exception\StateException If the Auth0 object does not have access token and refresh token, or the API did not renew tokens properly.
+     * @throws \Auth0\SDK\Exception\StateException         If the Auth0 object does not have access token and refresh token, or the API did not renew tokens properly.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client Secret is not configured.
+     * @throws \Auth0\SDK\Exception\NetworkException       When the API request fails due to a network error.
      *
-     * @link   https://auth0.com/docs/tokens/refresh-token/current
+     * @link https://auth0.com/docs/tokens/refresh-token/current
      */
     public function renew(
         ?array $params = null
@@ -403,8 +410,9 @@ final class Auth0
     /**
      * Get ID token from persisted session or from a code exchange
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getIdToken(): ?string
     {
@@ -420,8 +428,9 @@ final class Auth0
      *
      * @return array<string,array|int|string>|null
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getUser(): ?array
     {
@@ -435,8 +444,9 @@ final class Auth0
     /**
      * Get access token from persisted session or from a code exchange
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getAccessToken(): ?string
     {
@@ -450,8 +460,9 @@ final class Auth0
     /**
      * Get refresh token from persisted session or from a code exchange
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getRefreshToken(): ?string
     {
@@ -467,8 +478,9 @@ final class Auth0
      *
      * @return array<string>
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getAccessTokenScope(): ?array
     {
@@ -482,8 +494,9 @@ final class Auth0
     /**
      * Get token expiration from persisted session or from a code exchange
      *
-     * @throws \Auth0\SDK\Exception\StateException (see self::exchange()).
-     * @throws \Auth0\SDK\Exception\Auth0Exception (see self::exchange()).
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getAccessTokenExpiration(): ?int
     {
@@ -498,8 +511,6 @@ final class Auth0
      * Sets, validates, and persists the ID token.
      *
      * @param string $idToken Id token returned from the code exchange.
-     *
-     * @throws \Auth0\SDK\Exception\InvalidTokenException When an invalid token is passed.
      */
     public function setIdToken(
         string $idToken
@@ -582,7 +593,7 @@ final class Auth0
     }
 
     /**
-     * Sets and persists the access token expiration unix timestmap.
+     * Sets and persists the access token expiration unix timestamp.
      *
      * @param int $accessTokenExpiration Unix timestamp representing the expiration time on the access token.
      */

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -61,42 +61,42 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method SdkConfiguration setTransientStorage(?StoreInterface $transientStorage = null)
  * @method SdkConfiguration setUsePkce(bool $usePkce)
  *
- * @method array<string>|null getAudience()
- * @method string|null getCookieDomain()
+ * @method array<string>|null getAudience(?\Throwable $exceptionIfNull = null)
+ * @method string|null getCookieDomain(?\Throwable $exceptionIfNull = null)
  * @method int getCookieExpires()
  * @method string getCookiePath()
- * @method string|null getCookieSecret()
+ * @method string|null getCookieSecret(?\Throwable $exceptionIfNull = null)
  * @method bool getCookieSecure()
- * @method string getClientId()
- * @method string|null getClientSecret()
- * @method string getDomain()
- * @method ListenerProviderInterface|null getEventListenerProvider()
- * @method ClientInterface|null getHttpClient()
+ * @method string|null getClientId(?\Throwable $exceptionIfNull = null)
+ * @method string|null getClientSecret(?\Throwable $exceptionIfNull = null)
+ * @method string|string getDomain(?\Throwable $exceptionIfNull = null)
+ * @method ListenerProviderInterface|null getEventListenerProvider(?\Throwable $exceptionIfNull = null)
+ * @method ClientInterface|null getHttpClient(?\Throwable $exceptionIfNull = null)
  * @method int getHttpMaxRetries()
- * @method RequestFactoryInterface|null getHttpRequestFactory()
- * @method ResponseFactoryInterface|null getHttpResponseFactory()
- * @method StreamFactoryInterface|null getHttpStreamFactory()
+ * @method RequestFactoryInterface|null getHttpRequestFactory(?\Throwable $exceptionIfNull = null)
+ * @method ResponseFactoryInterface|null getHttpResponseFactory(?\Throwable $exceptionIfNull = null)
+ * @method StreamFactoryInterface|null getHttpStreamFactory(?\Throwable $exceptionIfNull = null)
  * @method bool getHttpTelemetry()
- * @method string|null getManagementToken()
- * @method CacheItemPoolInterface|null getManagementTokenCache()
- * @method array<string>|null getOrganization()
+ * @method string|null getManagementToken(?\Throwable $exceptionIfNull = null)
+ * @method CacheItemPoolInterface|null getManagementTokenCache(?\Throwable $exceptionIfNull = null)
+ * @method array<string>|null getOrganization(?\Throwable $exceptionIfNull = null)
  * @method bool getPersistAccessToken()
  * @method bool getPersistIdToken()
  * @method bool getPersistRefreshToken()
  * @method bool getPersistUser()
  * @method bool getQueryUserInfo()
- * @method string|null getRedirectUri()
+ * @method string|null getRedirectUri(?\Throwable $exceptionIfNull = null)
  * @method string getResponseMode()
  * @method string getResponseType()
  * @method array<string> getScope()
- * @method StoreInterface|null getSessionStorage()
+ * @method StoreInterface|null getSessionStorage(?\Throwable $exceptionIfNull = null)
  * @method string getTokenAlgorithm()
- * @method CacheItemPoolInterface|null getTokenCache()
+ * @method CacheItemPoolInterface|null getTokenCache(?\Throwable $exceptionIfNull = null)
  * @method int getTokenCacheTtl()
- * @method string|null getTokenJwksUri()
- * @method int|null getTokenLeeway()
- * @method int|null getTokenMaxAge()
- * @method StoreInterface|null getTransientStorage()
+ * @method string|null getTokenJwksUri(?\Throwable $exceptionIfNull = null)
+ * @method int|null getTokenLeeway(?\Throwable $exceptionIfNull = null)
+ * @method int|null getTokenMaxAge(?\Throwable $exceptionIfNull = null)
+ * @method StoreInterface|null getTransientStorage(?\Throwable $exceptionIfNull = null)
  * @method bool getUsePkce()
  *
  * @method bool hasAudience()
@@ -152,44 +152,44 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * SdkConfiguration Constructor
      *
-     * @param array<mixed>|null              $configuration         Optional. An key-value array matching this constructor's arguments. Overrides any passed arguments with the same key name.
-     * @param string|null                    $domain                Required. Auth0 domain for your tenant.
-     * @param string|null                    $clientId              Required. Client ID, found in the Auth0 Application settings.
-     * @param string|null                    $redirectUri           Optional. Authentication callback URI, as defined in your Auth0 Application settings.
-     * @param string|null                    $clientSecret          Optional. Client Secret, found in the Auth0 Application settings.
-     * @param array<string>|null             $audience              Optional. One or more API identifiers, found in your Auth0 API settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'aud' claim to validate an ID Token successfully.
-     * @param array<string>|null             $organization          Optional. One or more Organization IDs, found in your Auth0 Organization settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'org_id' claim to validate an ID Token successfully.
-     * @param bool                           $usePkce               Optional. Defaults to true. Use PKCE (Proof Key of Code Exchange) with Authorization Code Flow requests. See https://auth0.com/docs/flows/call-your-api-using-the-authorization-code-flow-with-pkce
-     * @param array<string>                  $scope                 Optional. One or more scopes to request for Tokens. See https://auth0.com/docs/scopes
-     * @param string                         $responseMode          Optional. Defaults to 'query.' Where to extract request parameters from, either 'query' for GET or 'form_post' for POST requests.
-     * @param string                         $responseType          Optional. Defaults to 'code.' Use 'code' for server-side flows and 'token' for application side flow.
-     * @param string                         $tokenAlgorithm        Optional. Defaults to 'RS256'. Algorithm to use for Token verification. Expects either 'RS256' or 'HS256'.
-     * @param string|null                    $tokenJwksUri          Optional. URI to the JWKS when verifying RS256 tokens.
-     * @param int|null                       $tokenMaxAge           Optional. The maximum window of time (in seconds) since the 'auth_time' to accept during Token validation.
-     * @param int                            $tokenLeeway           Optional. Defaults to 60. Leeway (in seconds) to allow during time calculations with Token validation.
-     * @param CacheItemPoolInterface|null    $tokenCache            Optional. A PSR-6 compatible cache adapter for storing JSON Web Key Sets (JWKS).
-     * @param int                            $tokenCacheTtl         Optional. How long (in seconds) to keep a JWKS cached.
-     * @param ClientInterface|null           $httpClient            Optional. A PSR-18 compatible HTTP client to use for API requests.
-     * @param int                            $httpMaxRetries        Optional. When a rate-limit (429 status code) response is returned from the Auth0 API, automatically retry the request up to this many times.
-     * @param RequestFactoryInterface|null   $httpRequestFactory    Optional. A PSR-17 compatible request factory to generate HTTP requests.
-     * @param ResponseFactoryInterface|null  $httpResponseFactory   Optional. A PSR-17 compatible response factory to generate HTTP responses.
-     * @param StreamFactoryInterface|null    $httpStreamFactory     Optional. A PSR-17 compatible stream factory to create request body streams.
-     * @param bool                           $httpTelemetry         Optional. Defaults to true. If true, API requests will include telemetry about the SDK and PHP runtime version to help us improve our services.
-     * @param StoreInterface|null            $sessionStorage        Optional. Defaults to use cookies. A StoreInterface-compatible class for storing Token state.
-     * @param string|null                    $cookieSecret          Optional. The secret used to derive an encryption key for the user identity in a session cookie and to sign the transient cookies used by the login callback.
-     * @param string|null                    $cookieDomain          Optional. Defaults to value of HTTP_HOST server environment information. Cookie domain, for example 'www.example.com', for use with PHP sessions and SDK cookies. To make cookies visible on all subdomains then the domain must be prefixed with a dot like '.example.com'.
-     * @param int                            $cookieExpires         Optional. Defaults to 0. How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
-     * @param string                         $cookiePath            Optional. Defaults to '/'. Specifies path on the domain where the cookies will work. Use a single slash ('/') for all paths on the domain.
-     * @param bool                           $cookieSecure          Optional. Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
-     * @param bool                           $persistUser           Optional. Defaults to true. If true, the user data will persist in session storage.
-     * @param bool                           $persistIdToken        Optional. Defaults to true. If true, the Id Token will persist in session storage.
-     * @param bool                           $persistAccessToken    Optional. Defaults to true. If true, the Access Token will persist in session storage.
-     * @param bool                           $persistRefreshToken   Optional. Defaults to true. If true, the Refresh Token will persist in session storage.
-     * @param StoreInterface|null            $transientStorage      Optional. Defaults to use cookies. A StoreInterface-compatible class for storing ephemeral state data, such as nonces.
-     * @param bool                           $queryUserInfo         Optional. Defaults to false. If true, query the /userinfo endpoint during an authorization code exchange.
-     * @param string|null                    $managementToken       Optional. An Access Token to use for Management API calls. If there isn't one specified, the SDK will attempt to get one for you using your $clientSecret.
-     * @param CacheItemPoolInterface|null    $managementTokenCache  Optional. A PSR-6 compatible cache adapter for storing generated management access tokens.
-     * @param ListenerProviderInterface|null $eventListenerProvider Optional. A PSR-14 compatible event listener provider, for interfacing with events triggered by the SDK.
+     * @param array<mixed>|null              $configuration         An key-value array matching this constructor's arguments. Overrides any other passed arguments with the same key name.
+     * @param string|null                    $domain                Auth0 domain for your tenant.
+     * @param string|null                    $clientId              Client ID, found in the Auth0 Application settings.
+     * @param string|null                    $redirectUri           Authentication callback URI, as defined in your Auth0 Application settings.
+     * @param string|null                    $clientSecret          Client Secret, found in the Auth0 Application settings.
+     * @param array<string>|null             $audience              One or more API identifiers, found in your Auth0 API settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'aud' claim to validate an ID Token successfully.
+     * @param array<string>|null             $organization          One or more Organization IDs, found in your Auth0 Organization settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'org_id' claim to validate an ID Token successfully.
+     * @param bool                           $usePkce               Defaults to true. Use PKCE (Proof Key of Code Exchange) with Authorization Code Flow requests. See https://auth0.com/docs/flows/call-your-api-using-the-authorization-code-flow-with-pkce
+     * @param array<string>                  $scope                 One or more scopes to request for Tokens. See https://auth0.com/docs/scopes
+     * @param string                         $responseMode          Defaults to 'query.' Where to extract request parameters from, either 'query' for GET or 'form_post' for POST requests.
+     * @param string                         $responseType          Defaults to 'code.' Use 'code' for server-side flows and 'token' for application side flow.
+     * @param string                         $tokenAlgorithm        Defaults to 'RS256'. Algorithm to use for Token verification. Expects either 'RS256' or 'HS256'.
+     * @param string|null                    $tokenJwksUri          URI to the JWKS when verifying RS256 tokens.
+     * @param int|null                       $tokenMaxAge           The maximum window of time (in seconds) since the 'auth_time' to accept during Token validation.
+     * @param int                            $tokenLeeway           Defaults to 60. Leeway (in seconds) to allow during time calculations with Token validation.
+     * @param CacheItemPoolInterface|null    $tokenCache            A PSR-6 compatible cache adapter for storing JSON Web Key Sets (JWKS).
+     * @param int                            $tokenCacheTtl         How long (in seconds) to keep a JWKS cached.
+     * @param ClientInterface|null           $httpClient            A PSR-18 compatible HTTP client to use for API requests.
+     * @param int                            $httpMaxRetries        When a rate-limit (429 status code) response is returned from the Auth0 API, automatically retry the request up to this many times.
+     * @param RequestFactoryInterface|null   $httpRequestFactory    A PSR-17 compatible request factory to generate HTTP requests.
+     * @param ResponseFactoryInterface|null  $httpResponseFactory   A PSR-17 compatible response factory to generate HTTP responses.
+     * @param StreamFactoryInterface|null    $httpStreamFactory     A PSR-17 compatible stream factory to create request body streams.
+     * @param bool                           $httpTelemetry         Defaults to true. If true, API requests will include telemetry about the SDK and PHP runtime version to help us improve our services.
+     * @param StoreInterface|null            $sessionStorage        Defaults to use cookies. A StoreInterface-compatible class for storing Token state.
+     * @param string|null                    $cookieSecret          The secret used to derive an encryption key for the user identity in a session cookie and to sign the transient cookies used by the login callback.
+     * @param string|null                    $cookieDomain          Defaults to value of HTTP_HOST server environment information. Cookie domain, for example 'www.example.com', for use with PHP sessions and SDK cookies. To make cookies visible on all subdomains then the domain must be prefixed with a dot like '.example.com'.
+     * @param int                            $cookieExpires         Defaults to 0. How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
+     * @param string                         $cookiePath            Defaults to '/'. Specifies path on the domain where the cookies will work. Use a single slash ('/') for all paths on the domain.
+     * @param bool                           $cookieSecure          Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
+     * @param bool                           $persistUser           Defaults to true. If true, the user data will persist in session storage.
+     * @param bool                           $persistIdToken        Defaults to true. If true, the Id Token will persist in session storage.
+     * @param bool                           $persistAccessToken    Defaults to true. If true, the Access Token will persist in session storage.
+     * @param bool                           $persistRefreshToken   Defaults to true. If true, the Refresh Token will persist in session storage.
+     * @param StoreInterface|null            $transientStorage      Defaults to use cookies. A StoreInterface-compatible class for storing ephemeral state data, such as nonces.
+     * @param bool                           $queryUserInfo         Defaults to false. If true, query the /userinfo endpoint during an authorization code exchange.
+     * @param string|null                    $managementToken       An Access Token to use for Management API calls. If there isn't one specified, the SDK will attempt to get one for you using your $clientSecret.
+     * @param CacheItemPoolInterface|null    $managementTokenCache  A PSR-6 compatible cache adapter for storing generated management access tokens.
+     * @param ListenerProviderInterface|null $eventListenerProvider A PSR-14 compatible event listener provider, for interfacing with events triggered by the SDK.
      */
     public function __construct(
         ?array $configuration = null,
@@ -232,20 +232,13 @@ final class SdkConfiguration implements ConfigurableContract
         ?ListenerProviderInterface $eventListenerProvider = null
     ) {
         $this->setState(func_get_args());
-
-        $this->setValidations([
-            'getDomain',
-            'getClientId',
-        ]);
-
         $this->setupConfiguration();
-        $this->validate();
     }
 
     /**
      * Return the configured domain with protocol.
      */
-    public function buildDomainUri(): string
+    public function formatDomain(): string
     {
         return 'https://' . $this->getDomain();
     }
@@ -253,7 +246,7 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * Return the configured scopes as a space-delimited string.
      */
-    public function buildScopeString(): ?string
+    public function formatScope(): ?string
     {
         if ($this->hasScope()) {
             $scope = $this->getScope();
@@ -269,7 +262,7 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * Get the first configured organization.
      */
-    public function buildDefaultOrganization(): ?string
+    public function defaultOrganization(): ?string
     {
         // Return the default organization.
         if ($this->hasOrganization()) {
@@ -286,7 +279,7 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * Get the first configured audience.
      */
-    public function buildDefaultAudience(): ?string
+    public function defaultAudience(): ?string
     {
         // Return the default audience.
         if ($this->hasAudience()) {
@@ -303,7 +296,7 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * Get an instance of the EventDispatcher.
      */
-    public function getEventDispatcher(): EventDispatcher
+    public function eventDispatcher(): EventDispatcher
     {
         if ($this->eventDispatcher === null) {
             $this->eventDispatcher = new EventDispatcher($this);

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -9,25 +9,11 @@ namespace Auth0\SDK\Exception;
  */
 final class AuthenticationException extends \Exception implements Auth0Exception
 {
-    public const MSG_REQUIRES_CLIENT_SECRET = 'A client secret must be configured for this request';
     public const MSG_REQUIRES_GRANT_TYPE = 'A grant type must be specified for this request';
-    public const MSG_REQUIRES_RETURN_URI = 'A return uri must be configured for this request';
-
-    public static function requiresClientSecret(
-        ?\Throwable $previous = null
-    ): self {
-        return new self(self::MSG_REQUIRES_CLIENT_SECRET, 0, $previous);
-    }
 
     public static function requiresGrantType(
         ?\Throwable $previous = null
     ): self {
         return new self(self::MSG_REQUIRES_GRANT_TYPE, 0, $previous);
-    }
-
-    public static function requiresReturnUri(
-        ?\Throwable $previous = null
-    ): self {
-        return new self(self::MSG_REQUIRES_RETURN_URI, 0, $previous);
     }
 }

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -10,8 +10,7 @@ namespace Auth0\SDK\Exception;
 final class ConfigurationException extends \Exception implements Auth0Exception
 {
     public const MSG_CONFIGURATION_REQUIRED = 'The Auth0 SDK requires an SdkConfiguration be provided at initialization';
-    public const MSG_MISSING_MANAGEMENT_KEY = 'A Management API token was not configured';
-    public const MSG_MISSING_COOKIE_SECRET = 'Missing or invalid `cookieSecret` configuration';
+    public const MSG_VALUE_REQUIRED = '`%s` is not configured';
     public const MSG_SET_IMMUTABLE = 'Changes cannot be applied to a locked configuration';
     public const MSG_SET_MISSING = 'Attempted to assign a value to undefined property "%s"';
     public const MSG_SET_INCOMPATIBLE = 'Parameter "%s" must be of type %s, %s used';
@@ -19,9 +18,15 @@ final class ConfigurationException extends \Exception implements Auth0Exception
     public const MSG_GET_MISSING = 'Attempted to retrieve the value of an undefined property "%s"';
 
     public const MSG_VALIDATION_FAILED = 'Validation of "%s" was unsuccessful';
-    public const MSG_MISSING_DOMAIN = 'Missing or invalid `domain` configuration';
-    public const MSG_MISSING_CLIENT_ID = 'Missing or invalid `clientId` configuration';
-    public const MSG_MISSING_REDIRECT_URI = 'Missing or invalid `redirectUri` configuration';
+
+    public const MSG_REQUIRES_COOKIE_SECRET = 'Cookie Secret must be configured for this type of request';
+    public const MSG_REQUIRES_CLIENT_ID = 'Client ID must be configured for this type of request';
+    public const MSG_REQUIRES_CLIENT_SECRET = 'Client Secret must be configured for this type of request';
+    public const MSG_REQUIRES_DOMAIN = 'Client Domain must be configured for this type of request';
+    public const MSG_REQUIRES_MANAGEMENT_KEY = 'Management API token must be configured for this type of request';
+    public const MSG_REQUIRES_REDIRECT_URI = 'Client Redirect URI must be configured for this type of request';
+    public const MSG_REQUIRES_RETURN_URI = 'Client Return URI must be configured for this type of request';
+
     public const MSG_INVALID_TOKEN_ALGORITHM = 'Invalid token algorithm; must be "HS256" or "RS256"';
 
     public const MSG_NO_PSR18_LIBRARY = 'No compatible PSR-18 library was configured, and one could not be auto-discovered.';
@@ -33,16 +38,53 @@ final class ConfigurationException extends \Exception implements Auth0Exception
         return new self(self::MSG_CONFIGURATION_REQUIRED, 0, $previous);
     }
 
-    public static function requiresManagementToken(
+    public static function requiresDomain(
         ?\Throwable $previous = null
     ): self {
-        return new self(self::MSG_MISSING_MANAGEMENT_KEY, 0, $previous);
+        return new self(self::MSG_REQUIRES_DOMAIN, 0, $previous);
     }
 
     public static function requiresCookieSecret(
         ?\Throwable $previous = null
     ): self {
-        return new self(self::MSG_MISSING_COOKIE_SECRET, 0, $previous);
+        return new self(self::MSG_REQUIRES_COOKIE_SECRET, 0, $previous);
+    }
+
+    public static function requiresClientId(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_CLIENT_ID, 0, $previous);
+    }
+
+    public static function requiresClientSecret(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_CLIENT_SECRET, 0, $previous);
+    }
+
+    public static function requiresManagementToken(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_MANAGEMENT_KEY, 0, $previous);
+    }
+
+    public static function requiresRedirectUri(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_REDIRECT_URI, 0, $previous);
+    }
+
+    public static function requiresReturnUri(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_RETURN_URI, 0, $previous);
+    }
+
+    public static function required(
+        string $propertyName,
+        ?\Throwable $previous = null
+    ): self {
+        return new self(sprintf(self::MSG_VALUE_REQUIRED, $propertyName), 0, $previous);
     }
 
     public static function setImmutable(
@@ -87,22 +129,6 @@ final class ConfigurationException extends \Exception implements Auth0Exception
         string $propertyName,
         ?\Throwable $previous = null
     ): self {
-        if ($propertyName === 'domain') {
-            return new self(self::MSG_MISSING_DOMAIN, 0, $previous);
-        }
-
-        if ($propertyName === 'clientId') {
-            return new self(self::MSG_MISSING_CLIENT_ID, 0, $previous);
-        }
-
-        if ($propertyName === 'cookieSecret') {
-            return new self(self::MSG_MISSING_COOKIE_SECRET, 0, $previous);
-        }
-
-        if ($propertyName === 'redirectUri') {
-            return new self(self::MSG_MISSING_REDIRECT_URI, 0, $previous);
-        }
-
         return new self(sprintf(self::MSG_VALIDATION_FAILED, $propertyName), 0, $previous);
     }
 

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -10,7 +10,10 @@ namespace Auth0\SDK\Exception;
 final class ConfigurationException extends \Exception implements Auth0Exception
 {
     public const MSG_CONFIGURATION_REQUIRED = 'The Auth0 SDK requires an SdkConfiguration be provided at initialization';
+    public const MSG_STRATEGY_REQUIRED = 'The Auth0 SDK requires a `strategy` to be configured';
+
     public const MSG_VALUE_REQUIRED = '`%s` is not configured';
+
     public const MSG_SET_IMMUTABLE = 'Changes cannot be applied to a locked configuration';
     public const MSG_SET_MISSING = 'Attempted to assign a value to undefined property "%s"';
     public const MSG_SET_INCOMPATIBLE = 'Parameter "%s" must be of type %s, %s used';
@@ -19,13 +22,14 @@ final class ConfigurationException extends \Exception implements Auth0Exception
 
     public const MSG_VALIDATION_FAILED = 'Validation of "%s" was unsuccessful';
 
-    public const MSG_REQUIRES_COOKIE_SECRET = 'Cookie Secret must be configured for this type of request';
-    public const MSG_REQUIRES_CLIENT_ID = 'Client ID must be configured for this type of request';
-    public const MSG_REQUIRES_CLIENT_SECRET = 'Client Secret must be configured for this type of request';
-    public const MSG_REQUIRES_DOMAIN = 'Client Domain must be configured for this type of request';
-    public const MSG_REQUIRES_MANAGEMENT_KEY = 'Management API token must be configured for this type of request';
-    public const MSG_REQUIRES_REDIRECT_URI = 'Client Redirect URI must be configured for this type of request';
-    public const MSG_REQUIRES_RETURN_URI = 'Client Return URI must be configured for this type of request';
+    public const MSG_REQUIRES_AUDIENCE = '`audience` must be configured';
+    public const MSG_REQUIRES_COOKIE_SECRET = '`cookieSecret` must be configured';
+    public const MSG_REQUIRES_CLIENT_ID = '`clientId` must be configured';
+    public const MSG_REQUIRES_CLIENT_SECRET = '`clientSecret` must be configured';
+    public const MSG_REQUIRES_DOMAIN = '`domain` must be configured';
+    public const MSG_REQUIRES_MANAGEMENT_KEY = '`managementToken` must be configured';
+    public const MSG_REQUIRES_REDIRECT_URI = '`redirectUri` must be configured';
+    public const MSG_REQUIRES_RETURN_URI = '`returnUri` must be configured';
 
     public const MSG_INVALID_TOKEN_ALGORITHM = 'Invalid token algorithm; must be "HS256" or "RS256"';
 
@@ -38,10 +42,22 @@ final class ConfigurationException extends \Exception implements Auth0Exception
         return new self(self::MSG_CONFIGURATION_REQUIRED, 0, $previous);
     }
 
+    public static function requiresStrategy(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_STRATEGY_REQUIRED, 0, $previous);
+    }
+
     public static function requiresDomain(
         ?\Throwable $previous = null
     ): self {
         return new self(self::MSG_REQUIRES_DOMAIN, 0, $previous);
+    }
+
+    public static function requiresAudience(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_REQUIRES_AUDIENCE, 0, $previous);
     }
 
     public static function requiresCookieSecret(

--- a/src/Exception/StateException.php
+++ b/src/Exception/StateException.php
@@ -11,7 +11,6 @@ final class StateException extends \Exception implements Auth0Exception
 {
     public const MSG_INVALID_STATE = 'Invalid state';
     public const MSG_MISSING_CODE_VERIFIER = 'Missing code_verifier';
-    public const MSG_EXISTING_SESSION = 'Cannot initialize session; a session is already active';
     public const MSG_BAD_ACCESS_TOKEN = 'Invalid access_token';
     public const MSG_MISSING_NONCE = 'Nonce was not found in the application storage';
     public const MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN = 'Cannot renew access token; a refresh token is not available';
@@ -28,12 +27,6 @@ final class StateException extends \Exception implements Auth0Exception
         ?\Throwable $previous = null
     ): self {
         return new self(self::MSG_MISSING_CODE_VERIFIER, 0, $previous);
-    }
-
-    public static function existingSession(
-        ?\Throwable $previous = null
-    ): self {
-        return new self(self::MSG_EXISTING_SESSION, 0, $previous);
     }
 
     public static function badAccessToken(

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -6,7 +6,6 @@ namespace Auth0\SDK\Mixins;
 
 use Auth0\SDK\Exception\ConfigurationException;
 use Auth0\SDK\Utility\Shortcut;
-use ReflectionException;
 
 trait ConfigurableMixin
 {
@@ -170,7 +169,7 @@ trait ConfigurableMixin
      *
      * @param mixed $args One or more of arguments from a class __constructor().
      *
-     * @throws ReflectionException When the class or method does not exist.
+     * @throws \ReflectionException When the class or method does not exist.
      * @throws ConfigurationException When the configuration is locked, or an invalid property type is used.
      */
     private function setState(

--- a/src/Token.php
+++ b/src/Token.php
@@ -97,7 +97,7 @@ final class Token
         $tokenCache = $tokenCache ?? $this->configuration->getTokenCache() ?? null;
 
         if ($tokenJwksUri === null) {
-            $tokenJwksUri = $this->configuration->buildDomainUri() . '/.well-known/jwks.json';
+            $tokenJwksUri = $this->configuration->formatDomain() . '/.well-known/jwks.json';
         }
 
         $this->parser->verify(
@@ -114,8 +114,8 @@ final class Token
     /**
      * Validate the claims of the token.
      *
-     * @param string             $tokenIssuer       The value expected for the 'iss' claim.
-     * @param array<string>      $tokenAudience     An array of allowed values for the 'aud' claim. Successful if ANY match.
+     * @param string|null        $tokenIssuer       Optional. The value expected for the 'iss' claim.
+     * @param array<string>|null $tokenAudience     Optional. An array of allowed values for the 'aud' claim. Successful if ANY match.
      * @param array<string>|null $tokenOrganization Optional. An array of allowed values for the 'org_id' claim. Successful if ANY match.
      * @param string|null        $tokenNonce        Optional. The value expected for the 'nonce' claim.
      * @param int|null           $tokenMaxAge       Optional. Maximum window of time in seconds since the 'auth_time' to accept the token.
@@ -140,9 +140,13 @@ final class Token
         $tokenMaxAge = $tokenMaxAge ?? $this->configuration->getTokenMaxAge() ?? null;
         $tokenLeeway = $tokenLeeway ?? $this->configuration->getTokenLeeway() ?? 60;
 
-        // If 'aud' claim check isn't defined, fallback to client id.
+        // If 'aud' claim check isn't defined, fallback to client id, if configured.
         if ($tokenAudience === null || count($tokenAudience) === 0) {
-            $tokenAudience = [ $this->configuration->getClientId() ];
+            $tokenAudience = [];
+
+            if ($this->configuration->hasClientId()) {
+                $tokenAudience[] = (string) $this->configuration->getClientId();
+            }
         }
 
         $validator = $this->parser->validate();

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -263,7 +263,7 @@ final class HttpRequest
      */
     public function call(): ResponseInterface
     {
-        $domain = $this->configuration->buildDomainUri();
+        $domain = $this->configuration->formatDomain();
         $uri = $domain . $this->basePath . $this->getUrl();
         $httpRequestFactory = $this->configuration->getHttpRequestFactory();
         $httpClient = $this->configuration->getHttpClient();
@@ -316,7 +316,7 @@ final class HttpRequest
         }
 
         // Dispatch event to listeners of Auth0\SDK\EventHttpRequestBuilt.
-        $this->configuration->getEventDispatcher()->dispatch(new HttpRequestBuilt($httpRequest));
+        $this->configuration->eventDispatcher()->dispatch(new HttpRequestBuilt($httpRequest));
 
         // Store the request so it can be potentially reviewed later for error troubleshooting, testing, etc.
         $this->lastRequest = $httpRequest;
@@ -337,7 +337,7 @@ final class HttpRequest
             }
 
             // Dispatch event to listeners of Auth0\SDK\HttpResponseReceived.
-            $this->configuration->getEventDispatcher()->dispatch(new HttpResponseReceived($httpResponse, $httpRequest));
+            $this->configuration->eventDispatcher()->dispatch(new HttpResponseReceived($httpResponse, $httpRequest));
 
             // Store the last response so it can be potentially reviewed later for error troubleshooting, testing, etc.
             $this->lastResponse = $httpResponse;

--- a/src/Utility/Shortcut.php
+++ b/src/Utility/Shortcut.php
@@ -97,6 +97,32 @@ final class Shortcut
             return [];
         }
 
-        return array_filter($array, static fn ($value) => $value !== null);
+        return array_map(static function ($value) {
+            if (is_string($value)) {
+                return Shortcut::trimNull($value);
+            }
+
+            return $value;
+        }, array_filter($array, static fn ($value) => $value !== null));
+    }
+
+    /**
+     * Throw an error if all the provided values are null. Otherwise, return the first non-null value.
+     *
+     * @param \Throwable $exception An exception to throw if all values are null.
+     * @param mixed      $values    One or more values to check.
+     *
+     * @return mixed
+     *
+     * @throws \Throwable If all $values are null.
+     */
+    public static function first(
+        \Throwable $exception,
+        ...$values
+    ) {
+        $values = Validate::any($exception, ...$values);
+
+        // At least one non-null value; return the first provided to the argument.
+        return reset($values);
     }
 }

--- a/src/Utility/Validate.php
+++ b/src/Utility/Validate.php
@@ -40,15 +40,19 @@ final class Validate
      * @param string $variable     The variable to check.
      * @param string $variableName The variable name.
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException If $var is empty or is not a string.
+     * @throws \Auth0\SDK\Exception\ArgumentException If $variable is empty or is not a string.
      */
     public static function string(
         string $variable,
         string $variableName
-    ): void {
-        if (mb_strlen(trim($variable)) === 0) {
+    ): string {
+        $variable = trim($variable);
+
+        if (mb_strlen($variable) === 0) {
             throw \Auth0\SDK\Exception\ArgumentException::missing($variableName);
         }
+
+        return $variable;
     }
 
     /**
@@ -57,15 +61,19 @@ final class Validate
      * @param string $email        The email to check.
      * @param string $variableName The variable name.
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException If $var is empty or is not a string.
+     * @throws \Auth0\SDK\Exception\ArgumentException If $variable is empty or is not a string.
      */
     public static function email(
         string $email,
         string $variableName
-    ): void {
+    ): string {
+        $email = trim($email);
+
         if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             throw \Auth0\SDK\Exception\ArgumentException::missing($variableName);
         }
+
+        return $email;
     }
 
     /**
@@ -74,7 +82,7 @@ final class Validate
      * @param array<mixed> $variable     The variable to check.
      * @param string       $variableName The variable name.
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException If $var is empty or is not a string.
+     * @throws \Auth0\SDK\Exception\ArgumentException If $variable is empty or is not a string.
      */
     public static function array(
         array $variable,
@@ -83,5 +91,30 @@ final class Validate
         if (count($variable) === 0) {
             throw \Auth0\SDK\Exception\ArgumentException::missing($variableName);
         }
+    }
+
+    /**
+     * Throw an error if all the provided values are null.
+     *
+     * @param \Throwable $exception An exception to throw if all values are null.
+     * @param mixed      $values    One or more values to check.
+     *
+     * @return mixed
+     *
+     * @throws \Throwable If all $values are null.
+     */
+    public static function any(
+        \Throwable $exception,
+        ...$values
+    ) {
+        $values = Shortcut::filterArray($values);
+
+        // All values were null, throw an exception.
+        if (count($values) === 0) {
+            throw $exception;
+        }
+
+        // Return all non-null values.
+        return $values;
     }
 }

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -51,9 +51,9 @@ test('getLoginLink() is properly formatted', function(): void {
     $this->assertStringContainsString('client_id=' . rawurlencode($this->configuration->getClientId()), $uri);
     $this->assertStringContainsString('response_type=' . rawurlencode($this->configuration->getResponseType()), $uri);
     $this->assertStringContainsString('redirect_uri=' . rawurlencode($this->configuration->getRedirectUri()), $uri);
-    $this->assertStringContainsString('audience=' . rawurlencode($this->configuration->buildDefaultAudience()), $uri);
-    $this->assertStringContainsString('scope=' . rawurlencode($this->configuration->buildScopeString()), $uri);
-    $this->assertStringContainsString('organization=' . rawurlencode($this->configuration->buildDefaultOrganization()), $uri);
+    $this->assertStringContainsString('audience=' . rawurlencode($this->configuration->defaultAudience()), $uri);
+    $this->assertStringContainsString('scope=' . rawurlencode($this->configuration->formatScope()), $uri);
+    $this->assertStringContainsString('organization=' . rawurlencode($this->configuration->defaultOrganization()), $uri);
 
     $exampleScope = uniqid();
     $uri = $class->getLoginLink(uniqid(), null, [

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -6,24 +6,6 @@ use Auth0\SDK\Configuration\SdkConfiguration;
 
 uses()->group('configuration');
 
-test('__construct() throws an error when domain is not configured', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_MISSING_DOMAIN);
-
-    new SdkConfiguration();
-});
-
-test('__construct() throws an error when clientId is not configured', function(): void {
-    $domain = uniqid();
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_MISSING_CLIENT_ID);
-
-    new SdkConfiguration([
-        'domain' => $domain,
-    ]);
-});
-
 test('__construct() accepts a configuration array', function(): void {
     $domain = uniqid();
     $cookieSecret = uniqid();
@@ -90,7 +72,7 @@ test('__construct() throws an exception if domain is an empty string', function(
     $redirectUri = uniqid();
 
     $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_MISSING_DOMAIN);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'domain'));
 
     $sdk = new SdkConfiguration([
         'domain' => '',
@@ -209,7 +191,7 @@ test('successfully resets values', function(): void
     $this->assertTrue($sdk->getUsePkce());
 });
 
-test('buildDomainUri() returns a properly formatted uri', function(): void
+test('formatDomain() returns a properly formatted uri', function(): void
 {
     $domain = uniqid();
 
@@ -220,10 +202,10 @@ test('buildDomainUri() returns a properly formatted uri', function(): void
         'redirectUri' => uniqid(),
     ]);
 
-    $this->assertEquals('https://' . $domain, $sdk->buildDomainUri());
+    $this->assertEquals('https://' . $domain, $sdk->formatDomain());
 });
 
-test('buildScopeString() returns an empty string when there are no scopes defined', function(): void
+test('formatScope() returns an empty string when there are no scopes defined', function(): void
 {
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
@@ -233,10 +215,10 @@ test('buildScopeString() returns an empty string when there are no scopes define
         'scope' => [],
     ]);
 
-    $this->assertEquals('', $sdk->buildScopeString());
+    $this->assertEquals('', $sdk->formatScope());
 });
 
-test('buildScopeString() successfully converts the array to a string', function(): void
+test('scope() successfully converts the array to a string', function(): void
 {
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
@@ -246,10 +228,10 @@ test('buildScopeString() successfully converts the array to a string', function(
         'scope' => ['one', 'two', 'three'],
     ]);
 
-    $this->assertEquals('one two three', $sdk->buildScopeString());
+    $this->assertEquals('one two three', $sdk->formatScope());
 });
 
-test('buildDefaultOrganization() successfully returns the first organization', function(): void
+test('defaultOrganization() successfully returns the first organization', function(): void
 {
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
@@ -259,10 +241,10 @@ test('buildDefaultOrganization() successfully returns the first organization', f
         'organization' => ['org1', 'org2', 'org3'],
     ]);
 
-    $this->assertEquals('org1', $sdk->buildDefaultOrganization());
+    $this->assertEquals('org1', $sdk->defaultOrganization());
 });
 
-test('buildDefaultAudience() successfully returns the first audience', function(): void
+test('defaultAudience() successfully returns the first audience', function(): void
 {
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
@@ -272,5 +254,5 @@ test('buildDefaultAudience() successfully returns the first audience', function(
         'audience' => ['aud1', 'aud2', 'aud3'],
     ]);
 
-    $this->assertEquals('aud1', $sdk->buildDefaultAudience());
+    $this->assertEquals('aud1', $sdk->defaultAudience());
 });


### PR DESCRIPTION
At the suggestion of DevRel, I'm working on simplifying the SdkConfiguration to reduce the number of required configuration options at initialization to reduce setup work for instances where certain features are not being used, such as an API-only setting where tokens are being processed for authorization, and we may not need things like Client ID.

This PR introduces a `strategy` option, which will define a different set of configuration state validations based on the value, appropriate for each use case.

- The `api` strategy only requires `domain` and `audience` be configured.
- For `webapp`, `domain` and `clientId` are required, and `clientSecret` is mandatory when `tokenAlgorithm` is set to HS256. 
- With `management`, either `managementToken` is required, or `clientId` and `clientSecret` to obtain a management token on the developers behalf.