### PR TITLE
Use different cookie prefix

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -186,9 +186,14 @@ final class Auth0
     public function clear(): self
     {
         $sessionStorage = $this->configuration->getSessionStorage();
+        $transientStorage = $this->configuration->getTransientStorage();
 
         if ($sessionStorage !== null) {
             $sessionStorage->deleteAll();
+        }
+
+        if ($transientStorage !== null) {
+            $transientStorage->deleteAll();
         }
 
         $this->state->reset();

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -389,11 +389,11 @@ final class SdkConfiguration implements ConfigurableContract
     private function setupStateStorage(): void
     {
         if (! $this->getSessionStorage() instanceof StoreInterface) {
-            $this->setSessionStorage(new CookieStore($this));
+            $this->setSessionStorage(new CookieStore($this, 'auth0_session'));
         }
 
         if (! $this->getTransientStorage() instanceof StoreInterface) {
-            $this->setTransientStorage(new CookieStore($this));
+            $this->setTransientStorage(new CookieStore($this, 'auth0_transient'));
         }
     }
 

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -17,13 +17,6 @@ trait ConfigurableMixin
     private array $configuredState = [];
 
     /**
-     * Tracks any configured validator functions to be called during validate().
-     *
-     * @var array<string>
-     */
-    private array $configuredValidations = [];
-
-    /**
      * When true, changes can no longer be applied to the configuration.
      */
     private bool $configurationImmutable = false;
@@ -117,32 +110,6 @@ trait ConfigurableMixin
     public function lock(): self
     {
         $this->configurationImmutable = true;
-        return $this;
-    }
-
-    /**
-     * Invoke any configured validation functions to determine if the configuration is valid.
-     *
-     * @throws ConfigurationException When the configuration fails to pass a validation check.
-     */
-    public function validate(): self
-    {
-        foreach ($this->configuredValidations as $condition) {
-            if (mb_strlen($condition) > 4 && (mb_substr($condition, 0, 3) === 'get' || mb_substr($condition, 0, 3) === 'has')) {
-                $propertyName = lcfirst(mb_substr($condition, 3));
-
-                if (isset($this->configuredState[$propertyName])) {
-                    if (call_user_func([$this, $condition]) === null) {
-                        if (method_exists($this, 'onValidationException')) {
-                            $this->onValidationException($propertyName);
-                        }
-
-                        throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
-                    }
-                }
-            }
-        }
-
         return $this;
     }
 
@@ -244,18 +211,6 @@ trait ConfigurableMixin
             }
         }
 
-        return $this;
-    }
-
-    /**
-     * Define validation functions to use for validate().
-     *
-     * @param array<string> $validations A list of function names to invoke upon validation. These should return a bool, or throw an error if they fail to pass.
-     */
-    private function setValidations(
-        array $validations = []
-    ): self {
-        $this->configuredValidations = $validations;
         return $this;
     }
 

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -48,7 +48,7 @@ class CookieStore implements StoreInterface
         Validate::string($cookiePrefix, 'cookiePrefix');
 
         $this->configuration = & $configuration;
-        $this->cookiePrefix = $cookiePrefix;
+        $this->cookiePrefix = trim($cookiePrefix);
 
         $this->chunkingThreshold = self::KEY_CHUNKING_THRESHOLD - strlen(hash(self::KEY_HASHING_ALGO, 'threshold'));
     }
@@ -210,7 +210,7 @@ class CookieStore implements StoreInterface
         $key = trim($key);
 
         if ($prefix) {
-            return $this->cookiePrefix . '_' . hash(self::KEY_HASHING_ALGO, trim($key));
+            return $this->cookiePrefix . '_' . hash(self::KEY_HASHING_ALGO, $key);
         }
 
         return $key;

--- a/src/Token.php
+++ b/src/Token.php
@@ -134,19 +134,15 @@ final class Token
         ?int $tokenNow = null
     ): self {
         $tokenIssuer = $tokenIssuer ?? 'https://' . $this->configuration->getDomain() . '/';
-        $tokenAudience = $tokenAudience ?? $this->configuration->getAudience() ?? null;
+        $tokenAudience = $tokenAudience ?? $this->configuration->getAudience() ?? [];
         $tokenOrganization = $tokenOrganization ?? $this->configuration->getOrganization() ?? null;
         $tokenNonce = $tokenNonce ?? null;
         $tokenMaxAge = $tokenMaxAge ?? $this->configuration->getTokenMaxAge() ?? null;
         $tokenLeeway = $tokenLeeway ?? $this->configuration->getTokenLeeway() ?? 60;
 
         // If 'aud' claim check isn't defined, fallback to client id, if configured.
-        if ($tokenAudience === null || count($tokenAudience) === 0) {
-            $tokenAudience = [];
-
-            if ($this->configuration->hasClientId()) {
-                $tokenAudience[] = (string) $this->configuration->getClientId();
-            }
+        if (count($tokenAudience) === 0 && $this->configuration->hasClientId()) {
+            $tokenAudience[] = (string) $this->configuration->getClientId();
         }
 
         $validator = $this->parser->validate();

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -75,8 +75,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier', '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier', '__test_code_verifier__');
 
         $this->expectException(\Auth0\SDK\Exception\StateException::class);
         $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_NONCE);
@@ -94,8 +94,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  null);
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  null);
 
         $this->expectException(\Auth0\SDK\Exception\StateException::class);
         $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_CODE_VERIFIER);
@@ -124,9 +124,9 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
         $this->assertArrayHasKey('sub', $auth0->getUser());
@@ -153,8 +153,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
         $this->assertArrayHasKey('sub', $auth0->getUser());
@@ -180,9 +180,9 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
         $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
@@ -209,8 +209,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
 
         $this->assertTrue($auth0->exchange());
         $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
@@ -239,9 +239,9 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
         $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
@@ -266,8 +266,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
 
@@ -295,8 +295,8 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
 
@@ -327,9 +327,9 @@ class Auth0Test extends TestCase
         $_GET['code'] = uniqid();
         $_GET['state'] = '__test_state__';
 
-        $auth0->configuration()->getSessionStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getSessionStorage()->set('code_verifier',  '__test_code_verifier__');
+        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
         $this->assertTrue($auth0->exchange());
 
@@ -537,7 +537,7 @@ class Auth0Test extends TestCase
             'tokenAlgorithm' => 'HS256',
         ]);
 
-        $auth0->configuration()->getSessionStorage()->set('nonce',  '__test_nonce__');
+        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
 
         $auth0->setIdToken($token);
 


### PR DESCRIPTION
When using the default storage, if we cleared the "session storage" all values from the "transient" storage where also cleared. 