### PR TITLE
Remove JSON_FORCE_OBJECT flag from JSON encoding process

### DIFF
--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -20,7 +20,7 @@ final class Organizations extends ManagementEndpoint
      * Create an organization.
      * Required scope: `create:organizations`
      *
-     * @param string              $name        The name of the Organization. Cannot be changed later.
+     * @param string              $name        The name of the Organization.
      * @param string              $displayName The displayed name of the Organization.
      * @param array<mixed>|null   $branding    Optional. An array containing branding customizations for the organization.
      * @param array<mixed>|null   $metadata    Optional. Additional metadata to store about the organization.
@@ -139,6 +139,7 @@ final class Organizations extends ManagementEndpoint
      * Required scope: `update:organizations`
      *
      * @param string               $id          Organization (by ID) to update.
+     * @param string               $name        The name of the Organization.
      * @param string               $displayName The displayed name of the Organization.
      * @param array<mixed>|null    $branding    Optional. An array containing branding customizations for the organization.
      * @param array<mixed>|null    $metadata    Optional. Additional metadata to store about the organization.
@@ -150,13 +151,14 @@ final class Organizations extends ManagementEndpoint
      */
     public function update(
         string $id,
+        string $name,
         string $displayName,
         ?array $branding = null,
         ?array $metadata = null,
         ?array $body = null,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        [$id, $displayName] = Toolkit::filter([$id, $displayName])->string()->trim();
+        [$id, $name, $displayName] = Toolkit::filter([$id, $name, $displayName])->string()->trim();
         [$branding, $metadata, $body] = Toolkit::filter([$branding, $metadata, $body])->array()->trim();
         [$branding, $metadata] = Toolkit::filter([$branding, $metadata])->array()->object();
 
@@ -170,6 +172,7 @@ final class Organizations extends ManagementEndpoint
             ->addPath('organizations', $id)
             ->withBody(
                 (object) Toolkit::merge([
+                    'name' => $name,
                     'display_name' => $displayName,
                     'branding' => $branding,
                     'metadata' => $metadata,

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -437,9 +437,7 @@ final class HttpRequest
         $body,
         bool $jsonEncode = true
     ): self {
-        if (is_object($body)) {
-            $body = json_encode($body, JSON_FORCE_OBJECT | JSON_THROW_ON_ERROR);
-        } elseif (is_array($body) || is_string($body) && $jsonEncode === true) {
+        if (is_array($body) || is_object($body) || is_string($body) && $jsonEncode === true) {
             $body = json_encode($body, JSON_THROW_ON_ERROR);
         }
 

--- a/tests/Unit/API/Management/BlacklistsTest.php
+++ b/tests/Unit/API/Management/BlacklistsTest.php
@@ -37,6 +37,9 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($aud, $body['aud']);
     $this->assertArrayHasKey('jti', $body);
     $this->assertEquals($jti, $body['jti']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['jti' => $jti, 'aud' => $aud]), $body);
 });
 
 test('get() issues valid requests', function(): void {

--- a/tests/Unit/API/Management/ClientGrantsTest.php
+++ b/tests/Unit/API/Management/ClientGrantsTest.php
@@ -53,6 +53,9 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($clientId, $body['client_id']);
     $this->assertEquals($audience, $body['audience']);
     $this->assertContains($scope, $body['scope']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['client_id' => $clientId, 'audience' => $audience, 'scope' => [$scope]]), $body);
 });
 
 test('getAll() issues valid requests', function(): void {
@@ -139,6 +142,9 @@ test('update() issues valid requests', function(): void {
     $body = $this->sdk->getRequestBody();
     $this->assertArrayHasKey('scope', $body);
     $this->assertContains($scope, $body['scope']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['scope' => [$scope]]), $body);
 });
 
 test('delete() issues valid requests', function(): void {

--- a/tests/Unit/API/Management/ClientsTest.php
+++ b/tests/Unit/API/Management/ClientsTest.php
@@ -56,17 +56,27 @@ class ClientsTest extends TestCase
      */
     public function testCreate(): void
     {
+        $mock = (object) [
+            'name' => uniqid(),
+            'body'=> [
+                'app_type' => uniqid()
+            ]
+        ];
+
         $api = new MockManagementApi();
-        $api->mock()->clients()->create('__test_name__', ['app_type' => '__test_app_type__']);
+        $api->mock()->clients()->create($mock->name, $mock->body);
 
         $this->assertEquals('POST', $api->getRequestMethod());
         $this->assertEquals('https://api.test.local/api/v2/clients', $api->getRequestUrl());
 
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('name', $body);
-        $this->assertEquals('__test_name__', $body['name']);
+        $this->assertEquals($mock->name, $body['name']);
         $this->assertArrayHasKey('app_type', $body);
-        $this->assertEquals('__test_app_type__', $body['app_type']);
+        $this->assertEquals($mock->body['app_type'], $body['app_type']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['name' => $mock->name], $mock->body)), $body);
     }
 
     /**

--- a/tests/Unit/API/Management/ConnectionsTest.php
+++ b/tests/Unit/API/Management/ConnectionsTest.php
@@ -78,20 +78,28 @@ class ConnectionsTest extends TestCase
      */
     public function testCreate(): void
     {
-        $name = 'TestConnection01';
-        $strategy = 'test-strategy-01';
-        $query = [ 'testing' => 'test '];
+        $mock = (object) [
+            'name' => uniqid(),
+            'strategy' => uniqid(),
+            'body' => [
+                'test1' => uniqid(),
+                'test2' => uniqid()
+            ]
+        ];
 
         $api = new MockManagementApi();
-        $api->mock()->connections()->create($name, $strategy, $query);
+        $api->mock()->connections()->create($mock->name, $mock->strategy, $mock->body);
 
         $request_body = $api->getRequestBody();
 
-        $this->assertEquals($name, $request_body['name']);
-        $this->assertEquals($strategy, $request_body['strategy']);
+        $this->assertEquals($mock->name, $request_body['name']);
+        $this->assertEquals($mock->strategy, $request_body['strategy']);
         $this->assertEquals('POST', $api->getRequestMethod());
         $this->assertEquals('https://api.test.local/api/v2/connections', $api->getRequestUrl());
         $this->assertEmpty($api->getRequestQuery());
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'strategy' => $mock->strategy], $mock->body)), $body);
     }
 
     /**

--- a/tests/Unit/API/Management/DeviceCredentialsTest.php
+++ b/tests/Unit/API/Management/DeviceCredentialsTest.php
@@ -69,6 +69,9 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($value, $body['value']);
     $this->assertEquals($deviceId, $body['device_id']);
     $this->assertEquals($additional, $body['additional']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['device_name' => $deviceName, 'type' => $type, 'value' => $value, 'device_id' => $deviceId, 'additional' => $additional]), $body);
 });
 
 test('get() issues valid requests', function(): void {

--- a/tests/Unit/API/Management/EmailTemplatesTest.php
+++ b/tests/Unit/API/Management/EmailTemplatesTest.php
@@ -76,6 +76,9 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($subject, $body['subject']);
     $this->assertEquals($syntax, $body['syntax']);
     $this->assertEquals(true, $body['enabled']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['template' => $template, 'body' => $payload, 'from' => $from, 'subject' => $subject, 'syntax' => $syntax, 'enabled' => true]), $body);
 });
 
 test('get() issues valid requests', function(): void {
@@ -103,6 +106,9 @@ test('update() issues valid requests', function(): void {
     $body = $this->sdk->getRequestBody();
     $this->assertArrayHasKey('test', $body);
     $this->assertEquals($payload, $body['test']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['test' => $payload]), $body);
 });
 
 test('patch() issues valid requests', function(): void {
@@ -119,4 +125,7 @@ test('patch() issues valid requests', function(): void {
     $body = $this->sdk->getRequestBody();
     $this->assertArrayHasKey('test', $body);
     $this->assertEquals($payload, $body['test']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['test' => $payload]), $body);
 });

--- a/tests/Unit/API/Management/EmailsTest.php
+++ b/tests/Unit/API/Management/EmailsTest.php
@@ -38,10 +38,19 @@ test('createProvider() issues valid requests', function(): void {
     $endpoint = $this->sdk->mock()->emails();
 
     $name = uniqid();
-    $credentials = uniqid();
-    $additional = uniqid();
+    $credentials = [
+        'api_user' => uniqid(),
+        'region' => uniqid(),
+        'smtp_host' => uniqid(),
+        'smtp_port' => uniqid(),
+        'smtp_user' => uniqid()
+    ];
+    $additional = [
+        'test1' => uniqid(),
+        'test2' => uniqid(),
+    ];
 
-    $endpoint->createProvider($name, [$credentials], ['additional' => $additional]);
+    $endpoint->createProvider($name, $credentials, ['additional' => $additional]);
 
     $this->assertEquals('POST', $this->sdk->getRequestMethod());
     $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
@@ -50,10 +59,13 @@ test('createProvider() issues valid requests', function(): void {
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
-    $this->assertCount(1, $body['credentials']);
+    $this->assertCount(5, $body['credentials']);
     $this->assertEquals($name, $body['name']);
-    $this->assertEquals($credentials, $body['credentials'][0]);
+    $this->assertEquals($credentials, $body['credentials']);
     $this->assertEquals($additional, $body['additional']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
 });
 
 test('getProvider() issues valid requests', function(): void {
@@ -69,10 +81,19 @@ test('updateProvider() issues valid requests', function(): void {
     $endpoint = $this->sdk->mock()->emails();
 
     $name = uniqid();
-    $credentials = uniqid();
-    $additional = uniqid();
+    $credentials = [
+        'api_user' => uniqid(),
+        'region' => uniqid(),
+        'smtp_host' => uniqid(),
+        'smtp_port' => uniqid(),
+        'smtp_user' => uniqid()
+    ];
+    $additional = [
+        'test1' => uniqid(),
+        'test2' => uniqid(),
+    ];
 
-    $endpoint->updateProvider($name, [$credentials], ['additional' => $additional]);
+    $endpoint->updateProvider($name, $credentials, ['additional' => $additional]);
 
     $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
     $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
@@ -81,10 +102,13 @@ test('updateProvider() issues valid requests', function(): void {
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
-    $this->assertCount(1, $body['credentials']);
+    $this->assertCount(5, $body['credentials']);
     $this->assertEquals($name, $body['name']);
-    $this->assertEquals($credentials, $body['credentials'][0]);
+    $this->assertEquals($credentials, $body['credentials']);
     $this->assertEquals($additional, $body['additional']);
+
+    $body = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
 });
 
 test('delete() issues valid requests', function(): void {

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -22,18 +22,25 @@ class OrganizationsTest extends TestCase
      */
     public function testThatCreateOrganizationRequestIsFormedCorrectly(): void
     {
+        $mock = (object) [
+            'id' => uniqid(),
+            'name' => uniqid(),
+            'branding' => [
+                'logo_url' => uniqid(),
+            ],
+            'metadata' => [
+                'test' => uniqid()
+            ],
+            'body' => [
+                'additional' => [
+                    'testing' => uniqid()
+                ]
+            ]
+        ];
+
         $api = new MockManagementApi();
 
-        $api->mock()->organizations()->create(
-            'test-organization',
-            'Test Organization',
-            [
-                'logo_url' => 'https://test.com/test.png',
-            ],
-            [
-                'meta' => 'data',
-            ]
-        );
+        $api->mock()->organizations()->create($mock->id, $mock->name, $mock->branding, $mock->metadata, $mock->body);
 
         $this->assertEquals('POST', $api->getRequestMethod());
         $this->assertEquals('https://api.test.local/api/v2/organizations', $api->getRequestUrl());
@@ -44,18 +51,21 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
 
         $this->assertArrayHasKey('name', $body);
-        $this->assertEquals('test-organization', $body['name']);
+        $this->assertEquals($mock->id, $body['name']);
 
         $this->assertArrayHasKey('display_name', $body);
-        $this->assertEquals('Test Organization', $body['display_name']);
+        $this->assertEquals($mock->name, $body['display_name']);
 
         $this->assertArrayHasKey('branding', $body);
         $this->assertArrayHasKey('logo_url', $body['branding']);
-        $this->assertEquals('https://test.com/test.png', $body['branding']['logo_url']);
+        $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
 
         $this->assertArrayHasKey('metadata', $body);
-        $this->assertArrayHasKey('meta', $body['metadata']);
-        $this->assertEquals('data', $body['metadata']['meta']);
+        $this->assertArrayHasKey('test', $body['metadata']);
+        $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
     }
 
     /**
@@ -89,37 +99,51 @@ class OrganizationsTest extends TestCase
      */
     public function testThatUpdateOrganizationRequestIsFormedCorrectly(): void
     {
+        $mock = (object) [
+            'id' => uniqid(),
+            'name' => uniqid(),
+            'displayName' => uniqid(),
+            'branding' => [
+                'logo_url' => uniqid(),
+            ],
+            'metadata' => [
+                'test' => uniqid()
+            ],
+            'body' => [
+                'additional' => [
+                    'testing' => uniqid()
+                ]
+            ]
+        ];
+
         $api = new MockManagementApi();
 
-        $api->mock()->organizations()->update(
-            'test-organization',
-            'Test Organization',
-            [
-                'logo_url' => 'https://test.com/test.png',
-            ],
-            [
-                'meta' => 'data',
-            ]
-        );
+        $api->mock()->organizations()->update($mock->id, $mock->name, $mock->displayName, $mock->branding, $mock->metadata, $mock->body);
 
         $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/organizations/test-organization', $api->getRequestUrl());
+        $this->assertEquals('https://api.test.local/api/v2/organizations/' . $mock->id, $api->getRequestUrl());
 
         $headers = $api->getRequestHeaders();
         $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
         $body = $api->getRequestBody();
 
+        $this->assertArrayHasKey('name', $body);
+        $this->assertEquals($mock->name, $body['name']);
+
         $this->assertArrayHasKey('display_name', $body);
-        $this->assertEquals('Test Organization', $body['display_name']);
+        $this->assertEquals($mock->displayName, $body['display_name']);
 
         $this->assertArrayHasKey('branding', $body);
         $this->assertArrayHasKey('logo_url', $body['branding']);
-        $this->assertEquals('https://test.com/test.png', $body['branding']['logo_url']);
+        $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
 
         $this->assertArrayHasKey('metadata', $body);
-        $this->assertArrayHasKey('meta', $body['metadata']);
-        $this->assertEquals('data', $body['metadata']['meta']);
+        $this->assertArrayHasKey('test', $body['metadata']);
+        $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'display_name' => $mock->displayName, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
     }
 
     /**
@@ -132,7 +156,7 @@ class OrganizationsTest extends TestCase
         $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
         $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
-        $api->mock()->organizations()->update('', '');
+        $api->mock()->organizations()->update('', '', '');
     }
 
     /**
@@ -145,7 +169,7 @@ class OrganizationsTest extends TestCase
         $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
         $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
 
-        $api->mock()->organizations()->update('test-organization', '');
+        $api->mock()->organizations()->update('test-organization', '', '');
     }
 
     /**
@@ -174,7 +198,7 @@ class OrganizationsTest extends TestCase
         $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
         $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
-        $api->mock()->organizations()->update('', '');
+        $api->mock()->organizations()->delete('');
     }
 
     /**
@@ -322,6 +346,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('connection_id', $body);
         $this->assertEquals('test-connection', $body['connection_id']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['connection_id' => 'test-connection', 'assign_membership_on_login' => true]), $body);
     }
 
     /**
@@ -368,6 +395,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('assign_membership_on_login', $body);
         $this->assertTrue($body['assign_membership_on_login']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['assign_membership_on_login' => true]), $body);
     }
 
     /**
@@ -479,6 +509,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('members', $body);
         $this->assertContains('test-user', $body['members']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
     }
 
     /**
@@ -522,6 +555,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('members', $body);
         $this->assertContains('test-user', $body['members']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
     }
 
     /**
@@ -607,6 +643,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('roles', $body);
         $this->assertContains('test-role', $body['roles']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
     }
 
     /**
@@ -663,6 +702,9 @@ class OrganizationsTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('roles', $body);
         $this->assertContains('test-role', $body['roles']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
     }
 
     /**
@@ -798,6 +840,9 @@ class OrganizationsTest extends TestCase
         $this->assertArrayHasKey('invitee', $body);
         $this->assertArrayHasKey('email', $body['invitee']);
         $this->assertEquals('email@test.com', $body['invitee']['email']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['client_id' => 'test-client', 'inviter' => ['name' => 'Test Sender'], 'invitee' => ['email' => 'email@test.com']]), $body);
     }
 
     /**

--- a/tests/Unit/API/Management/RolesTest.php
+++ b/tests/Unit/API/Management/RolesTest.php
@@ -45,6 +45,9 @@ class RolesTest extends TestCase
         $this->assertEquals($id, $body['name']);
         $this->assertArrayHasKey('description', $body);
         $this->assertEquals('__test_description__', $body['description']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['name' => $id, 'description' => '__test_description__']), $body);
     }
 
     /**
@@ -91,6 +94,9 @@ class RolesTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('name', $body);
         $this->assertEquals('__test_new_name__', $body['name']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['name' => '__test_new_name__']), $body);
     }
 
     /**
@@ -193,5 +199,8 @@ class RolesTest extends TestCase
         $this->assertCount(2, $body['users']);
         $this->assertContains('strategy|1234567890', $body['users']);
         $this->assertContains('strategy|0987654321', $body['users']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['users' => ['strategy|1234567890', 'strategy|0987654321']]), $body);
     }
 }

--- a/tests/Unit/API/Management/RulesTest.php
+++ b/tests/Unit/API/Management/RulesTest.php
@@ -93,6 +93,9 @@ class RulesTest extends TestCase
 
         $this->assertArrayHasKey('test_parameter', $body);
         $this->assertEquals($mockup->query['test_parameter'], $body['test_parameter']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['name' => $mockup->name, 'script' => $mockup->script], $mockup->query)), $body);
     }
 
     /**
@@ -118,5 +121,8 @@ class RulesTest extends TestCase
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('test_parameter', $body);
         $this->assertEquals($mockup->query['test_parameter'], $body['test_parameter']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode($mockup->query), $body);
     }
 }

--- a/tests/Unit/API/Management/TicketsTest.php
+++ b/tests/Unit/API/Management/TicketsTest.php
@@ -11,17 +11,17 @@ class TicketsTest extends TestCase
 {
     public function testCreateEmailVerification(): void
     {
+        $mock = (object) [
+            'userId' => uniqid(),
+            'identity' => [
+                'user_id' => '__test_secondary_user_id__',
+                'provider' => '__test_provider__',
+            ],
+        ];
+
         $api = new MockManagementApi();
 
-        $api->mock()->tickets()->createEmailVerification(
-            '__test_user_id__',
-            [
-                'identity' => [
-                    'user_id' => '__test_secondary_user_id__',
-                    'provider' => '__test_provider__',
-                ],
-            ]
-        );
+        $api->mock()->tickets()->createEmailVerification($mock->userId, ['identity' => $mock->identity]);
 
         $this->assertEquals('POST', $api->getRequestMethod());
         $this->assertEquals('https://api.test.local/api/v2/tickets/email-verification', $api->getRequestUrl());
@@ -29,34 +29,31 @@ class TicketsTest extends TestCase
 
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('user_id', $body);
-        $this->assertEquals('__test_user_id__', $body['user_id']);
+        $this->assertEquals($mock->userId, $body['user_id']);
         $this->assertArrayHasKey('identity', $body);
-        $this->assertEquals(
-            [
-                'user_id' => '__test_secondary_user_id__',
-                'provider' => '__test_provider__',
-            ],
-            $body['identity']
-        );
+        $this->assertEquals($mock->identity, $body['identity']);
 
         $headers = $api->getRequestHeaders();
         $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(['user_id' => $mock->userId, 'identity' => $mock->identity]), $body);
     }
 
     public function testCreatePasswordChange(): void
     {
+        $mock = [
+            'user_id' => uniqid(),
+            'new_password' => uniqid(),
+            'result_url' => uniqid(),
+            'connection_id' => uniqid(),
+            'ttl_sec' => uniqid(),
+            'client_id' => uniqid(),
+        ];
+
         $api = new MockManagementApi();
 
-        $api->mock()->tickets()->createPasswordChange(
-            [
-                'user_id' => '__test_user_id__',
-                'new_password' => '__test_password__',
-                'result_url' => '__test_result_url__',
-                'connection_id' => '__test_connection_id__',
-                'ttl_sec' => 8675309,
-                'client_id' => '__test_client_id__',
-            ]
-        );
+        $api->mock()->tickets()->createPasswordChange($mock);
 
         $this->assertEquals('POST', $api->getRequestMethod());
         $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getRequestUrl());
@@ -64,19 +61,22 @@ class TicketsTest extends TestCase
 
         $body = $api->getRequestBody();
         $this->assertArrayHasKey('user_id', $body);
-        $this->assertEquals('__test_user_id__', $body['user_id']);
+        $this->assertEquals($mock['user_id'], $body['user_id']);
         $this->assertArrayHasKey('new_password', $body);
-        $this->assertEquals('__test_password__', $body['new_password']);
+        $this->assertEquals($mock['new_password'], $body['new_password']);
         $this->assertArrayHasKey('result_url', $body);
-        $this->assertEquals('__test_result_url__', $body['result_url']);
+        $this->assertEquals($mock['result_url'], $body['result_url']);
         $this->assertArrayHasKey('connection_id', $body);
-        $this->assertEquals('__test_connection_id__', $body['connection_id']);
+        $this->assertEquals($mock['connection_id'], $body['connection_id']);
         $this->assertArrayHasKey('ttl_sec', $body);
-        $this->assertEquals(8675309, $body['ttl_sec']);
+        $this->assertEquals($mock['ttl_sec'], $body['ttl_sec']);
         $this->assertArrayHasKey('client_id', $body);
-        $this->assertEquals('__test_client_id__', $body['client_id']);
+        $this->assertEquals($mock['client_id'], $body['client_id']);
 
         $headers = $api->getRequestHeaders();
         $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode($mock), $body);
     }
 }

--- a/tests/Unit/API/Management/UsersTest.php
+++ b/tests/Unit/API/Management/UsersTest.php
@@ -73,6 +73,9 @@ class UsersTest extends TestCase
         $this->assertArrayHasKey('user_metadata', $body);
         $this->assertArrayHasKey('__test_meta_key__', $body['user_metadata']);
         $this->assertEquals($mockup->query['user_metadata']['__test_meta_key__'], $body['user_metadata']['__test_meta_key__']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode($mockup->query), $body);
     }
 
     /**
@@ -104,6 +107,9 @@ class UsersTest extends TestCase
         $this->assertEquals($mockup->query['email'], $body['email']);
         $this->assertArrayHasKey('password', $body);
         $this->assertEquals($mockup->query['password'], $body['password']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode(array_merge(['connection' => $mockup->connection], $mockup->query)), $body);
     }
 
     /**
@@ -153,6 +159,9 @@ class UsersTest extends TestCase
         $this->assertEquals($mockup->query['connection_id'], $body['connection_id']);
         $this->assertArrayHasKey('user_id', $body);
         $this->assertEquals($mockup->query['user_id'], $body['user_id']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals(json_encode($mockup->query), $body);
     }
 
     /**
@@ -237,6 +246,9 @@ class UsersTest extends TestCase
         $this->assertCount(2, $body['roles']);
         $this->assertEquals($mockup->roles[0], $body['roles'][0]);
         $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
     }
 
     /**
@@ -266,6 +278,9 @@ class UsersTest extends TestCase
         $this->assertCount(2, $body['roles']);
         $this->assertEquals($mockup->roles[0], $body['roles'][0]);
         $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
     }
 
     /**
@@ -327,6 +342,9 @@ class UsersTest extends TestCase
         $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
         $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
         $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
     }
 
     /**
@@ -360,6 +378,9 @@ class UsersTest extends TestCase
         $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
         $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
         $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
+
+        $body = $api->getRequestBodyAsString();
+        $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
     }
 
     /**


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

Remove the JSON_FORCE_OBJECT flag to avoid inadvertently converting structures that should remain arrays into objects. Add regression tests to ensure this encoding mistake is captured, should it pop up again.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #540

### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
