### PR TITLE
Adding InMemory storage for tests

### DIFF
--- a/src/Store/InMemoryStorage.php
+++ b/src/Store/InMemoryStorage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Store;
+
+use Auth0\SDK\Contract\StoreInterface;
+
+/**
+ * In memory storage. This is useful only in tests. Do not use this in production.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class InMemoryStorage implements StoreInterface
+{
+    private array $data = [];
+
+    public function set(string $key, $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function get(string $key, ?string $default = null)
+    {
+        if (\array_key_exists($key, $this->data)) {
+            return $this->data[$key];
+        }
+
+        return $default;
+    }
+
+    public function delete(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+
+    public function deleteAll(): void
+    {
+        $this->data = [];
+    }
+}

--- a/src/Store/InMemoryStorage.php
+++ b/src/Store/InMemoryStorage.php
@@ -11,17 +11,24 @@ use Auth0\SDK\Contract\StoreInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class InMemoryStorage implements StoreInterface
+final class InMemoryStorage implements StoreInterface
 {
+    /**
+     * @var array<string, mixed>
+     */
     private array $data = [];
 
-    public function set(string $key, $value): void
-    {
+    public function set(
+        string $key,
+        $value
+    ): void {
         $this->data[$key] = $value;
     }
 
-    public function get(string $key, ?string $default = null)
-    {
+    public function get(
+        string $key,
+        ?string $default = null
+    ) {
         if (\array_key_exists($key, $this->data)) {
             return $this->data[$key];
         }
@@ -29,8 +36,9 @@ class InMemoryStorage implements StoreInterface
         return $default;
     }
 
-    public function delete(string $key): void
-    {
+    public function delete(
+        string $key
+    ): void {
         unset($this->data[$key]);
     }
 

--- a/tests/Unit/Store/InMemoryTest.php
+++ b/tests/Unit/Store/InMemoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Tests\Unit\Store;
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Store\CookieStore;
+use Auth0\SDK\Store\InMemoryStorage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class InMemoryTest extends TestCase
+{
+    public function testSetGet(): void
+    {
+        $store = new InMemoryStorage();
+        $store->set('test_set_key', '__test_set_value__');
+        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
+        $this->assertSame(null, $store->get('missing_key'));
+    }
+
+    public function testGetDefault(): void
+    {
+        $store = new InMemoryStorage();
+        $store->set('test_set_key', null);
+        $this->assertSame(null, $store->get('test_set_key', 'foobar'));
+        $this->assertSame('foobar', $store->get('missing_key', 'foobar'));
+        $this->assertSame(null, $store->get('missing_key'));
+    }
+
+    public function testDelete(): void
+    {
+        $store = new InMemoryStorage();
+        $store->set('test_set_key', '__test_set_value__');
+
+        $store->delete('test_set_key');
+        $this->assertNull($store->get('test_set_key'));
+    }
+
+    public function testDeleteAll(): void
+    {
+        $store = new InMemoryStorage();
+        $store->set('test_set_key', '__test_set_value__');
+
+        $store->deleteAll();
+        $this->assertNull($store->get('test_set_key'));
+    }
+}

--- a/tests/Unit/Store/InMemoryTest.php
+++ b/tests/Unit/Store/InMemoryTest.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Unit\Store;
 
-use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Store\CookieStore;
 use Auth0\SDK\Store\InMemoryStorage;
 use PHPUnit\Framework\TestCase;
 
 /**
- *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class InMemoryTest extends TestCase


### PR DESCRIPTION
When writing functional tests, I want to make sure no cookie is written. Adding an `InMemoryStorage` will help me create an `SdkConfiguration` that do not mess with the global state. 

This is a class that I would need in every application, hence I thought it to be good to add in to the SDK. 

### Changes


### References

None

### Testing

Use PHPUnit

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
