### PR TITLE
Dont pass config by reference

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -47,7 +47,7 @@ final class Authentication
         }
 
         // Store the configuration internally.
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -78,7 +78,7 @@ final class Management
         }
 
         // Store the configuration internally.
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/Event/HttpRequestBuilt.php
+++ b/src/Event/HttpRequestBuilt.php
@@ -12,9 +12,9 @@ final class HttpRequestBuilt implements Auth0Event
     private RequestInterface $httpRequest;
 
     public function __construct(
-        RequestInterface &$httpRequest
+        RequestInterface $httpRequest
     ) {
-        $this->httpRequest = & $httpRequest;
+        $this->httpRequest = $httpRequest;
     }
 
     public function &get(): RequestInterface
@@ -23,9 +23,9 @@ final class HttpRequestBuilt implements Auth0Event
     }
 
     public function set(
-        RequestInterface &$httpRequest
+        RequestInterface $httpRequest
     ): self {
-        $this->httpRequest = & $httpRequest;
+        $this->httpRequest = $httpRequest;
         return $this;
     }
 }

--- a/src/Event/HttpResponseReceived.php
+++ b/src/Event/HttpResponseReceived.php
@@ -14,10 +14,10 @@ final class HttpResponseReceived implements Auth0Event
     private RequestInterface $httpRequest;
 
     public function __construct(
-        ResponseInterface &$httpResponse,
+        ResponseInterface $httpResponse,
         RequestInterface $httpRequest
     ) {
-        $this->httpResponse = & $httpResponse;
+        $this->httpResponse = $httpResponse;
         $this->httpRequest = $httpRequest;
     }
 
@@ -32,9 +32,9 @@ final class HttpResponseReceived implements Auth0Event
     }
 
     public function set(
-        ResponseInterface &$httpResponse
+        ResponseInterface $httpResponse
     ): self {
-        $this->httpResponse = & $httpResponse;
+        $this->httpResponse = $httpResponse;
         return $this;
     }
 }

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -42,7 +42,7 @@ class CookieStore implements StoreInterface
      * @param string           $cookiePrefix    A string to prefix stored cookie keys with.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         string $cookiePrefix = 'auth0'
     ) {
         [$cookiePrefix] = Toolkit::filter([$cookiePrefix])->string()->trim();
@@ -51,7 +51,7 @@ class CookieStore implements StoreInterface
             [$cookiePrefix, \Auth0\SDK\Exception\ArgumentException::missing('cookiePrefix')],
         ])->isString();
 
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->cookiePrefix = $cookiePrefix ?? 'auth0';
 
         $this->chunkingThreshold = self::KEY_CHUNKING_THRESHOLD - strlen(hash(self::KEY_HASHING_ALGO, 'threshold'));

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -75,6 +75,7 @@ class CookieStore implements StoreInterface
         $_COOKIE[$key] = $value;
 
         if (strlen($value) >= $this->chunkingThreshold) {
+            // @phpstan-ignore-next-line
             $chunks = str_split($value, $this->chunkingThreshold);
 
             // @phpstan-ignore-next-line

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -31,7 +31,7 @@ final class SessionStore implements StoreInterface
      * @param string           $sessionPrefix A string to prefix session keys with.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         string $sessionPrefix = 'auth0'
     ) {
         [$sessionPrefix] = Toolkit::filter([$sessionPrefix])->string()->trim();
@@ -40,7 +40,7 @@ final class SessionStore implements StoreInterface
             [$sessionPrefix, \Auth0\SDK\Exception\ArgumentException::missing('sessionPrefix')],
         ])->isString();
 
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->sessionPrefix = $sessionPrefix ?? 'auth0';
 
         $this->start();

--- a/src/Token.php
+++ b/src/Token.php
@@ -44,7 +44,7 @@ final class Token
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token parsing fails. See the exception message for further details.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         string $jwt,
         int $type = self::TYPE_ID_TOKEN
     ) {
@@ -52,7 +52,7 @@ final class Token
         $this->type = $type;
 
         // Store the configuration internally.
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
 
         // Begin parsing the token.
         $this->parse($jwt);

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -59,9 +59,9 @@ final class Parser
      */
     public function __construct(
         string $jwt,
-        SdkConfiguration &$configuration
+        SdkConfiguration $configuration
     ) {
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->parse($jwt);
     }
 

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -76,7 +76,7 @@ final class Verifier
      * @param CacheItemPoolInterface|null $cache        Optional. A PSR-6 CacheItemPoolInterface instance to cache JWKS results within.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         string $payload,
         string $signature,
         array $headers,
@@ -86,7 +86,7 @@ final class Verifier
         ?int $cacheExpires = null,
         ?CacheItemPoolInterface $cache = null
     ) {
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->payload = $payload;
         $this->signature = $signature;
         $this->headers = $headers;

--- a/src/Utility/EventDispatcher.php
+++ b/src/Utility/EventDispatcher.php
@@ -25,9 +25,9 @@ final class EventDispatcher implements EventDispatcherInterface
      * @param SdkConfiguration   $configuration   Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      */
     public function __construct(
-        SdkConfiguration &$configuration
+        SdkConfiguration $configuration
     ) {
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
     }
 
     public function getListenerProvider(): ?ListenerProviderInterface

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -59,12 +59,12 @@ final class HttpClient
      * @param array<int|string> $headers         Optional. Additional headers to send with the HTTP request.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         int $context = self::CONTEXT_AUTHENTICATION_CLIENT,
         string $basePath = '/',
         array $headers = []
     ) {
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->basePath = $basePath;
         $this->headers = $headers;
         $this->context = $context;

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -132,7 +132,7 @@ final class HttpRequest
      * @param array<object>|null $mockedResponses Optional. Only intended for unit testing purposes.
      */
     public function __construct(
-        SdkConfiguration &$configuration,
+        SdkConfiguration $configuration,
         int $context,
         string $method,
         string $basePath = '/',
@@ -140,7 +140,7 @@ final class HttpRequest
         ?string $domain = null,
         ?array &$mockedResponses = null
     ) {
-        $this->configuration = & $configuration;
+        $this->configuration = $configuration;
         $this->context = $context;
         $this->method = mb_strtoupper($method);
         $this->basePath = $basePath;

--- a/src/Utility/Request/RequestOptions.php
+++ b/src/Utility/Request/RequestOptions.php
@@ -29,8 +29,8 @@ final class RequestOptions
         ?FilteredRequest $fields = null,
         ?PaginatedRequest $pagination = null
     ) {
-        $this->fields = & $fields;
-        $this->pagination = & $pagination;
+        $this->fields = $fields;
+        $this->pagination = $pagination;
     }
 
     /**
@@ -39,9 +39,9 @@ final class RequestOptions
      * @param FilteredRequest|null $fields Request fields be included or excluded from the API response using a FilteredRequest object.
      */
     public function setFields(
-        ?FilteredRequest &$fields
+        ?FilteredRequest $fields
     ): self {
-        $this->fields = & $fields;
+        $this->fields = $fields;
         return $this;
     }
 
@@ -59,9 +59,9 @@ final class RequestOptions
      * @param PaginatedRequest|null $pagination Request paged results using a PaginatedRequest object.
      */
     public function setPagination(
-        ?PaginatedRequest &$pagination
+        ?PaginatedRequest $pagination
     ): self {
-        $this->pagination = & $pagination;
+        $this->pagination = $pagination;
         return $this;
     }
 


### PR DESCRIPTION
### Changes

There is no need to pass `SdkConfiguration` by reference to the CookieStore or SessionStore. Objects are always passed by reference. 

I run into issues when we define the `SdkConfiguration` as a Symfony service. I may be able to do some workaround in my service definition but it seams easier to submit this PR as removing the ampersand has no effect on the functionality. 
(Please correct me if Im wrong)

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

### Testing



### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
