### PR TITLE
Add PSR-6 store

### DIFF
--- a/src/Store/Psr6Store.php
+++ b/src/Store/Psr6Store.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Store;
+
+use Auth0\SDK\Contract\StoreInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * The PSR-6 store needs a PSR-6 CacheItemPool and a public StoreInterface (e.g. CookieStore).
+ * The public store is used to store the cache key and the private PSR-6 store is
+ * for the actual user data.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class Psr6Store implements StoreInterface
+{
+    private const PUBLIC_STORAGE_KEY = 'storage_key';
+    private StoreInterface $publicStore;
+    private CacheItemPoolInterface $privateStore;
+
+    public function __construct(
+        StoreInterface $publicStore,
+        CacheItemPoolInterface $privateStore
+    ) {
+        $this->publicStore = $publicStore;
+        $this->privateStore = $privateStore;
+    }
+
+    public function set(
+        string $key,
+        $value
+    ): void {
+        $item = $this->privateStore->getItem($this->getCacheKey());
+        $data = $item->get();
+        if (! is_array($data)) {
+            $data = [];
+        }
+        $data[$key] = $value;
+        $item->set($data);
+        $this->privateStore->saveDeferred($item);
+    }
+
+    public function get(
+        string $key,
+        ?string $default = null
+    ) {
+        $item = $this->privateStore->getItem($this->getCacheKey());
+        $data = $item->get();
+        if (! is_array($data)) {
+            $data = [];
+        }
+
+        if (array_key_exists($key, $data)) {
+            return $data[$key];
+        }
+
+        return $default;
+    }
+
+    public function delete(
+        string $key
+    ): void {
+        $item = $this->privateStore->getItem($this->getCacheKey());
+        $data = $item->get();
+        if (! is_array($data)) {
+            $data = [];
+        }
+
+        unset($data[$key]);
+        $item->set($data);
+        $this->privateStore->saveDeferred($item);
+    }
+
+    public function deleteAll(): void
+    {
+        $this->privateStore->deleteItem($this->getCacheKey());
+        $this->publicStore->delete(self::PUBLIC_STORAGE_KEY);
+    }
+
+    private function generateKey(): string
+    {
+        try {
+            $randomBytes = random_bytes(32);
+        } catch (\Exception $exception) {
+            $randomBytes = (string) openssl_random_pseudo_bytes(32);
+        }
+
+        return bin2hex($randomBytes);
+    }
+
+    private function getCacheKey(): string
+    {
+        $key = $this->publicStore->get(self::PUBLIC_STORAGE_KEY);
+        if (! is_string($key)) {
+            $key = $this->generateKey();
+            $this->publicStore->set(self::PUBLIC_STORAGE_KEY, $key);
+        }
+
+        return 'auth0_'.$key;
+    }
+}

--- a/tests/Unit/Store/Psr6StoreTest.php
+++ b/tests/Unit/Store/Psr6StoreTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Tests\Unit\Store;
+
+use Auth0\SDK\Contract\StoreInterface;
+use Auth0\SDK\Store\InMemoryStorage;
+use Auth0\SDK\Store\Psr6Store;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Psr6StoreTest extends TestCase
+{
+    private const PUBLIC_STORAGE_KEY = 'storage_key';
+
+    public function testSetGet(): void
+    {
+        $public = new InMemoryStorage();
+        $private = new ArrayAdapter();
+        $store = new Psr6Store($public, $private);
+        $store->set('test_set_key', '__test_set_value__');
+        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
+        $this->assertSame(null, $store->get('missing_key'));
+
+        $this->assertNotNull($randomKey = $public->get(self::PUBLIC_STORAGE_KEY));
+        $public->delete(self::PUBLIC_STORAGE_KEY);
+        $this->assertSame(null, $store->get('test_set_key'));
+
+        // Make sure we have a new key
+        $this->assertNotSame($randomKey, $store->get('test_set_key'));
+        $this->assertNotNull($public->get(self::PUBLIC_STORAGE_KEY));
+    }
+
+    public function testDataIsStoredInPrivate(): void
+    {
+        $public = $this->getMockBuilder(StoreInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['set', 'get', 'delete', 'deleteAll'])
+            ->getMock();
+        $public->expects($this->atLeastOnce())->method('get')->with(self::PUBLIC_STORAGE_KEY)->willReturn('foobar');
+        // Make sure we don't create a new key
+        $public->expects($this->never())->method('set');
+
+        $private = $this->getMockBuilder(CacheItemPoolInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getItem', 'saveDeferred', 'getItems', 'hasItem', 'clear',
+                'save', 'deleteItems', 'deleteItem', 'commit'
+            ])
+            ->getMock();
+
+        $item = $this->getMockBuilder(CacheItemInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get', 'set', 'getKey', 'isHit', 'expiresAt', 'expiresAfter'])
+            ->getMock();
+        $item->expects($this->once())->method('set')->with(['test_set_key'=>'__test_set_value__']);
+        $item->method('get')->willReturnOnConsecutiveCalls(null, ['test_set_key'=>'__test_set_value__']);
+
+        $private->method('getItem')->with('auth0_foobar')->willReturn($item);
+        $private->method('saveDeferred')->willReturn(true);
+
+        $store = new Psr6Store($public, $private);
+        $store->set('test_set_key', '__test_set_value__');
+        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
+        $this->assertSame(null, $store->get('missing_key'));
+    }
+
+    public function testGetDefault(): void
+    {
+        $public = new InMemoryStorage();
+        $private = new ArrayAdapter();
+        $store = new Psr6Store($public, $private);
+        $store->set('test_set_key', null);
+        $this->assertSame(null, $store->get('test_set_key', 'foobar'));
+        $this->assertSame('foobar', $store->get('missing_key', 'foobar'));
+        $this->assertSame(null, $store->get('missing_key'));
+    }
+
+    public function testDelete(): void
+    {
+        $public = new InMemoryStorage();
+        $private = new ArrayAdapter();
+        $store = new Psr6Store($public, $private);
+        $store->set('test_set_key', '__test_set_value__');
+
+        $store->delete('test_set_key');
+        $this->assertNull($store->get('test_set_key'));
+    }
+
+    public function testDeleteAll(): void
+    {
+        $public = new InMemoryStorage();
+        $private = new ArrayAdapter();
+        $store = new Psr6Store($public, $private);
+        $store->set('test_set_key', '__test_set_value__');
+
+        $store->deleteAll();
+        $this->assertNull($store->get('test_set_key'));
+    }
+}


### PR DESCRIPTION
### Changes

This PR make sure we save all the large user data in a PSR-6 cache store. Ie Redis or disk. We use a "public" `StoreInterface` to store the cache key. 

This is not competing with #542. Both this PR and #542 adds value to the project. Separate and together. 

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #539 

### Testing



### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
