### PR TITLE
[SDK-2717] Implement Actions API endpoints

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -96,6 +96,7 @@ final class Management
         array $arguments
     ) {
         $classes = [
+            'actions' => 'Actions',
             'blacklists' => 'Blacklists',
             'clients' => 'Clients',
             'clientGrants' => 'ClientGrants',

--- a/src/API/Management/Actions.php
+++ b/src/API/Management/Actions.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\API\Management;
+
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Toolkit;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class Actions.
+ * Handles requests to the Actions endpoint of the v2 Management API.
+ *
+ * @link https://auth0.com/docs/api/management/v2#!/Actions
+ */
+final class Actions extends ManagementEndpoint
+{
+    /**
+     * Create an action. Once an action is created, it must be deployed, and then bound to a trigger before it will be executed as part of a flow.
+     * Required scope: `create:actions`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/post_action
+     */
+    public function create(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('post')
+            ->addPath('actions', 'actions')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve all actions.
+     * Required scope: `read:actions`
+     *
+     * @param array<int|string|null>|null $parameters Optional. Additional query parameters to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null         $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_actions
+     */
+    public function getAll(
+        ?array $parameters = null,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$parameters] = Toolkit::filter([$parameters])->array()->trim();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', 'actions')
+            ->withParams($parameters)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve an action by its ID.
+     * Required scope: `read:actions`
+     *
+     * @param string              $id      Action (by it's ID) to retrieve.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_action
+     */
+    public function get(
+        string $id,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', 'actions', $id)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Update an existing action. If this action is currently bound to a trigger, updating it will not affect any user flows until the action is deployed.
+     * Required scope: `update:actions`
+     *
+     * @param string              $id      Action (by it's ID) to update.
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/patch_action
+     */
+    public function update(
+        string $id,
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('patch')
+            ->addPath('actions', 'actions', $id)
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Delete an action and all of its associated versions. An action must be unbound from all triggers before it can be deleted.
+     * Required scope: `delete:actions`
+     *
+     * @param string              $id      Action (by it's ID) to delete.
+     * @param bool|null           $force   Force action deletion detaching bindings
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/delete_action
+     */
+    public function delete(
+        string $id,
+        ?bool $force = null,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('delete')
+            ->addPath('actions', 'actions', $id)
+            ->withParams(Toolkit::filter([
+                [
+                    'force' => $force,
+                ],
+            ])->array()->trim()[0])
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Deploy an action. Deploying an action will create a new immutable version of the action. If the action is currently bound to a trigger, then the system will begin executing the newly deployed version of the action immediately. Otherwise, the action will only be executed as a part of a flow once it is bound to that flow.
+     * Required scope: `create:actions`
+     *
+     * @param string              $id      Action (by it's ID) to deploy.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/post_deploy_action
+     */
+    public function deploy(
+        string $id,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('post')
+            ->addPath('actions', $id, 'deploy')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Test an action. After updating an action, it can be tested prior to being deployed to ensure it behaves as expected.
+     * Required scope: `create:actions`
+     *
+     * @param string              $id      Action (by it's ID) to test.
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/post_test_action
+     */
+    public function test(
+        string $id,
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('post')
+            ->addPath('actions', 'actions', $id, 'test')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve a specific version of an action. An action version is created whenever an action is deployed. An action version is immutable, once created.
+     * Required scope: `read:actions`
+     *
+     * @param string              $id       Action version (by it's ID) to retrieve.
+     * @param string              $actionId Action (by it's ID) to retrieve.
+     * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_action_version
+     */
+    public function getVersion(
+        string $id,
+        string $actionId,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id, $actionId] = Toolkit::filter([$id, $actionId])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+            [$actionId, \Auth0\SDK\Exception\ArgumentException::missing('actionId')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', $actionId, 'versions', $id)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve all of an action's versions. An action version is created whenever an action is deployed. An action version is immutable, once created.
+     * Required scope: `read:actions`
+     *
+     * @param string              $actionId Action (by it's ID) to retrieve.
+     * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_action_versions
+     */
+    public function getVersions(
+        string $actionId,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$actionId] = Toolkit::filter([$actionId])->string()->trim();
+
+        Toolkit::assert([
+            [$actionId, \Auth0\SDK\Exception\ArgumentException::missing('actionId')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', $actionId, 'versions')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Performs the equivalent of a roll-back of an action to an earlier, specified version. Creates a new, deployed action version that is identical to the specified version. If this action is currently bound to a trigger, the system will begin executing the newly-created version immediately.
+     * Required scope: `read:actions`
+     *
+     * @param string              $id       Action version (by it's ID) to roll-back to.
+     * @param string              $actionId Action (by it's ID) to perform the roll-back on.
+     * @param RequestOptions|null $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/post_deploy_draft_version
+     */
+    public function rollbackVersion(
+        string $id,
+        string $actionId,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$actionId, $id] = Toolkit::filter([$actionId, $id])->string()->trim();
+
+        Toolkit::assert([
+            [$actionId, \Auth0\SDK\Exception\ArgumentException::missing('actionId')],
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('post')
+            ->addPath('actions', $actionId, 'versions', $id, 'deploy')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve the set of triggers currently available within actions. A trigger is an extensibility point to which actions can be bound.
+     * Required scope: `read:actions`
+     *
+     * @param RequestOptions|null $options   Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_triggers
+     */
+    public function getTriggers(
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', 'triggers')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Retrieve the actions that are bound to a trigger. Once an action is created and deployed, it must be attached (i.e. bound) to a trigger so that it will be executed as part of a flow. The list of actions returned reflects the order in which they will be executed during the appropriate flow.
+     * Required scope: `read:actions`
+     *
+     * @param string              $triggerId An actions extensibility point.
+     * @param RequestOptions|null $options   Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_bindings
+     */
+    public function getTriggerBindings(
+        string $triggerId,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$triggerId] = Toolkit::filter([$triggerId])->string()->trim();
+
+        Toolkit::assert([
+            [$triggerId, \Auth0\SDK\Exception\ArgumentException::missing('triggerId')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', 'triggers', $triggerId, 'bindings')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Update the actions that are bound (i.e. attached) to a trigger. Once an action is created and deployed, it must be attached (i.e. bound) to a trigger so that it will be executed as part of a flow. The order in which the actions are provided will determine the order in which they are executed.
+     * Required scope: `update:actions`
+     *
+     * @param string              $triggerId An actions extensibility point.
+     * @param array<mixed>        $body      Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options   Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/patch_bindings
+     */
+    public function updateTriggerBindings(
+        string $triggerId,
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$triggerId] = Toolkit::filter([$triggerId])->string()->trim();
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$triggerId, \Auth0\SDK\Exception\ArgumentException::missing('triggerId')],
+        ])->isString();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('patch')
+            ->addPath('actions', 'triggers', $triggerId, 'bindings')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Get information about a specific execution of a trigger. Relevant execution IDs will be included in tenant logs generated as part of that authentication flow. Executions will only be stored for 10 days after their creation.
+     * Required scope: `read:actions`
+     *
+     * @param string              $id      Execution (by it's ID) to retrieve.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Actions/get_execution
+     */
+    public function getExecution(
+        string $id,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('actions', 'executions', $id)
+            ->withOptions($options)
+            ->call();
+    }
+}

--- a/tests/Unit/API/Management/ActionsTest.php
+++ b/tests/Unit/API/Management/ActionsTest.php
@@ -1,0 +1,492 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Request\FilteredRequest;
+use Auth0\SDK\Utility\Request\PaginatedRequest;
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\Tests\Utilities\MockManagementApi;
+
+uses()->group('management', 'actions');
+
+beforeEach(function(): void {
+    $this->sdk = new MockManagementApi();
+
+    $this->filteredRequest = new FilteredRequest();
+    $this->paginatedRequest = new PaginatedRequest();
+    $this->requestOptions = new RequestOptions(
+        $this->filteredRequest,
+        $this->paginatedRequest
+    );
+
+    $this->endpoint = $this->sdk->mock()->actions();
+});
+
+test('create() issues valid requests', function(array $body): void {
+    $this->endpoint->create($body);
+
+    $this->assertEquals('POST', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+
+    $request = $this->sdk->getRequestBody();
+    $this->assertArrayHasKey('name', $request);
+    $this->assertArrayHasKey('supported-triggers', $request);
+
+    $this->assertEquals('my-action', $request['name']);
+    $this->assertIsArray($request['supported-triggers']);
+
+    $request = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals('{"name":"my-action","supported-triggers":[{"id":"post-login","version":"v2"}],"code":"module.exports = () => {}","dependencies":[{"name":"lodash","version":"1.0.0"}],"runtime":"node12","secrets":[{"name":"mySecret","value":"mySecretValue"}]}', $request);
+})->with(['valid body' => [
+    fn() => [
+        'name' => 'my-action',
+        'supported-triggers' => [
+            (object) [
+                'id' => 'post-login',
+                'version' => 'v2'
+            ],
+        ],
+        'code' => 'module.exports = () => {}',
+        'dependencies' => [
+            (object) [
+                'name' => 'lodash',
+                'version' => '1.0.0'
+            ],
+        ],
+        'runtime' => 'node12',
+        'secrets' => [
+            (object) [
+                'name' => 'mySecret',
+                'value' => 'mySecretValue'
+            ]
+        ]
+    ]
+]]);
+
+test('create() throws an error with an empty body', function(array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+    $this->endpoint->create($body);
+})->with(['empty body' => [
+    fn() => []
+]]);
+
+test('getAll() issues valid requests', function(): void {
+    $this->endpoint->getAll();
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+});
+
+test('getAll() issues valid requests using parameters', function(array $parameters): void {
+    $this->endpoint->getAll($parameters);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
+    $this->assertStringContainsString('&triggerId=' . $parameters['triggerId'], $this->sdk->getRequestQuery());
+    $this->assertStringContainsString('&actionName=' . $parameters['actionName'], $this->sdk->getRequestQuery());
+})->with(['valid parameters' => [
+    fn() => [
+        'triggerId' => uniqid(),
+        'actionName' => uniqid()
+    ]
+]]);
+
+test('get() issues valid requests', function(string $id): void {
+    $this->endpoint->get($id);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+})->with(['valid id' => [
+    fn() => uniqid()
+]]);
+
+test('get() throws an error with an empty id', function(string $id): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->get($id);
+})->with(['empty id' => [
+    fn() => ''
+]]);
+
+test('update() issues valid requests', function(string $id, array $body): void {
+    $this->endpoint->update($id, $body);
+
+    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+
+    $request = $this->sdk->getRequestBody();
+    $this->assertArrayHasKey('name', $request);
+    $this->assertArrayHasKey('supported-triggers', $request);
+
+    $this->assertEquals('my-action', $request['name']);
+    $this->assertIsArray($request['supported-triggers']);
+
+    $request = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals('{"name":"my-action","supported-triggers":[{"id":"post-login","version":"v2"}],"code":"module.exports = () => {}","dependencies":[{"name":"lodash","version":"1.0.0"}],"runtime":"node12","secrets":[{"name":"mySecret","value":"mySecretValue"}]}', $request);
+})->with(['valid request' => [
+    fn() => uniqid(),
+    fn() => [
+        'name' => 'my-action',
+        'supported-triggers' => [
+            (object) [
+                'id' => 'post-login',
+                'version' => 'v2'
+            ],
+        ],
+        'code' => 'module.exports = () => {}',
+        'dependencies' => [
+            (object) [
+                'name' => 'lodash',
+                'version' => '1.0.0'
+            ],
+        ],
+        'runtime' => 'node12',
+        'secrets' => [
+            (object) [
+                'name' => 'mySecret',
+                'value' => 'mySecretValue'
+            ]
+        ]
+    ]
+]]);
+
+test('update() throws an error with an empty id', function(string $id, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->update($id, $body);
+})->with(['invalid request' => [
+    fn() => '',
+    fn() => [
+        'name' => 'my-action',
+        'supported-triggers' => [
+            (object) [
+                'id' => 'post-login',
+                'version' => 'v2'
+            ],
+        ],
+        'code' => 'module.exports = () => {}',
+        'dependencies' => [
+            (object) [
+                'name' => 'lodash',
+                'version' => '1.0.0'
+            ],
+        ],
+        'runtime' => 'node12',
+        'secrets' => [
+            (object) [
+                'name' => 'mySecret',
+                'value' => 'mySecretValue'
+            ]
+        ]
+    ]
+]]);
+
+test('update() throws an error with an empty body', function(string $id, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+    $this->endpoint->update($id, $body);
+})->with(['invalid request' => [
+    fn() => uniqid(),
+    fn() => []
+]]);
+
+test('delete() issues valid requests', function(string $id, ?bool $force): void {
+    $this->endpoint->delete($id, $force);
+
+    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
+})->with(['valid id' => [
+    fn() => uniqid(),
+    fn() => null
+]]);
+
+test('delete() issues valid requests when using optional ?force parameter', function(string $id, ?bool $force): void {
+    $this->endpoint->delete($id, $force);
+
+    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertStringContainsString('&force=false', $this->sdk->getRequestQuery());
+})->with(['valid id and force=false' => [
+    fn() => uniqid(),
+    fn() => false
+]]);
+
+test('delete() throws an error with an empty id', function(string $id, ?bool $force): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->delete($id, $force);
+})->with(['empty id' => [
+    fn() => '',
+    fn() => null
+]]);
+
+test('deploy() issues valid requests', function(string $id): void {
+    $this->endpoint->deploy($id);
+
+    $this->assertEquals('POST', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/' . $id . '/deploy', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+})->with(['valid id' => [
+    fn() => uniqid()
+]]);
+
+test('deploy() throws an error with an empty id', function(string $id): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->deploy($id);
+})->with(['empty id' => [
+    fn() => ''
+]]);
+
+test('test() issues valid requests', function(string $id, array $body): void {
+    $this->endpoint->test($id, $body);
+
+    $this->assertEquals('POST', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id . '/test', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+
+    $request = $this->sdk->getRequestBody();
+    $this->assertArrayHasKey('payload', $request);
+    $this->assertIsArray($request['payload']);
+    $this->assertArrayHasKey('test', $request['payload'][0]);
+    $this->assertEquals($body['payload'][0]->test, $request['payload'][0]['test']);
+
+    $request = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals('{"payload":[{"test":"' . $body['payload'][0]->test . '"}]}', $request);
+})->with(['valid request' => [
+    fn() => uniqid(),
+    fn() => [
+        'payload' => [
+            (object) [
+                'test' => uniqid(),
+            ],
+        ],
+    ]
+]]);
+
+test('test() throws an error with an empty id', function(string $id, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->test($id, $body);
+})->with(['empty id' => [
+    fn() => '',
+    fn() => [
+        'payload' => [
+            (object) [
+                'test' => uniqid(),
+            ],
+        ],
+    ]
+]]);
+
+test('test() throws an error with an empty body', function(string $id, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+    $this->endpoint->test($id, $body);
+})->with(['empty body' => [
+    fn() => uniqid(),
+    fn() => []
+]]);
+
+test('getVersion() issues valid requests', function(string $id, string $actionId): void {
+    $this->endpoint->getVersion($id, $actionId);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id, $this->sdk->getRequestUrl());
+})->with(['valid id' => [
+    fn() => uniqid(),
+    fn() => uniqid()
+]]);
+
+test('getVersion() throws an error with an empty id', function(string $id, string $actionId): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getVersion($id, $actionId);
+})->with(['empty id' => [
+    fn() => '',
+    fn() => uniqid()
+]]);
+
+test('getVersion() throws an error with an empty action id', function(string $id, string $actionId): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
+
+    $this->endpoint->getVersion($id, $actionId);
+})->with(['empty action id' => [
+    fn() => uniqid(),
+    fn() => ''
+]]);
+
+test('getVersions() issues valid requests', function(string $actionId): void {
+    $this->endpoint->getVersions($actionId);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions', $this->sdk->getRequestUrl());
+})->with(['valid action id' => [
+    fn() => uniqid()
+]]);
+
+test('getVersions() throws an error with an empty action id', function(string $actionId): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
+
+    $this->endpoint->getVersions($actionId);
+})->with(['empty action id' => [
+    fn() => ''
+]]);
+
+test('rollbackVersion() issues valid requests', function(string $id, string $actionId): void {
+    $this->endpoint->rollbackVersion($id, $actionId);
+
+    $this->assertEquals('POST', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id . '/deploy', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+})->with(['valid request' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
+
+test('rollbackVersion() throws an error with an empty id', function(string $id, string $actionId): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->rollbackVersion($id, $actionId);
+})->with(['empty id' => [
+    fn() => '',
+    fn() => uniqid(),
+]]);
+
+test('rollbackVersion() throws an error with an action id', function(string $id, string $actionId): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
+
+    $this->endpoint->rollbackVersion($id, $actionId);
+})->with(['empty action id' => [
+    fn() => uniqid(),
+    fn() => '',
+]]);
+
+test('getTriggers() issues valid requests', function(): void {
+    $this->endpoint->getTriggers();
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+});
+
+test('getTriggerBindings() issues valid requests', function(string $triggerId): void {
+    $this->endpoint->getTriggerBindings($triggerId);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+})->with(['valid trigger id' => [
+    fn() => uniqid(),
+]]);
+
+test('updateTriggerBindings() issues valid requests', function(string $triggerId, array $body): void {
+    $this->endpoint->updateTriggerBindings($triggerId, $body);
+
+    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+
+    $request = $this->sdk->getRequestBody();
+    $this->assertArrayHasKey('bindings', $request);
+    $this->assertIsArray($request['bindings']);
+    $this->assertArrayHasKey('ref', $request['bindings'][0]);
+    $this->assertEquals($body['bindings'][0]->ref->value, $request['bindings'][0]['ref']['value']);
+
+    $request = $this->sdk->getRequestBodyAsString();
+    $this->assertEquals('{"bindings":[{"ref":{"type":"action_name","value":"my-action"},"display_name":"First Action"},{"ref":{"type":"action_id","value":"a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd"},"display_name":"Second Action"}]}', $request);
+})->with(['valid request' => [
+    fn() => uniqid(),
+    fn() => [
+        'bindings' => [
+            (object) [
+                'ref' => (object) [
+                    'type' => 'action_name',
+                    'value' => 'my-action',
+                ],
+                'display_name' => 'First Action',
+            ],
+            (object) [
+                'ref' => (object) [
+                    'type' => 'action_id',
+                    'value' => 'a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd',
+                ],
+                'display_name' => 'Second Action',
+            ],
+        ],
+    ]
+]]);
+
+test('updateTriggerBindings() throws an error with an empty trigger id', function(string $triggerId, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'triggerId'));
+
+    $this->endpoint->updateTriggerBindings($triggerId, $body);
+})->with(['empty id' => [
+    fn() => '',
+    fn() => [
+        'bindings' => [
+            (object) [
+                'ref' => (object) [
+                    'type' => 'action_name',
+                    'value' => 'my-action',
+                ],
+                'display_name' => 'First Action',
+            ],
+            (object) [
+                'ref' => (object) [
+                    'type' => 'action_id',
+                    'value' => 'a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd',
+                ],
+                'display_name' => 'Second Action',
+            ],
+        ],
+    ]
+]]);
+
+test('updateTriggerBindings() throws an error with an empty body', function(string $triggerId, array $body): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+    $this->endpoint->updateTriggerBindings($triggerId, $body);
+})->with(['empty id' => [
+    fn() => uniqid(),
+    fn() => [],
+]]);
+
+test('getExecution() issues valid requests', function(string $id): void {
+    $this->endpoint->getExecution($id);
+
+    $this->assertEquals('GET', $this->sdk->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/executions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEmpty($this->sdk->getRequestQuery());
+})->with(['valid id' => [
+    fn() => uniqid()
+]]);
+
+test('getExecution() throws an error with an empty id', function(string $id): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getExecution($id);
+})->with(['valid trigger id' => [
+    fn() => '',
+]]);


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR adds support for the [Actions API endpoints](https://auth0.com/docs/api/management/v2#!/Actions/get_actions) to the Management SDK, and includes new tests to cover the new class methods. Coverage is at 100% for these additions.

```zsh
Tests:  355 passed
Time:   2.02s

API/Management/Actions  ...................................... 100.0 %
```

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Please see internal ticket 2653 for additional details on this.

### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->
- Please run either `composer run tests` to invoke tests locally, or `composer run tests:docker` to run them containerized. - To run the new Actions API tests exclusively, `./vendor/bin/pest --group actions` will only run the related unit tests.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
