### PR TITLE
[SDK-2752] Expand test coverage and finish migration to Pest framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
   "require-dev": {
     "ergebnis/phpstan-rules": "^0.15",
     "firebase/php-jwt": "^5.0",
+    "hyperf/event": "^2.2",
     "infection/infection": "^0.23",
     "mockery/mockery": "^1.4",
     "nunomaduro/phpinsights": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "psr/http-factory-implementation": "^1.0"
   },
   "require-dev": {
-    "symfony/cache": "^4.4 || ^5.2",
     "ergebnis/phpstan-rules": "^0.15",
     "firebase/php-jwt": "^5.0",
     "infection/infection": "^0.23",
@@ -51,9 +50,11 @@
     "nunomaduro/phpinsights": "^2.0",
     "nyholm/psr7": "^1.4",
     "pestphp/pest": "^1.0",
+    "pestphp/pest-plugin-parallel": "^0.2.0",
     "php-http/mock-client": "^1.4",
     "phpstan/phpstan": "^0.12",
     "phpstan/phpstan-strict-rules": "^0.12",
+    "symfony/cache": "^4.4 || ^5.2",
     "thecodingmachine/phpstan-strict-rules": "^0.12",
     "vimeo/psalm": "^4.7"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,89 +1,89 @@
 {
-    "name": "auth0/auth0-php",
-    "description": "Auth0 PHP SDK. Straight-forward and tested methods for accessing Auth0 Authentication and Management API endpoints.",
-    "type": "library",
-    "keywords": [
-        "auth0",
-        "authentication",
-        "authorization",
-        "login",
-        "auth",
-        "jwt",
-        "json web token",
-        "jwk",
-        "json web key",
-        "oauth",
-        "openid",
-        "secure",
-        "protect",
-        "api"
-    ],
-    "homepage": "https://github.com/auth0/auth0-PHP",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Auth0",
-            "email": "support@auth0.com",
-            "homepage": "https://auth0.com/"
-        }
-    ],
-    "require": {
-        "php": "^7.4 || ^8.0",
-        "ext-filter": "*",
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "ext-openssl": "*",
-        "php-http/discovery": "^1.0",
-        "php-http/httplug": "^2.2",
-        "php-http/multipart-stream-builder": "^1.1",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "psr/event-dispatcher": "^1.0",
-        "psr/http-client-implementation": "^1.0",
-        "psr/http-factory-implementation": "^1.0",
-        "psr/http-message-implementation": "^1.0"
-    },
-    "require-dev": {
-        "ergebnis/phpstan-rules": "^0.15",
-        "firebase/php-jwt": "^5.0",
-        "infection/infection": "^0.23",
-        "mockery/mockery": "^1.4",
-        "nunomaduro/phpinsights": "^2.0",
-        "nyholm/psr7": "^1.4",
-        "pestphp/pest": "^1.0",
-        "pestphp/pest-plugin-parallel": "^0.2.0",
-        "php-http/mock-client": "^1.4",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-strict-rules": "^0.12",
-        "symfony/cache": "^4.4 || ^5.2",
-        "thecodingmachine/phpstan-strict-rules": "^0.12",
-        "vimeo/psalm": "^4.7"
-    },
-    "autoload": {
-        "psr-4": {
-            "Auth0\\SDK\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Auth0\\Tests\\": "tests/"
-        }
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "sort-packages": true
-    },
-    "scripts": {
-        "tests:docker": "docker compose run --rm tests",
-        "tests": [
-            "@tests:phpinsights",
-            "@tests:phpstan",
-            "@tests:psalm",
-            "@tests:pest"
-        ],
-        "tests:phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
-        "tests:phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
-        "tests:psalm": "@php ./vendor/bin/psalm",
-        "tests:pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
-        "tests:infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest"
+  "name": "auth0/auth0-php",
+  "description": "Auth0 PHP SDK. Straight-forward and tested methods for accessing Auth0 Authentication and Management API endpoints.",
+  "type": "library",
+  "keywords": [
+    "auth0",
+    "authentication",
+    "authorization",
+    "login",
+    "auth",
+    "jwt",
+    "json web token",
+    "jwk",
+    "json web key",
+    "oauth",
+    "openid",
+    "secure",
+    "protect",
+    "api"
+  ],
+  "homepage": "https://github.com/auth0/auth0-PHP",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Auth0",
+      "email": "support@auth0.com",
+      "homepage": "https://auth0.com/"
     }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0",
+    "ext-filter": "*",
+    "ext-json": "*",
+    "ext-mbstring": "*",
+    "ext-openssl": "*",
+    "php-http/discovery": "^1.0",
+    "php-http/httplug": "^2.2",
+    "php-http/multipart-stream-builder": "^1.1",
+    "psr/cache": "^1.0 || ^2.0 || ^3.0",
+    "psr/event-dispatcher": "^1.0",
+    "psr/http-client-implementation": "^1.0",
+    "psr/http-factory-implementation": "^1.0",
+    "psr/http-message-implementation": "^1.0"
+  },
+  "require-dev": {
+    "ergebnis/phpstan-rules": "^0.15",
+    "firebase/php-jwt": "^5.0",
+    "infection/infection": "^0.23",
+    "mockery/mockery": "^1.4",
+    "nunomaduro/phpinsights": "^2.0",
+    "nyholm/psr7": "^1.4",
+    "pestphp/pest": "^1.0",
+    "pestphp/pest-plugin-parallel": "^0.2.0",
+    "php-http/mock-client": "^1.4",
+    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan-strict-rules": "^0.12",
+    "symfony/cache": "^4.4 || ^5.2",
+    "thecodingmachine/phpstan-strict-rules": "^0.12",
+    "vimeo/psalm": "^4.7"
+  },
+  "autoload": {
+    "psr-4": {
+      "Auth0\\SDK\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Auth0\\Tests\\": "tests/"
+    }
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "sort-packages": true
+  },
+  "scripts": {
+    "tests:docker": "docker compose run --rm tests",
+    "tests": [
+      "@tests:phpinsights",
+      "@tests:phpstan",
+      "@tests:psalm",
+      "@tests:pest"
+    ],
+    "tests:phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
+    "tests:phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
+    "tests:psalm": "@php ./vendor/bin/psalm",
+    "tests:pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
+    "tests:infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,89 +1,89 @@
 {
-  "name": "auth0/auth0-php",
-  "description": "Auth0 PHP SDK. Straight-forward and tested methods for accessing Auth0 Authentication and Management API endpoints.",
-  "type": "library",
-  "keywords": [
-    "auth0",
-    "authentication",
-    "authorization",
-    "login",
-    "auth",
-    "jwt",
-    "json web token",
-    "jwk",
-    "json web key",
-    "oauth",
-    "openid",
-    "secure",
-    "protect",
-    "api"
-  ],
-  "homepage": "https://github.com/auth0/auth0-PHP",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Auth0",
-      "email": "support@auth0.com",
-      "homepage": "https://auth0.com/"
-    }
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ext-filter": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-openssl": "*",
-    "php-http/discovery": "^1.0",
-    "php-http/httplug": "^2.2",
-    "php-http/multipart-stream-builder": "^1.1",
-    "psr/cache": "^1.0 || ^2.0 || ^3.0",
-    "psr/event-dispatcher": "^1.0",
-    "psr/http-client-implementation": "^1.0",
-    "psr/http-factory-implementation": "^1.0",
-    "psr/http-message-implementation": "^1.0"
-  },
-  "require-dev": {
-    "ergebnis/phpstan-rules": "^0.15",
-    "firebase/php-jwt": "^5.0",
-    "infection/infection": "^0.23",
-    "mockery/mockery": "^1.4",
-    "nunomaduro/phpinsights": "^2.0",
-    "nyholm/psr7": "^1.4",
-    "pestphp/pest": "^1.0",
-    "pestphp/pest-plugin-parallel": "^0.2.0",
-    "php-http/mock-client": "^1.4",
-    "phpstan/phpstan": "^0.12",
-    "phpstan/phpstan-strict-rules": "^0.12",
-    "symfony/cache": "^4.4 || ^5.2",
-    "thecodingmachine/phpstan-strict-rules": "^0.12",
-    "vimeo/psalm": "^4.7"
-  },
-  "autoload": {
-    "psr-4": {
-      "Auth0\\SDK\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Auth0\\Tests\\": "tests/"
-    }
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "sort-packages": true
-  },
-  "scripts": {
-    "tests:docker": "docker compose run --rm tests",
-    "tests": [
-      "@tests:phpinsights",
-      "@tests:phpstan",
-      "@tests:psalm",
-      "@tests:pest"
+    "name": "auth0/auth0-php",
+    "description": "Auth0 PHP SDK. Straight-forward and tested methods for accessing Auth0 Authentication and Management API endpoints.",
+    "type": "library",
+    "keywords": [
+        "auth0",
+        "authentication",
+        "authorization",
+        "login",
+        "auth",
+        "jwt",
+        "json web token",
+        "jwk",
+        "json web key",
+        "oauth",
+        "openid",
+        "secure",
+        "protect",
+        "api"
     ],
-    "tests:phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
-    "tests:phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
-    "tests:psalm": "@php ./vendor/bin/psalm",
-    "tests:pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
-    "tests:infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest"
-  }
+    "homepage": "https://github.com/auth0/auth0-PHP",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Auth0",
+            "email": "support@auth0.com",
+            "homepage": "https://auth0.com/"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-filter": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "php-http/discovery": "^1.0",
+        "php-http/httplug": "^2.2",
+        "php-http/multipart-stream-builder": "^1.1",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "psr/event-dispatcher": "^1.0",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
+        "psr/http-message-implementation": "^1.0"
+    },
+    "require-dev": {
+        "ergebnis/phpstan-rules": "^0.15",
+        "firebase/php-jwt": "^5.0",
+        "infection/infection": "^0.23",
+        "mockery/mockery": "^1.4",
+        "nunomaduro/phpinsights": "^2.0",
+        "nyholm/psr7": "^1.4",
+        "pestphp/pest": "^1.0",
+        "pestphp/pest-plugin-parallel": "^0.2.0",
+        "php-http/mock-client": "^1.4",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "symfony/cache": "^4.4 || ^5.2",
+        "thecodingmachine/phpstan-strict-rules": "^0.12",
+        "vimeo/psalm": "^4.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Auth0\\SDK\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Auth0\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    },
+    "scripts": {
+        "tests:docker": "docker compose run --rm tests",
+        "tests": [
+            "@tests:phpinsights",
+            "@tests:phpstan",
+            "@tests:psalm",
+            "@tests:pest"
+        ],
+        "tests:phpinsights": "@php ./vendor/bin/phpinsights -v --no-interaction",
+        "tests:phpstan": "@php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M",
+        "tests:psalm": "@php ./vendor/bin/psalm",
+        "tests:pest": "@php ./vendor/bin/pest --stop-on-failure --coverage",
+        "tests:infection": "@php ./vendor/bin/infection --threads=4 --test-framework=pest"
+    }
 }

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -50,7 +50,7 @@ return [
                 'src/Configuration/SdkConfiguration.php',
                 'src/Configuration/SdkState.php',
                 'src/Store/SessionStore.php',
-                'src/Store/InMemoryStorage.php',
+                'src/Store/MemoryStore.php',
                 'src/Store/Psr6Store.php',
             ],
         ],

--- a/src/API/Management/ManagementEndpoint.php
+++ b/src/API/Management/ManagementEndpoint.php
@@ -43,7 +43,7 @@ abstract class ManagementEndpoint
      */
     final public function getLastRequest(): ?HttpRequest
     {
-        return $this->httpClient->getLastRequest();
+        return $this->getHttpClient()->getLastRequest();
     }
 
     /**
@@ -51,6 +51,6 @@ abstract class ManagementEndpoint
      */
     final public function getResponsePaginator(): HttpResponsePaginator
     {
-        return new HttpResponsePaginator($this->httpClient);
+        return new HttpResponsePaginator($this->getHttpClient());
     }
 }

--- a/src/API/Management/Tenants.php
+++ b/src/API/Management/Tenants.php
@@ -26,7 +26,7 @@ final class Tenants extends ManagementEndpoint
      *
      * @link https://auth0.com/docs/api/management/v2#!/Tenants/tenant_settings_route
      */
-    public function get(
+    public function getSettings(
         ?RequestOptions $options = null
     ): ResponseInterface {
         return $this->getHttpClient()
@@ -48,15 +48,15 @@ final class Tenants extends ManagementEndpoint
      *
      * @link https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings
      */
-    public function update(
+    public function updateSettings(
         array $body,
         ?RequestOptions $options = null
     ): ResponseInterface {
-        [$body] = Toolkit::filter([$body])->string()->trim();
+        [$body] = Toolkit::filter([$body])->array()->trim();
 
         Toolkit::assert([
             [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
-        ])->isString();
+        ])->isArray();
 
         return $this->getHttpClient()
             ->method('patch')

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -166,8 +166,7 @@ final class Auth0
     public function handleInvitation(
         ?string $redirectUrl = null,
         ?array $params = null
-    ): ?string
-    {
+    ): ?string {
         $invite = $this->getInvitationParameters();
 
         if ($invite !== null) {
@@ -207,8 +206,7 @@ final class Auth0
      */
     public function clear(
         bool $transient = true
-    ): self
-    {
+    ): self {
         $sessionStorage = $this->configuration()->getSessionStorage();
         $transientStorage = $this->configuration()->getTransientStorage();
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -152,6 +152,35 @@ final class Auth0
     }
 
     /**
+     * If invitation parameters are present in the request, handle extraction and return a URL for redirection to Universal Login to accept. Returns null if no invitation parameters were found.
+     *
+     * @param string|null                 $redirectUrl Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.
+     * @param array<int|string|null>|null $params Additional parameters to include with the request.
+     *
+     * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
+     * @throws \Auth0\SDK\Exception\ConfigurationException When `redirectUri` is not specified, and supplied SdkConfiguration does not have a default redirectUri configured.
+     *
+     * @link https://auth0.com/docs/universal-login/new-experience
+     * @link https://auth0.com/docs/api/authentication#login
+     */
+    public function handleInvitation(
+        ?string $redirectUrl = null,
+        ?array $params = null
+    ): ?string
+    {
+        $invite = $this->getInvitationParameters();
+
+        if ($invite !== null) {
+            return $this->login($redirectUrl, Toolkit::merge([
+                'invitation' => (string) $invite->invitation,
+                'organization' => (string) $invite->organization,
+            ], $params));
+        }
+
+        return null;
+    }
+
+    /**
      * Delete any persistent data and clear out all stored properties, and return the URI to Auth0 /logout endpoint for redirection.
      *
      * @param string|null                 $returnUri Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.
@@ -173,8 +202,12 @@ final class Auth0
 
     /**
      * Delete any persistent data and clear out all stored properties.
+     *
+     * @oaram bool $transient When true, data in transient storage is also cleared.
      */
-    public function clear(): self
+    public function clear(
+        bool $transient = true
+    ): self
     {
         $sessionStorage = $this->configuration()->getSessionStorage();
         $transientStorage = $this->configuration()->getTransientStorage();
@@ -183,7 +216,7 @@ final class Auth0
             $sessionStorage->deleteAll();
         }
 
-        if ($transientStorage !== null) {
+        if ($transientStorage !== null && $transient === true) {
             $transientStorage->deleteAll();
         }
 
@@ -268,6 +301,8 @@ final class Auth0
             return false;
         }
 
+        $this->clear(false);
+
         if ($state === null || ! $this->getTransientStore()->verify('state', $state)) {
             $this->clear();
             throw \Auth0\SDK\Exception\StateException::invalidState();
@@ -279,10 +314,6 @@ final class Auth0
             if ($codeVerifier === null) {
                 throw \Auth0\SDK\Exception\StateException::missingCodeVerifier();
             }
-        }
-
-        if ($this->getState()->hasUser()) {
-            $this->clear();
         }
 
         $response = $this->authentication()->codeExchange($code, $redirectUri, $codeVerifier);
@@ -609,18 +640,20 @@ final class Auth0
      * Get the specified parameter from POST or GET, depending on configured response mode.
      *
      * @param string $parameterName Name of the parameter to pull from the request.
+     * @param int $filter Defaults to FILTER_SANITIZE_STRING. The type of PHP filter_var() filter to apply.
      */
     public function getRequestParameter(
-        string $parameterName
+        string $parameterName,
+        int $filter = FILTER_SANITIZE_STRING
     ): ?string {
         $responseMode = $this->configuration()->getResponseMode();
 
         if ($responseMode === 'query' && isset($_GET[$parameterName])) {
-            return filter_var($_GET[$parameterName], FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE);
+            return filter_var($_GET[$parameterName], $filter, FILTER_NULL_ON_FAILURE);
         }
 
         if ($responseMode === 'form_post' && isset($_POST[$parameterName])) {
-            return filter_var($_POST[$parameterName], FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE);
+            return filter_var($_POST[$parameterName], $filter, FILTER_NULL_ON_FAILURE);
         }
 
         return null;
@@ -644,23 +677,6 @@ final class Auth0
         }
 
         return null;
-    }
-
-    /**
-     * If invitation parameters are present in the request, handle extraction and automatically redirect to Universal Login.
-     */
-    public function handleInvitation(): self
-    {
-        $invite = $this->getInvitationParameters();
-
-        if ($invite !== null) {
-            $this->login(null, [
-                'invitation' => (string) $invite->invitation,
-                'organization' => (string) $invite->organization,
-            ]);
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -343,6 +343,8 @@ final class SdkConfiguration implements ConfigurableContract
      * Setup SDK factories.
      *
      * @throws NotFoundException When a PSR-18 or PSR-17 are not configured, and cannot be discovered.
+     *
+     * @codeCoverageIgnore
      */
     private function setupStateFactories(): void
     {
@@ -440,20 +442,6 @@ final class SdkConfiguration implements ConfigurableContract
             throw \Auth0\SDK\Exception\ConfigurationException::invalidAlgorithm();
         }
 
-        if ($propertyName === 'tokenMaxAge' || $propertyName === 'tokenLeeway') {
-            if (is_int($propertyValue)) {
-                // Value was passed as an int, perfect.
-                return $propertyValue;
-            }
-
-            if (is_numeric($propertyValue)) {
-                // Value was passed as a string, but it is numeric so cast to int.
-                return (int) $propertyValue;
-            }
-
-            throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
-        }
-
         if (in_array($propertyName, ['organization', 'audience'], true)) {
             if (is_array($propertyValue) && count($propertyValue) !== 0) {
                 return $propertyValue;
@@ -463,19 +451,6 @@ final class SdkConfiguration implements ConfigurableContract
         }
 
         return $propertyValue;
-    }
-
-    /**
-     * Fires when a validation event fails to pass, such as a bad parameter type being used.
-     *
-     * @param string      $parameter The name of the parameter that failed validation.
-     *
-     * @throws ConfigurationException When invoked.
-     */
-    private function onValidationException(
-        string $parameter
-    ): void {
-        throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($parameter);
     }
 
     /**

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -227,6 +227,14 @@ trait ConfigurableMixin
         string $propertyName,
         $propertyValue
     ): void {
+        if ($this->configurationImmutable) {
+            throw \Auth0\SDK\Exception\ConfigurationException::setImmutable();
+        }
+
+        if (! isset($this->configuredState[$propertyName])) {
+            throw \Auth0\SDK\Exception\ConfigurationException::setMissing($propertyName);
+        }
+
         $propertyType = gettype($propertyValue);
 
         $normalizedPropertyTypes = [
@@ -235,14 +243,6 @@ trait ConfigurableMixin
         ];
 
         $propertyType = $normalizedPropertyTypes[$propertyType] ?? $propertyType;
-
-        if ($this->configurationImmutable) {
-            throw \Auth0\SDK\Exception\ConfigurationException::setImmutable();
-        }
-
-        if (! isset($this->configuredState[$propertyName])) {
-            throw \Auth0\SDK\Exception\ConfigurationException::setMissing($propertyName);
-        }
 
         $allowedTypes = [$this->configuredState[$propertyName]->type];
         $expectedType = $this->configuredState[$propertyName]->type;

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -69,7 +69,12 @@ trait ConfigurableMixin
                     $arguments[0] = [ $arguments[0] ];
                 }
 
-                $arguments = array_filter(Toolkit::filter($arguments)->array()->trim(), static function ($val) { return ($val !== null && count($val) !== 0); });
+                $arguments = array_filter(
+                    Toolkit::filter($arguments)->array()->trim(),
+                    static function ($val): bool {
+                        return $val !== null && count($val) !== 0;
+                    }
+                );
 
                 if (count($arguments) !== 0) {
                     if (is_array($this->configuredState[$propertyName]->value)) {
@@ -226,7 +231,7 @@ trait ConfigurableMixin
 
         $normalizedPropertyTypes = [
             'boolean' => 'bool',
-            'integer' => 'int'
+            'integer' => 'int',
         ];
 
         $propertyType = $normalizedPropertyTypes[$propertyType] ?? $propertyType;
@@ -246,7 +251,7 @@ trait ConfigurableMixin
             $allowedTypes[] = 'NULL';
         }
 
-        if (! in_array($propertyType, $allowedTypes)) {
+        if (! in_array($propertyType, $allowedTypes, true)) {
             if (! $propertyValue instanceof $expectedType) {
                 if ($this->configuredState[$propertyName]->allowsNull) {
                     throw \Auth0\SDK\Exception\ConfigurationException::setIncompatibleNullable($propertyName, $expectedType, $propertyType);

--- a/src/Store/MemoryStore.php
+++ b/src/Store/MemoryStore.php
@@ -11,13 +11,19 @@ use Auth0\SDK\Contract\StoreInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class InMemoryStorage implements StoreInterface
+final class MemoryStore implements StoreInterface
 {
     /**
      * @var array<string, mixed>
      */
     private array $data = [];
 
+    /**
+     * Store value in memory.
+     *
+     * @param string $key   Session key to set.
+     * @param mixed  $value Value to use.
+     */
     public function set(
         string $key,
         $value
@@ -25,6 +31,15 @@ final class InMemoryStorage implements StoreInterface
         $this->data[$key] = $value;
     }
 
+    /**
+     * Return value from memory.
+     * If the value is not set, returns $default.
+     *
+     * @param string $key     Session key to set.
+     * @param mixed  $default Default to return if nothing was found.
+     *
+     * @return mixed
+     */
     public function get(
         string $key,
         $default = null
@@ -36,17 +51,34 @@ final class InMemoryStorage implements StoreInterface
         return $default;
     }
 
+    /**
+     * Removes a value identified by $key from memory.
+     *
+     * @param string $key Key of value to remove.
+     */
     public function delete(
         string $key
     ): void {
         unset($this->data[$key]);
     }
 
+    /**
+     * Removes all stored values from memory.
+     */
     public function purge(): void
     {
         $this->data = [];
     }
 
+    /**
+     * This has no effect when using memory as a storage medium.
+     *
+     * @param bool $deferring Whether to defer persisting the storage state.
+     *
+     * @codeCoverageIgnore
+     *
+     * @phpstan-ignore-next-line
+     */
     public function defer(
         bool $deferring = true
     ): void {

--- a/src/Store/Psr6Store.php
+++ b/src/Store/Psr6Store.php
@@ -131,6 +131,8 @@ final class Psr6Store implements StoreInterface
      *
      * @param bool $deferring Whether to defer persisting the storage state.
      *
+     * @codeCoverageIgnore
+     *
      * @phpstan-ignore-next-line
      */
     public function defer(
@@ -141,6 +143,8 @@ final class Psr6Store implements StoreInterface
 
     /**
      * Generate a cryptographically-secure random string.
+     *
+     * @codeCoverageIgnore
      */
     private function generateKey(): string
     {
@@ -155,6 +159,8 @@ final class Psr6Store implements StoreInterface
 
     /**
      * Generate a cryptographically-secure random string.
+     *
+     * @codeCoverageIgnore
      */
     private function getCacheKey(): string
     {

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -51,6 +51,8 @@ final class SessionStore implements StoreInterface
      *
      * @param bool $deferring Whether to defer persisting the storage state.
      *
+     * @codeCoverageIgnore
+     *
      * @phpstan-ignore-next-line
      */
     public function defer(

--- a/src/Token.php
+++ b/src/Token.php
@@ -185,7 +185,7 @@ final class Token
         $claim = $this->parser->getClaim('aud');
 
         if (is_string($claim)) {
-            return [ $claim ];
+            $claim = [ $claim ];
         }
 
         return $claim;
@@ -202,9 +202,10 @@ final class Token
     /**
      * Get the contents of the 'auth_time' claim. Null if not present.
      */
-    public function getAuthTime(): ?string
+    public function getAuthTime(): ?int
     {
-        return $this->parser->getClaim('auth_time');
+        $response = $this->parser->getClaim('auth_time');
+        return $response === null ? null : (int) $response;
     }
 
     /**
@@ -212,7 +213,8 @@ final class Token
      */
     public function getExpiration(): ?int
     {
-        return $this->parser->getClaim('exp');
+        $response = $this->parser->getClaim('exp');
+        return $response === null ? null : (int) $response;
     }
 
     /**
@@ -220,7 +222,8 @@ final class Token
      */
     public function getIssued(): ?int
     {
-        return $this->parser->getClaim('iat');
+        $response = $this->parser->getClaim('iat');
+        return $response === null ? null : (int) $response;
     }
 
     /**

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -87,9 +87,12 @@ final class Parser
         $this->tokenClaims = $this->decodeClaims($parts[1]);
         $this->tokenSignature = $this->decodeSignature($parts[2]);
 
+        // @codeCoverageIgnoreStart
+        // This is not currently testable using our JWT encoding test libraries.
         if (! isset($this->tokenHeaders['typ'])) {
             $this->tokenHeaders['typ'] = 'JWT';
         }
+        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -181,9 +184,12 @@ final class Parser
     {
         $claims = $this->tokenClaims;
 
+        // @codeCoverageIgnoreStart
+        // This is not currently testable using our JWT encoding test libraries.
         if (! is_array($claims)) {
             return [];
         }
+        // @codeCoverageIgnoreEnd
 
         return $claims;
     }
@@ -260,6 +266,8 @@ final class Parser
      * @return array<array|int|string>|null
      *
      * @throws \JsonException When claims portion cannot be decoded properly.
+     *
+     * @codeCoverageIgnore
      */
     private function decodeClaims(
         string $claims
@@ -281,6 +289,8 @@ final class Parser
      * @return array<int|string>|null
      *
      * @throws \JsonException When headers portion cannot be decoded properly.
+     *
+     * @codeCoverageIgnore
      */
     private function decodeHeaders(
         string $headers
@@ -298,6 +308,8 @@ final class Parser
      * Decodes and returns the signature portion of a JWT as a string.
      *
      * @param string $signature String representing the signature portion of the JWT.
+     *
+     * @codeCoverageIgnore
      */
     private function decodeSignature(
         string $signature

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -66,7 +66,7 @@ final class Verifier
     /**
      * Mocked responses for HTTP requests; only used in unit tests.
      *
-     * array<object>
+     * @var array<object>
      */
     private ?array $mockedHttpResponses = null;
 
@@ -183,7 +183,8 @@ final class Verifier
         $jwksCacheKey = hash('sha256', $this->jwksUri);
         $jwksUri = parse_url($this->jwksUri);
 
-        if ($jwksCacheKey === false || ! is_array($jwksUri)) {
+        // @phpstan-ignore-next-line
+        if (! is_string($jwksCacheKey) || ! is_array($jwksUri)) {
             return [];
         }
 

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -92,6 +92,8 @@ final class HttpClient
 
     /**
      * Inject a series of Psr\Http\Message\ResponseInterface objects into created HttpRequest clients.
+     *
+     * @codeCoverageIgnore
      */
     public function mockResponse(
         ResponseInterface $response,
@@ -111,6 +113,8 @@ final class HttpClient
      * Inject a series of Psr\Http\Message\ResponseInterface objects into created HttpRequest clients.
      *
      * @param array<ResponseInterface|array> $responses An array of ResponseInterface objects, or an array of arrays containing ResponseInterfaces with callbacks.
+     *
+     * @codeCoverageIgnore
      */
     public function mockResponses(
         array $responses

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -577,6 +577,8 @@ final class HttpRequest
      * Issue a usleep() for $milliseconds, and log the delay.
      *
      * @param int $milliseconds How long, in milliseconds, to trigger a usleep() for.
+     *
+     * @codeCoverageIgnore
      */
     private function sleep(
         int $milliseconds

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -151,6 +151,8 @@ final class HttpResponsePaginator implements \Countable, \Iterator
      * Return the current result at our position, if available.
      *
      * @return array<mixed>|bool
+     *
+     * @codeCoverageIgnore
      */
     public function current()
     {
@@ -236,9 +238,11 @@ final class HttpResponsePaginator implements \Countable, \Iterator
         if ($lastBuilder !== null && $this->lastResponse() !== null) {
             // Ensure basic pagination details are included in the request.
             if ($this->usingCheckpointPagination) {
+                // @codeCoverageIgnoreStart
                 if ($this->nextCheckpoint === null) {
                     return false;
                 }
+                // @codeCoverageIgnoreEnd
 
                 $lastBuilder->withParam('from', $this->nextCheckpoint);
             } else {
@@ -263,7 +267,9 @@ final class HttpResponsePaginator implements \Countable, \Iterator
             return $this->processLastResponse();
         }
 
+        // @codeCoverageIgnoreStart
         return false;
+        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -298,10 +304,12 @@ final class HttpResponsePaginator implements \Countable, \Iterator
 
                 $start = (int) $start;
 
+                // @codeCoverageIgnoreStart
                 // No results, abort processing.
                 if (! is_array($results) || count($results) === 0) {
                     return false;
                 }
+                // @codeCoverageIgnoreEnd
 
                 $hadResults = false;
                 $nextCheckpoint = null;
@@ -358,7 +366,9 @@ final class HttpResponsePaginator implements \Countable, \Iterator
             return false;
         }
 
+        // @codeCoverageIgnoreStart
         return false;
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/Utility/HttpTelemetry.php
+++ b/src/Utility/HttpTelemetry.php
@@ -50,10 +50,12 @@ final class HttpTelemetry
     {
         $phpVersion = phpversion();
 
+        // @codeCoverageIgnoreStart
         // phpversion() can potentially return false in unusual circumstances; set PHP version to an empty string in those cases.
         if ($phpVersion === false) {
             $phpVersion = '';
         }
+        // @codeCoverageIgnoreEnd
 
         self::setPackage('auth0-php', Auth0::VERSION);
         self::setEnvProperty('php', $phpVersion);

--- a/src/Utility/PKCE.php
+++ b/src/Utility/PKCE.php
@@ -30,11 +30,13 @@ final class PKCE
         while (($len = mb_strlen($string)) < $length) {
             $size = $length - $len;
 
+            // @codeCoverageIgnoreStart
             try {
                 $bytes = random_bytes($size);
             } catch (\Exception $exception) {
                 $bytes = (string) openssl_random_pseudo_bytes($size);
             }
+            // @codeCoverageIgnoreEnd
 
             $string .= mb_substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
         }

--- a/src/Utility/Toolkit.php
+++ b/src/Utility/Toolkit.php
@@ -95,13 +95,13 @@ final class Toolkit
      * Throw an $exception or return false if any of the provided values are null.
      *
      * @param \Throwable|null $exception An exception to throw if all values are null.
-     * @param mixed           $values    One or more values to check.
+     * @param array           $values    One or more values to check.
      *
      * @throws \Throwable If there are no non-null values.
      */
     public static function every(
         ?\Throwable $exception = null,
-        ...$values
+        array $values
     ): bool {
         foreach ($values as $value) {
             if ($value === null) {
@@ -120,7 +120,7 @@ final class Toolkit
      * Throw an $exception or return false if all the provided values are null.
      *
      * @param \Throwable|null $exception An exception to throw if all values are null.
-     * @param mixed           $values    One or more values to check.
+     * @param array           $values    One or more values to check.
      *
      * @return array<mixed>|false
      *
@@ -128,7 +128,7 @@ final class Toolkit
      */
     public static function some(
         ?\Throwable $exception = null,
-        ...$values
+        array $values
     ) {
         // Trim the array of null values.
         [$trimmed] = self::filter([$values])->array()->trim();

--- a/src/Utility/Toolkit.php
+++ b/src/Utility/Toolkit.php
@@ -95,12 +95,12 @@ final class Toolkit
      * Throw an $exception or return false if any of the provided values are null.
      *
      * @param \Throwable|null $exception An exception to throw if all values are null.
-     * @param array           $values    One or more values to check.
+     * @param array<mixed>    $values    One or more values to check.
      *
      * @throws \Throwable If there are no non-null values.
      */
     public static function every(
-        ?\Throwable $exception = null,
+        ?\Throwable $exception,
         array $values
     ): bool {
         foreach ($values as $value) {
@@ -120,14 +120,14 @@ final class Toolkit
      * Throw an $exception or return false if all the provided values are null.
      *
      * @param \Throwable|null $exception An exception to throw if all values are null.
-     * @param array           $values    One or more values to check.
+     * @param array<mixed>    $values    One or more values to check.
      *
      * @return array<mixed>|false
      *
      * @throws \Throwable If there are no non-null values.
      */
     public static function some(
-        ?\Throwable $exception = null,
+        ?\Throwable $exception,
         array $values
     ) {
         // Trim the array of null values.

--- a/src/Utility/Toolkit.php
+++ b/src/Utility/Toolkit.php
@@ -56,10 +56,10 @@ final class Toolkit
      * @param \Closure $callback The function to pass each item through.
      */
     public static function each(
-        iterable $items,
+        iterable &$items,
         \Closure $callback
     ): void {
-        foreach ($items as $key => $item) {
+        foreach ($items as $key => &$item) {
             if ($callback($item, $key) === false) {
                 break;
             }
@@ -136,7 +136,7 @@ final class Toolkit
         $result = self::filter($values)->array()->trim();
 
         // All values were null, throw an exception.
-        if (count($result) === 0) {
+        if (count($result) === 0 || count($result) === 1 && is_array($result[0]) && count($result[0]) === 0) {
             if ($exception !== null) {
                 throw $exception;
             }

--- a/src/Utility/Toolkit.php
+++ b/src/Utility/Toolkit.php
@@ -103,8 +103,6 @@ final class Toolkit
         ?\Throwable $exception = null,
         ...$values
     ): bool {
-        $values = array_values($values);
-
         foreach ($values as $value) {
             if ($value === null) {
                 if ($exception !== null) {
@@ -133,10 +131,10 @@ final class Toolkit
         ...$values
     ) {
         // Trim the array of null values.
-        $result = self::filter($values)->array()->trim();
+        [$trimmed] = self::filter([$values])->array()->trim();
 
         // All values were null, throw an exception.
-        if (count($result) === 0 || count($result) === 1 && is_array($result[0]) && count($result[0]) === 0) {
+        if (count($trimmed) === 0) {
             if ($exception !== null) {
                 throw $exception;
             }
@@ -145,6 +143,6 @@ final class Toolkit
         }
 
         // Return all non-null values.
-        return $result;
+        return $trimmed;
     }
 }

--- a/src/Utility/Toolkit/Filter/ArrayFilter.php
+++ b/src/Utility/Toolkit/Filter/ArrayFilter.php
@@ -116,7 +116,7 @@ final class ArrayFilter
             $values = Toolkit::some($exception, $subject);
 
             if ($values !== false) {
-                $results[] = array_slice(current($values), 0)[0];
+                $results[] = array_slice($values, 0)[0];
                 continue;
             }
         }

--- a/src/Utility/Toolkit/Filter/ArrayFilter.php
+++ b/src/Utility/Toolkit/Filter/ArrayFilter.php
@@ -113,6 +113,10 @@ final class ArrayFilter
         $results = [];
 
         foreach ($this->subject as $subject) {
+            if (! is_array($subject) || count($subject) === 0) {
+                continue;
+            }
+
             $values = Toolkit::some($exception, $subject);
 
             if ($values !== false) {

--- a/src/Utility/TransientStoreHandler.php
+++ b/src/Utility/TransientStoreHandler.php
@@ -113,6 +113,8 @@ final class TransientStoreHandler
      * Generate a random nonce value.
      *
      * @param int $length Length of the generated value, in bytes.
+     *
+     * @codeCoverageIgnore
      */
     private function getNonce(
         int $length = 16

--- a/src/Utility/TransientStoreHandler.php
+++ b/src/Utility/TransientStoreHandler.php
@@ -39,6 +39,8 @@ final class TransientStoreHandler
      * Defer saving state changes to destination to improve performance during blocks of changes.
      *
      * @param bool $deferring Whether to defer persisting the storage state.
+     *
+     * @codeCoverageIgnore
      */
     public function defer(
         bool $deferring

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -19,4 +19,4 @@ uses()
             $this->paginatedRequest
         );
     })
-    ->in('Unit\API\Management');
+    ->in('Unit' . DIRECTORY_SEPARATOR   . 'API' . DIRECTORY_SEPARATOR . 'Management');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,22 @@
+<?php
+
+// For unit tests, use a mock network client rather than sending real requests.
+uses()
+    ->beforeAll(function(): void {
+        \Http\Discovery\Psr18ClientDiscovery::prependStrategy(\Http\Discovery\Strategy\MockClientStrategy::class);
+    })
+    ->in('Unit');
+
+// For Management SDK unit tests, configure the MockManagementApi client.
+uses()
+    ->beforeEach(function(): void {
+        $this->api = new \Auth0\Tests\Utilities\MockManagementApi();
+
+        $this->filteredRequest = new \Auth0\SDK\Utility\Request\FilteredRequest();
+        $this->paginatedRequest = new \Auth0\SDK\Utility\Request\PaginatedRequest();
+        $this->requestOptions = new \Auth0\SDK\Utility\Request\RequestOptions(
+            $this->filteredRequest,
+            $this->paginatedRequest
+        );
+    })
+    ->in('Unit\API\Management');

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 use Auth0\SDK\API\Authentication;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Http\Discovery\Psr18ClientDiscovery;
-use Http\Discovery\Strategy\MockClientStrategy;
 
 uses()->group('authentication');
 
 beforeEach(function(): void {
-    // Allow mock HttpClient to be auto-discovered for use in testing.
-    Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);
 
     $this->configuration = new SdkConfiguration([
         'domain' => 'https://test-domain.auth0.com',

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -37,107 +37,107 @@ test('__construct() accepts a configuration as an array', function(): void {
         'audience' => [uniqid()]
     ]);
 
-    $this->assertInstanceOf(Authentication::class, $auth);
+    expect($auth)->toBeInstanceOf(Authentication::class);
 });
 
 test('__construct() successfully loads an inherited configuration', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getLoginLink(uniqid());
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
 });
 
 test('__construct() successfully loads a direct configuration', function(): void {
     $class = new Authentication($this->configuration);
     $uri = $class->getLoginLink(uniqid());
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
 });
 
 test('getLoginLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getLoginLink(uniqid());
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('client_id=' . rawurlencode($this->configuration->getClientId()), $uri);
-    $this->assertStringContainsString('response_type=' . rawurlencode($this->configuration->getResponseType()), $uri);
-    $this->assertStringContainsString('redirect_uri=' . rawurlencode($this->configuration->getRedirectUri()), $uri);
-    $this->assertStringContainsString('audience=' . rawurlencode($this->configuration->defaultAudience()), $uri);
-    $this->assertStringContainsString('scope=' . rawurlencode($this->configuration->formatScope()), $uri);
-    $this->assertStringContainsString('organization=' . rawurlencode($this->configuration->defaultOrganization()), $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('client_id=' . rawurlencode($this->configuration->getClientId()));
+    expect($uri)->toContain('response_type=' . rawurlencode($this->configuration->getResponseType()));
+    expect($uri)->toContain('redirect_uri=' . rawurlencode($this->configuration->getRedirectUri()));
+    expect($uri)->toContain('audience=' . rawurlencode($this->configuration->defaultAudience()));
+    expect($uri)->toContain('scope=' . rawurlencode($this->configuration->formatScope()));
+    expect($uri)->toContain('organization=' . rawurlencode($this->configuration->defaultOrganization()));
 
     $exampleScope = uniqid();
     $uri = $class->getLoginLink(uniqid(), null, [
         'scope' => $exampleScope,
     ]);
 
-    $this->assertStringContainsString('scope=' . rawurlencode($exampleScope), $uri);
+    expect($uri)->toContain('scope=' . rawurlencode($exampleScope));
 });
 
 test('getSamlpLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getSamlpLink();
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('/samlp/' . rawurlencode($this->configuration->getClientId()) . '?', $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('/samlp/' . rawurlencode($this->configuration->getClientId()) . '?');
 
     $exampleClientId = uniqid();
     $exampleConnection = uniqid();
     $uri = $class->getSamlpLink($exampleClientId, $exampleConnection);
 
-    $this->assertStringContainsString('/samlp/' . rawurlencode($exampleClientId) . '?', $uri);
-    $this->assertStringContainsString('connection=' . rawurlencode($exampleConnection), $uri);
+    expect($uri)->toContain('/samlp/' . rawurlencode($exampleClientId) . '?');
+    expect($uri)->toContain('connection=' . rawurlencode($exampleConnection));
 });
 
 test('getSamlpMetadataLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getSamlpMetadataLink();
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('/samlp/metadata/' . rawurlencode($this->configuration->getClientId()), $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('/samlp/metadata/' . rawurlencode($this->configuration->getClientId()));
 
     $exampleClientId = uniqid();
     $uri = $class->getSamlpMetadataLink($exampleClientId);
 
-    $this->assertStringContainsString('/samlp/metadata/' . rawurlencode($exampleClientId), $uri);
+    expect($uri)->toContain('/samlp/metadata/' . rawurlencode($exampleClientId));
 });
 
 test('getWsfedLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getWsfedLink();
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('/wsfed/' . rawurlencode($this->configuration->getClientId()) . '?', $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('/wsfed/' . rawurlencode($this->configuration->getClientId()) . '?');
 
     $exampleClientId = uniqid();
     $exampleParam = uniqid();
     $uri = $class->getWsfedLink($exampleClientId, ['whr' => $exampleParam]);
 
-    $this->assertStringContainsString('/wsfed/' . rawurlencode($exampleClientId) . '?', $uri);
-    $this->assertStringContainsString('whr=' . rawurlencode($exampleParam), $uri);
+    expect($uri)->toContain('/wsfed/' . rawurlencode($exampleClientId) . '?');
+    expect($uri)->toContain('whr=' . rawurlencode($exampleParam));
 });
 
 test('getWsfedMetadataLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getWsfedMetadataLink();
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('/wsfed/FederationMetadata/2007-06/FederationMetadata.xml', $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('/wsfed/FederationMetadata/2007-06/FederationMetadata.xml');
 });
 
 test('getLogoutLink() is properly formatted', function(): void {
     $class = $this->sdk->authentication();
     $uri = $class->getLogoutLink();
 
-    $this->assertStringContainsString($this->configuration->getDomain(), $uri);
-    $this->assertStringContainsString('returnTo=' . rawurlencode($this->configuration->getRedirectUri()), $uri);
+    expect($uri)->toContain($this->configuration->getDomain());
+    expect($uri)->toContain('returnTo=' . rawurlencode($this->configuration->getRedirectUri()));
 
     $exampleReturnTo = uniqid();
     $exampleParam = uniqid();
     $uri = $class->getLogoutLink($exampleReturnTo, ['ex' => $exampleParam]);
 
-    $this->assertStringContainsString('returnTo=' . rawurlencode($exampleReturnTo), $uri);
-    $this->assertStringContainsString('ex=' . rawurlencode($exampleParam), $uri);
+    expect($uri)->toContain('returnTo=' . rawurlencode($exampleReturnTo));
+    expect($uri)->toContain('ex=' . rawurlencode($exampleParam));
 });
 
 test('passwordlessStart() throws a ConfigurationException if client secret is not configured', function(): void {
@@ -164,12 +164,12 @@ test('passwordlessStart() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody = json_decode($request->getBody()->__toString(), true);
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/passwordless/start', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/passwordless/start');
     $this->assertArrayHasKey('client_id', $requestBody);
     $this->assertArrayHasKey('client_secret', $requestBody);
-    $this->assertEquals($this->configuration->getClientId(), $requestBody['client_id']);
-    $this->assertEquals($this->configuration->getClientSecret(), $requestBody['client_secret']);
+    expect($requestBody['client_id'])->toEqual($this->configuration->getClientId());
+    expect($requestBody['client_secret'])->toEqual($this->configuration->getClientSecret());
 });
 
 test('emailPasswordlessStart() throws an ArgumentException if `email` is empty', function(): void {
@@ -207,18 +207,18 @@ test('emailPasswordlessStart() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody = json_decode($request->getBody()->__toString(), true);
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/passwordless/start', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/passwordless/start');
     $this->assertArrayHasKey('client_id', $requestBody);
     $this->assertArrayHasKey('client_secret', $requestBody);
     $this->assertArrayHasKey('connection', $requestBody);
     $this->assertArrayHasKey('email', $requestBody);
     $this->assertArrayHasKey('send', $requestBody);
-    $this->assertEquals($this->configuration->getClientId(), $requestBody['client_id']);
-    $this->assertEquals($this->configuration->getClientSecret(), $requestBody['client_secret']);
-    $this->assertEquals('email', $requestBody['connection']);
-    $this->assertEquals('someone@somewhere.somehow', $requestBody['email']);
-    $this->assertEquals('code', $requestBody['send']);
+    expect($requestBody['client_id'])->toEqual($this->configuration->getClientId());
+    expect($requestBody['client_secret'])->toEqual($this->configuration->getClientSecret());
+    expect($requestBody['connection'])->toEqual('email');
+    expect($requestBody['email'])->toEqual('someone@somewhere.somehow');
+    expect($requestBody['send'])->toEqual('code');
 });
 
 test('smsPasswordlessStart() throws an ArgumentException if `phoneNumber` is empty', function(): void {
@@ -238,16 +238,16 @@ test('smsPasswordlessStart() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody = json_decode($request->getBody()->__toString(), true);
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/passwordless/start', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/passwordless/start');
     $this->assertArrayHasKey('client_id', $requestBody);
     $this->assertArrayHasKey('client_secret', $requestBody);
     $this->assertArrayHasKey('connection', $requestBody);
     $this->assertArrayHasKey('phone_number', $requestBody);
-    $this->assertEquals($this->configuration->getClientId(), $requestBody['client_id']);
-    $this->assertEquals($this->configuration->getClientSecret(), $requestBody['client_secret']);
-    $this->assertEquals('sms', $requestBody['connection']);
-    $this->assertEquals('8675309', $requestBody['phone_number']);
+    expect($requestBody['client_id'])->toEqual($this->configuration->getClientId());
+    expect($requestBody['client_secret'])->toEqual($this->configuration->getClientSecret());
+    expect($requestBody['connection'])->toEqual('sms');
+    expect($requestBody['phone_number'])->toEqual('8675309');
 });
 
 test('userInfo() is properly formatted', function(): void {
@@ -260,10 +260,10 @@ test('userInfo() is properly formatted', function(): void {
     $requestBody = json_decode($request->getBody()->__toString(), true);
     $requestHeaders = $request->getHeaders();
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/userinfo', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/userinfo');
     $this->assertArrayHasKey('Authorization', $requestHeaders);
-    $this->assertEquals('Bearer ' . $accessToken, $requestHeaders['Authorization'][0]);
+    expect($requestHeaders['Authorization'][0])->toEqual('Bearer ' . $accessToken);
 });
 
 test('oauthToken() is properly formatted', function(): void {
@@ -276,12 +276,12 @@ test('oauthToken() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody =  explode('&', $request->getBody()->__toString());
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=authorization_code', $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
+    expect($requestBody)->toContain('grant_type=authorization_code');
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
 });
 
 test('codeExchange() is properly formatted', function(): void {
@@ -297,15 +297,15 @@ test('codeExchange() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody =  explode('&', $request->getBody()->__toString());
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=authorization_code', $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
-    $this->assertContains('code=' . $code, $requestBody);
-    $this->assertContains('redirect_uri=' . $redirect, $requestBody);
-    $this->assertContains('code_verifier=' . $verifier, $requestBody);
+    expect($requestBody)->toContain('grant_type=authorization_code');
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('code=' . $code);
+    expect($requestBody)->toContain('redirect_uri=' . $redirect);
+    expect($requestBody)->toContain('code_verifier=' . $verifier);
 });
 
 test('login() is properly formatted', function(): void {
@@ -322,15 +322,15 @@ test('login() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody =  explode('&', $request->getBody()->__toString());
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=' . urlencode('http://auth0.com/oauth/grant-type/password-realm'), $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
-    $this->assertContains('username=' . $username, $requestBody);
-    $this->assertContains('password=' . $password, $requestBody);
-    $this->assertContains('realm=' . $realm, $requestBody);
+    expect($requestBody)->toContain('grant_type=' . urlencode('http://auth0.com/oauth/grant-type/password-realm'));
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('username=' . $username);
+    expect($requestBody)->toContain('password=' . $password);
+    expect($requestBody)->toContain('realm=' . $realm);
 });
 
 test('loginWithDefaultDirectory() is properly formatted', function(): void {
@@ -346,14 +346,14 @@ test('loginWithDefaultDirectory() is properly formatted', function(): void {
     $requestUri = $request->getUri();
     $requestBody =  explode('&', $request->getBody()->__toString());
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=password', $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
-    $this->assertContains('username=' . $username, $requestBody);
-    $this->assertContains('password=' . $password, $requestBody);
+    expect($requestBody)->toContain('grant_type=password');
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('username=' . $username);
+    expect($requestBody)->toContain('password=' . $password);
 });
 
 test('clientCredentials() is properly formatted', function(): void {
@@ -367,17 +367,17 @@ test('clientCredentials() is properly formatted', function(): void {
     $requestBody =  explode('&', $request->getBody()->__toString());
     $requestHeaders = $request->getHeaders();
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=client_credentials', $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
-    $this->assertContains('audience=aud1', $requestBody);
-    $this->assertContains('testing=123', $requestBody);
+    expect($requestBody)->toContain('grant_type=client_credentials');
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('audience=aud1');
+    expect($requestBody)->toContain('testing=123');
 
     $this->assertArrayHasKey('header_testing', $requestHeaders);
-    $this->assertEquals(123, $requestHeaders['header_testing'][0]);
+    expect($requestHeaders['header_testing'][0])->toEqual(123);
 });
 
 test('refreshToken() is properly formatted', function(): void {
@@ -392,17 +392,17 @@ test('refreshToken() is properly formatted', function(): void {
     $requestBody =  explode('&', $request->getBody()->__toString());
     $requestHeaders = $request->getHeaders();
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/oauth/token', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
 
-    $this->assertContains('grant_type=refresh_token', $requestBody);
-    $this->assertContains('client_id=__test_client_id__', $requestBody);
-    $this->assertContains('client_secret=' . $clientSecret, $requestBody);
-    $this->assertContains('refresh_token=' . $refreshToken, $requestBody);
-    $this->assertContains('testing=123', $requestBody);
+    expect($requestBody)->toContain('grant_type=refresh_token');
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('refresh_token=' . $refreshToken);
+    expect($requestBody)->toContain('testing=123');
 
     $this->assertArrayHasKey('header_testing', $requestHeaders);
-    $this->assertEquals(123, $requestHeaders['header_testing'][0]);
+    expect($requestHeaders['header_testing'][0])->toEqual(123);
 });
 
 test('dbConnectionsSignup() is properly formatted', function(): void {
@@ -420,8 +420,8 @@ test('dbConnectionsSignup() is properly formatted', function(): void {
     $requestBody = json_decode($request->getBody()->__toString(), true);
     $requestHeaders = $request->getHeaders();
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/dbconnections/signup', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/dbconnections/signup');
 
     $this->assertArrayHasKey('client_id', $requestBody);
     $this->assertArrayHasKey('email', $requestBody);
@@ -429,14 +429,14 @@ test('dbConnectionsSignup() is properly formatted', function(): void {
     $this->assertArrayHasKey('connection', $requestBody);
     $this->assertArrayHasKey('testing', $requestBody);
 
-    $this->assertEquals('__test_client_id__', $requestBody['client_id']);
-    $this->assertEquals(trim($email), $requestBody['email']);
-    $this->assertEquals($password, $requestBody['password']);
-    $this->assertEquals($connection, $requestBody['connection']);
-    $this->assertEquals(123, $requestBody['testing']);
+    expect($requestBody['client_id'])->toEqual('__test_client_id__');
+    expect($requestBody['email'])->toEqual(trim($email));
+    expect($requestBody['password'])->toEqual($password);
+    expect($requestBody['connection'])->toEqual($connection);
+    expect($requestBody['testing'])->toEqual(123);
 
     $this->assertArrayHasKey('header_testing', $requestHeaders);
-    $this->assertEquals(123, $requestHeaders['header_testing'][0]);
+    expect($requestHeaders['header_testing'][0])->toEqual(123);
 });
 
 test('dbConnectionsChangePassword() is properly formatted', function(): void {
@@ -453,19 +453,19 @@ test('dbConnectionsChangePassword() is properly formatted', function(): void {
     $requestBody = json_decode($request->getBody()->__toString(), true);
     $requestHeaders = $request->getHeaders();
 
-    $this->assertEquals($this->configuration->getDomain(), $requestUri->getHost());
-    $this->assertEquals('/dbconnections/change_password', $requestUri->getPath());
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/dbconnections/change_password');
 
     $this->assertArrayHasKey('client_id', $requestBody);
     $this->assertArrayHasKey('email', $requestBody);
     $this->assertArrayHasKey('connection', $requestBody);
     $this->assertArrayHasKey('testing', $requestBody);
 
-    $this->assertEquals('__test_client_id__', $requestBody['client_id']);
-    $this->assertEquals(trim($email), $requestBody['email']);
-    $this->assertEquals($connection, $requestBody['connection']);
-    $this->assertEquals(123, $requestBody['testing']);
+    expect($requestBody['client_id'])->toEqual('__test_client_id__');
+    expect($requestBody['email'])->toEqual(trim($email));
+    expect($requestBody['connection'])->toEqual($connection);
+    expect($requestBody['testing'])->toEqual(123);
 
     $this->assertArrayHasKey('header_testing', $requestHeaders);
-    $this->assertEquals(123, $requestHeaders['header_testing'][0]);
+    expect($requestHeaders['header_testing'][0])->toEqual(123);
 });

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -24,11 +24,8 @@ beforeEach(function(): void {
 });
 
 test('__construct() fails without a configuration', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
-
     new Authentication(null);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
 
 test('__construct() accepts a configuration as an array', function(): void {
     $auth = new Authentication([
@@ -141,20 +138,13 @@ test('getLogoutLink() is properly formatted', function(): void {
 });
 
 test('passwordlessStart() throws a ConfigurationException if client secret is not configured', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
-
     $this->sdk->authentication()->passwordlessStart();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
 
 test('passwordlessStart() throws a ConfigurationException if client id is not configured', function(): void {
     $this->configuration->setClientId(null);
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
-
     $this->sdk->authentication()->passwordlessStart();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
 
 test('passwordlessStart() is properly formatted', function(): void {
     $this->configuration->setClientSecret(uniqid());
@@ -174,30 +164,18 @@ test('passwordlessStart() is properly formatted', function(): void {
 
 test('emailPasswordlessStart() throws an ArgumentException if `email` is empty', function(): void {
     $this->configuration->setClientSecret(uniqid());
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'email'));
-
     $this->sdk->authentication()->emailPasswordlessStart('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'email'));
 
 test('emailPasswordlessStart() throws an ArgumentException if `email` is not a valid email address', function(): void {
     $this->configuration->setClientSecret(uniqid());
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'email'));
-
     $this->sdk->authentication()->emailPasswordlessStart(uniqid(), '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'email'));
 
 test('emailPasswordlessStart() throws an ArgumentException if `type` is empty', function(): void {
     $this->configuration->setClientSecret(uniqid());
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'type'));
-
     $this->sdk->authentication()->emailPasswordlessStart('someone@somewhere.somehow', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'type'));
 
 test('emailPasswordlessStart() is properly formatted', function(): void {
     $this->configuration->setClientSecret(uniqid());
@@ -223,12 +201,8 @@ test('emailPasswordlessStart() is properly formatted', function(): void {
 
 test('smsPasswordlessStart() throws an ArgumentException if `phoneNumber` is empty', function(): void {
     $this->configuration->setClientSecret(uniqid());
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'phoneNumber'));
-
     $this->sdk->authentication()->smsPasswordlessStart('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'phoneNumber'));
 
 test('smsPasswordlessStart() is properly formatted', function(): void {
     $this->configuration->setClientSecret(uniqid());

--- a/tests/Unit/API/Management/ActionsTest.php
+++ b/tests/Unit/API/Management/ActionsTest.php
@@ -10,33 +10,24 @@ use Auth0\Tests\Utilities\MockManagementApi;
 uses()->group('management', 'actions');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
-
-    $this->filteredRequest = new FilteredRequest();
-    $this->paginatedRequest = new PaginatedRequest();
-    $this->requestOptions = new RequestOptions(
-        $this->filteredRequest,
-        $this->paginatedRequest
-    );
-
-    $this->endpoint = $this->sdk->mock()->actions();
+    $this->endpoint = $this->api->mock()->actions();
 });
 
 test('create() issues valid requests', function(array $body): void {
     $this->endpoint->create($body);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-    $request = $this->sdk->getRequestBody();
+    $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $request);
     $this->assertArrayHasKey('supported-triggers', $request);
 
     $this->assertEquals('my-action', $request['name']);
     $this->assertIsArray($request['supported-triggers']);
 
-    $request = $this->sdk->getRequestBodyAsString();
+    $request = $this->api->getRequestBodyAsString();
     $this->assertEquals('{"name":"my-action","supported-triggers":[{"id":"post-login","version":"v2"}],"code":"module.exports = () => {}","dependencies":[{"name":"lodash","version":"1.0.0"}],"runtime":"node12","secrets":[{"name":"mySecret","value":"mySecretValue"}]}', $request);
 })->with(['valid body' => [
     fn() => [
@@ -76,18 +67,18 @@ test('create() throws an error with an empty body', function(array $body): void 
 test('getAll() issues valid requests', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 });
 
 test('getAll() issues valid requests using parameters', function(array $parameters): void {
     $this->endpoint->getAll($parameters);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions', $this->sdk->getRequestUrl());
-    $this->assertStringContainsString('&triggerId=' . $parameters['triggerId'], $this->sdk->getRequestQuery());
-    $this->assertStringContainsString('&actionName=' . $parameters['actionName'], $this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions', $this->api->getRequestUrl());
+    $this->assertStringContainsString('&triggerId=' . $parameters['triggerId'], $this->api->getRequestQuery());
+    $this->assertStringContainsString('&actionName=' . $parameters['actionName'], $this->api->getRequestQuery());
 })->with(['valid parameters' => [
     fn() => [
         'triggerId' => uniqid(),
@@ -98,9 +89,9 @@ test('getAll() issues valid requests using parameters', function(array $paramete
 test('get() issues valid requests', function(string $id): void {
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 })->with(['valid id' => [
     fn() => uniqid()
 ]]);
@@ -117,18 +108,18 @@ test('get() throws an error with an empty id', function(string $id): void {
 test('update() issues valid requests', function(string $id, array $body): void {
     $this->endpoint->update($id, $body);
 
-    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-    $request = $this->sdk->getRequestBody();
+    $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $request);
     $this->assertArrayHasKey('supported-triggers', $request);
 
     $this->assertEquals('my-action', $request['name']);
     $this->assertIsArray($request['supported-triggers']);
 
-    $request = $this->sdk->getRequestBodyAsString();
+    $request = $this->api->getRequestBodyAsString();
     $this->assertEquals('{"name":"my-action","supported-triggers":[{"id":"post-login","version":"v2"}],"code":"module.exports = () => {}","dependencies":[{"name":"lodash","version":"1.0.0"}],"runtime":"node12","secrets":[{"name":"mySecret","value":"mySecretValue"}]}', $request);
 })->with(['valid request' => [
     fn() => uniqid(),
@@ -202,8 +193,8 @@ test('update() throws an error with an empty body', function(string $id, array $
 test('delete() issues valid requests', function(string $id, ?bool $force): void {
     $this->endpoint->delete($id, $force);
 
-    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
 })->with(['valid id' => [
     fn() => uniqid(),
     fn() => null
@@ -212,9 +203,9 @@ test('delete() issues valid requests', function(string $id, ?bool $force): void 
 test('delete() issues valid requests when using optional ?force parameter', function(string $id, ?bool $force): void {
     $this->endpoint->delete($id, $force);
 
-    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->sdk->getRequestUrl());
-    $this->assertStringContainsString('&force=false', $this->sdk->getRequestQuery());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
+    $this->assertStringContainsString('&force=false', $this->api->getRequestQuery());
 })->with(['valid id and force=false' => [
     fn() => uniqid(),
     fn() => false
@@ -233,9 +224,9 @@ test('delete() throws an error with an empty id', function(string $id, ?bool $fo
 test('deploy() issues valid requests', function(string $id): void {
     $this->endpoint->deploy($id);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/' . $id . '/deploy', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/' . $id . '/deploy', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 })->with(['valid id' => [
     fn() => uniqid()
 ]]);
@@ -252,17 +243,17 @@ test('deploy() throws an error with an empty id', function(string $id): void {
 test('test() issues valid requests', function(string $id, array $body): void {
     $this->endpoint->test($id, $body);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id . '/test', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id . '/test', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-    $request = $this->sdk->getRequestBody();
+    $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('payload', $request);
     $this->assertIsArray($request['payload']);
     $this->assertArrayHasKey('test', $request['payload'][0]);
     $this->assertEquals($body['payload'][0]->test, $request['payload'][0]['test']);
 
-    $request = $this->sdk->getRequestBodyAsString();
+    $request = $this->api->getRequestBodyAsString();
     $this->assertEquals('{"payload":[{"test":"' . $body['payload'][0]->test . '"}]}', $request);
 })->with(['valid request' => [
     fn() => uniqid(),
@@ -304,8 +295,8 @@ test('test() throws an error with an empty body', function(string $id, array $bo
 test('getVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->getVersion($id, $actionId);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id, $this->api->getRequestUrl());
 })->with(['valid id' => [
     fn() => uniqid(),
     fn() => uniqid()
@@ -334,8 +325,8 @@ test('getVersion() throws an error with an empty action id', function(string $id
 test('getVersions() issues valid requests', function(string $actionId): void {
     $this->endpoint->getVersions($actionId);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions', $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions', $this->api->getRequestUrl());
 })->with(['valid action id' => [
     fn() => uniqid()
 ]]);
@@ -352,9 +343,9 @@ test('getVersions() throws an error with an empty action id', function(string $a
 test('rollbackVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->rollbackVersion($id, $actionId);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id . '/deploy', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id . '/deploy', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 })->with(['valid request' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -383,17 +374,17 @@ test('rollbackVersion() throws an error with an action id', function(string $id,
 test('getTriggers() issues valid requests', function(): void {
     $this->endpoint->getTriggers();
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 });
 
 test('getTriggerBindings() issues valid requests', function(string $triggerId): void {
     $this->endpoint->getTriggerBindings($triggerId);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 })->with(['valid trigger id' => [
     fn() => uniqid(),
 ]]);
@@ -401,17 +392,17 @@ test('getTriggerBindings() issues valid requests', function(string $triggerId): 
 test('updateTriggerBindings() issues valid requests', function(string $triggerId, array $body): void {
     $this->endpoint->updateTriggerBindings($triggerId, $body);
 
-    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-    $request = $this->sdk->getRequestBody();
+    $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('bindings', $request);
     $this->assertIsArray($request['bindings']);
     $this->assertArrayHasKey('ref', $request['bindings'][0]);
     $this->assertEquals($body['bindings'][0]->ref->value, $request['bindings'][0]['ref']['value']);
 
-    $request = $this->sdk->getRequestBodyAsString();
+    $request = $this->api->getRequestBodyAsString();
     $this->assertEquals('{"bindings":[{"ref":{"type":"action_name","value":"my-action"},"display_name":"First Action"},{"ref":{"type":"action_id","value":"a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd"},"display_name":"Second Action"}]}', $request);
 })->with(['valid request' => [
     fn() => uniqid(),
@@ -475,9 +466,9 @@ test('updateTriggerBindings() throws an error with an empty body', function(stri
 test('getExecution() issues valid requests', function(string $id): void {
     $this->endpoint->getExecution($id);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/executions/' . $id, $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/actions/executions/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 })->with(['valid id' => [
     fn() => uniqid()
 ]]);

--- a/tests/Unit/API/Management/ActionsTest.php
+++ b/tests/Unit/API/Management/ActionsTest.php
@@ -191,14 +191,11 @@ test('delete() issues valid requests when using optional ?force parameter', func
 ]]);
 
 test('delete() throws an error with an empty id', function(string $id, ?bool $force): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->delete($id, $force);
 })->with(['empty id' => [
     fn() => '',
     fn() => null
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('deploy() issues valid requests', function(string $id): void {
     $this->endpoint->deploy($id);
@@ -211,13 +208,10 @@ test('deploy() issues valid requests', function(string $id): void {
 ]]);
 
 test('deploy() throws an error with an empty id', function(string $id): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->deploy($id);
 })->with(['empty id' => [
     fn() => ''
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('test() issues valid requests', function(string $id, array $body): void {
     $this->endpoint->test($id, $body);
@@ -246,9 +240,6 @@ test('test() issues valid requests', function(string $id, array $body): void {
 ]]);
 
 test('test() throws an error with an empty id', function(string $id, array $body): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->test($id, $body);
 })->with(['empty id' => [
     fn() => '',
@@ -259,17 +250,14 @@ test('test() throws an error with an empty id', function(string $id, array $body
             ],
         ],
     ]
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('test() throws an error with an empty body', function(string $id, array $body): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
-
     $this->endpoint->test($id, $body);
 })->with(['empty body' => [
     fn() => uniqid(),
     fn() => []
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
 
 test('getVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->getVersion($id, $actionId);
@@ -282,24 +270,18 @@ test('getVersion() issues valid requests', function(string $id, string $actionId
 ]]);
 
 test('getVersion() throws an error with an empty id', function(string $id, string $actionId): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getVersion($id, $actionId);
 })->with(['empty id' => [
     fn() => '',
     fn() => uniqid()
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getVersion() throws an error with an empty action id', function(string $id, string $actionId): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
-
     $this->endpoint->getVersion($id, $actionId);
 })->with(['empty action id' => [
     fn() => uniqid(),
     fn() => ''
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
 
 test('getVersions() issues valid requests', function(string $actionId): void {
     $this->endpoint->getVersions($actionId);
@@ -311,13 +293,10 @@ test('getVersions() issues valid requests', function(string $actionId): void {
 ]]);
 
 test('getVersions() throws an error with an empty action id', function(string $actionId): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
-
     $this->endpoint->getVersions($actionId);
 })->with(['empty action id' => [
     fn() => ''
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
 
 test('rollbackVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->rollbackVersion($id, $actionId);
@@ -331,24 +310,18 @@ test('rollbackVersion() issues valid requests', function(string $id, string $act
 ]]);
 
 test('rollbackVersion() throws an error with an empty id', function(string $id, string $actionId): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->rollbackVersion($id, $actionId);
 })->with(['empty id' => [
     fn() => '',
     fn() => uniqid(),
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('rollbackVersion() throws an error with an action id', function(string $id, string $actionId): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
-
     $this->endpoint->rollbackVersion($id, $actionId);
 })->with(['empty action id' => [
     fn() => uniqid(),
     fn() => '',
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actionId'));
 
 test('getTriggers() issues valid requests', function(): void {
     $this->endpoint->getTriggers();
@@ -406,9 +379,6 @@ test('updateTriggerBindings() issues valid requests', function(string $triggerId
 ]]);
 
 test('updateTriggerBindings() throws an error with an empty trigger id', function(string $triggerId, array $body): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'triggerId'));
-
     $this->endpoint->updateTriggerBindings($triggerId, $body);
 })->with(['empty id' => [
     fn() => '',
@@ -430,17 +400,14 @@ test('updateTriggerBindings() throws an error with an empty trigger id', functio
             ],
         ],
     ]
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'triggerId'));
 
 test('updateTriggerBindings() throws an error with an empty body', function(string $triggerId, array $body): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
-
     $this->endpoint->updateTriggerBindings($triggerId, $body);
 })->with(['empty id' => [
     fn() => uniqid(),
     fn() => [],
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
 
 test('getExecution() issues valid requests', function(string $id): void {
     $this->endpoint->getExecution($id);
@@ -453,10 +420,7 @@ test('getExecution() issues valid requests', function(string $id): void {
 ]]);
 
 test('getExecution() throws an error with an empty id', function(string $id): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getExecution($id);
 })->with(['valid trigger id' => [
     fn() => '',
-]]);
+]])->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));

--- a/tests/Unit/API/Management/ActionsTest.php
+++ b/tests/Unit/API/Management/ActionsTest.php
@@ -172,8 +172,8 @@ test('update() throws an error with an empty body', function(): void {
 test('delete() issues valid requests', function(string $id, ?bool $force): void {
     $this->endpoint->delete($id, $force);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/actions/actions/' . $id);
 })->with(['valid id' => [
     fn() => uniqid(),
     fn() => null
@@ -182,9 +182,9 @@ test('delete() issues valid requests', function(string $id, ?bool $force): void 
 test('delete() issues valid requests when using optional ?force parameter', function(string $id, ?bool $force): void {
     $this->endpoint->delete($id, $force);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/actions/' . $id, $this->api->getRequestUrl());
-    $this->assertStringContainsString('&force=false', $this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/actions/actions/' . $id);
+    expect($this->api->getRequestQuery())->toContain('&force=false');
 })->with(['valid id and force=false' => [
     fn() => uniqid(),
     fn() => false
@@ -203,9 +203,9 @@ test('delete() throws an error with an empty id', function(string $id, ?bool $fo
 test('deploy() issues valid requests', function(string $id): void {
     $this->endpoint->deploy($id);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/' . $id . '/deploy', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/' . $id . '/deploy');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['valid id' => [
     fn() => uniqid()
 ]]);
@@ -222,18 +222,18 @@ test('deploy() throws an error with an empty id', function(string $id): void {
 test('test() issues valid requests', function(string $id, array $body): void {
     $this->endpoint->test($id, $body);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/actions/' . $id . '/test', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/actions/' . $id . '/test');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('payload', $request);
-    $this->assertIsArray($request['payload']);
+    expect($request['payload'])->toBeArray();
     $this->assertArrayHasKey('test', $request['payload'][0]);
-    $this->assertEquals($body['payload'][0]->test, $request['payload'][0]['test']);
+    expect($request['payload'][0]['test'])->toEqual($body['payload'][0]->test);
 
     $request = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"payload":[{"test":"' . $body['payload'][0]->test . '"}]}', $request);
+    expect($request)->toEqual('{"payload":[{"test":"' . $body['payload'][0]->test . '"}]}');
 })->with(['valid request' => [
     fn() => uniqid(),
     fn() => [
@@ -274,8 +274,8 @@ test('test() throws an error with an empty body', function(string $id, array $bo
 test('getVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->getVersion($id, $actionId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id);
 })->with(['valid id' => [
     fn() => uniqid(),
     fn() => uniqid()
@@ -304,8 +304,8 @@ test('getVersion() throws an error with an empty action id', function(string $id
 test('getVersions() issues valid requests', function(string $actionId): void {
     $this->endpoint->getVersions($actionId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/actions/' . $actionId . '/versions');
 })->with(['valid action id' => [
     fn() => uniqid()
 ]]);
@@ -322,9 +322,9 @@ test('getVersions() throws an error with an empty action id', function(string $a
 test('rollbackVersion() issues valid requests', function(string $id, string $actionId): void {
     $this->endpoint->rollbackVersion($id, $actionId);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id . '/deploy', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/' . $actionId . '/versions/' . $id . '/deploy');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['valid request' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -353,17 +353,17 @@ test('rollbackVersion() throws an error with an action id', function(string $id,
 test('getTriggers() issues valid requests', function(): void {
     $this->endpoint->getTriggers();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/triggers');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('getTriggerBindings() issues valid requests', function(string $triggerId): void {
     $this->endpoint->getTriggerBindings($triggerId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['valid trigger id' => [
     fn() => uniqid(),
 ]]);
@@ -371,18 +371,18 @@ test('getTriggerBindings() issues valid requests', function(string $triggerId): 
 test('updateTriggerBindings() issues valid requests', function(string $triggerId, array $body): void {
     $this->endpoint->updateTriggerBindings($triggerId, $body);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/triggers/' . $triggerId . '/bindings');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('bindings', $request);
-    $this->assertIsArray($request['bindings']);
+    expect($request['bindings'])->toBeArray();
     $this->assertArrayHasKey('ref', $request['bindings'][0]);
-    $this->assertEquals($body['bindings'][0]->ref->value, $request['bindings'][0]['ref']['value']);
+    expect($request['bindings'][0]['ref']['value'])->toEqual($body['bindings'][0]->ref->value);
 
     $request = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"bindings":[{"ref":{"type":"action_name","value":"my-action"},"display_name":"First Action"},{"ref":{"type":"action_id","value":"a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd"},"display_name":"Second Action"}]}', $request);
+    expect($request)->toEqual('{"bindings":[{"ref":{"type":"action_name","value":"my-action"},"display_name":"First Action"},{"ref":{"type":"action_id","value":"a6a5a107-d2e3-45a3-8ff6-1218aa4bf8bd"},"display_name":"Second Action"}]}');
 })->with(['valid request' => [
     fn() => uniqid(),
     fn() => [
@@ -445,9 +445,9 @@ test('updateTriggerBindings() throws an error with an empty body', function(stri
 test('getExecution() issues valid requests', function(string $id): void {
     $this->endpoint->getExecution($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/actions/executions/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/actions/executions/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['valid id' => [
     fn() => uniqid()
 ]]);

--- a/tests/Unit/API/Management/BlacklistsTest.php
+++ b/tests/Unit/API/Management/BlacklistsTest.php
@@ -2,55 +2,39 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Utility\Request\FilteredRequest;
-use Auth0\SDK\Utility\Request\PaginatedRequest;
-use Auth0\SDK\Utility\Request\RequestOptions;
-use Auth0\Tests\Utilities\MockManagementApi;
-
-uses()->group('management', 'blacklists');
+uses()->group('management', 'management.blacklists');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
-
-    $this->filteredRequest = new FilteredRequest();
-    $this->paginatedRequest = new PaginatedRequest();
-    $this->requestOptions = new RequestOptions(
-        $this->filteredRequest,
-        $this->paginatedRequest
-    );
+    $this->endpoint = $this->api->mock()->blacklists();
 });
 
-test('create() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->blacklists();
-
+test('create() issues an appropriate request', function(): void {
     $jti = uniqid();
     $aud = uniqid();
 
-    $endpoint->create($jti, $aud);
+    $this->endpoint->create($jti, $aud);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/blacklists/tokens', $this->sdk->getRequestUrl());
-    $this->assertEmpty($this->sdk->getRequestQuery());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/blacklists/tokens', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('aud', $body);
     $this->assertEquals($aud, $body['aud']);
     $this->assertArrayHasKey('jti', $body);
     $this->assertEquals($jti, $body['jti']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['jti' => $jti, 'aud' => $aud]), $body);
 });
 
 test('get() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->blacklists();
-
     $aud = uniqid();
 
-    $endpoint->get($aud);
+    $this->endpoint->get($aud);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/blacklists/tokens', $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/blacklists/tokens', $this->api->getRequestUrl());
 
-    $this->assertEquals('aud=' . $aud, $this->sdk->getRequestQuery(null));
+    $this->assertEquals('aud=' . $aud, $this->api->getRequestQuery(null));
 });

--- a/tests/Unit/API/Management/BlacklistsTest.php
+++ b/tests/Unit/API/Management/BlacklistsTest.php
@@ -14,18 +14,18 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($jti, $aud);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/blacklists/tokens', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/blacklists/tokens');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('aud', $body);
-    $this->assertEquals($aud, $body['aud']);
+    expect($body['aud'])->toEqual($aud);
     $this->assertArrayHasKey('jti', $body);
-    $this->assertEquals($jti, $body['jti']);
+    expect($body['jti'])->toEqual($jti);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['jti' => $jti, 'aud' => $aud]), $body);
+    expect($body)->toEqual(json_encode(['jti' => $jti, 'aud' => $aud]));
 });
 
 test('get() issues valid requests', function(): void {
@@ -33,8 +33,8 @@ test('get() issues valid requests', function(): void {
 
     $this->endpoint->get($aud);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/blacklists/tokens', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/blacklists/tokens');
 
-    $this->assertEquals('aud=' . $aud, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestQuery(null))->toEqual('aud=' . $aud);
 });

--- a/tests/Unit/API/Management/ClientGrantsTest.php
+++ b/tests/Unit/API/Management/ClientGrantsTest.php
@@ -9,19 +9,12 @@ beforeEach(function(): void {
 });
 
 test('create() throws an error when clientId is missing', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
-
     $this->endpoint->create('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
 
 test('create() throws an error when audience is missing', function(): void {
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'audience'));
-
     $this->endpoint->create(uniqid(), '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'audience'));
 
 test('create() issues an appropriate request', function(): void {
     $clientId = uniqid();

--- a/tests/Unit/API/Management/ClientGrantsTest.php
+++ b/tests/Unit/API/Management/ClientGrantsTest.php
@@ -30,19 +30,19 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($clientId, $audience, [$scope]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/client-grants');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('client_id', $body);
     $this->assertArrayHasKey('audience', $body);
     $this->assertArrayHasKey('scope', $body);
-    $this->assertEquals($clientId, $body['client_id']);
-    $this->assertEquals($audience, $body['audience']);
-    $this->assertContains($scope, $body['scope']);
+    expect($body['client_id'])->toEqual($clientId);
+    expect($body['audience'])->toEqual($audience);
+    expect($body['scope'])->toContain($scope);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['client_id' => $clientId, 'audience' => $audience, 'scope' => [$scope]]), $body);
+    expect($body)->toEqual(json_encode(['client_id' => $clientId, 'audience' => $audience, 'scope' => [$scope]]));
 });
 
 test('getAll() issues an appropriate request', function(): void {
@@ -50,10 +50,10 @@ test('getAll() issues an appropriate request', function(): void {
 
     $this->endpoint->getAll(['example' => $exampleParam]);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/client-grants');
 
-    $this->assertEquals('example=' . $exampleParam, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestQuery(null))->toEqual('example=' . $exampleParam);
 });
 
 test('getAll() supports field filtering parameters', function(): void {
@@ -63,11 +63,11 @@ test('getAll() supports field filtering parameters', function(): void {
 
     $this->endpoint->getAll(null, $this->requestOptions);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/client-grants');
 
-    $this->assertStringContainsString('&fields=' . rawurlencode($field1 . ',' . $field2), $this->api->getRequestQuery());
-    $this->assertStringContainsString('&include_fields=true', $this->api->getRequestQuery());
+    expect($this->api->getRequestQuery())->toContain('&fields=' . rawurlencode($field1 . ',' . $field2));
+    expect($this->api->getRequestQuery())->toContain('&include_fields=true');
 });
 
 test('getAll() supports standard pagination parameters', function(): void {
@@ -75,12 +75,12 @@ test('getAll() supports standard pagination parameters', function(): void {
 
     $this->endpoint->getAll(null, $this->requestOptions);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/client-grants');
 
-    $this->assertStringContainsString('&page=1', $this->api->getRequestQuery());
-    $this->assertStringContainsString('&per_page=5', $this->api->getRequestQuery());
-    $this->assertStringContainsString('&include_totals=true', $this->api->getRequestQuery());
+    expect($this->api->getRequestQuery())->toContain('&page=1');
+    expect($this->api->getRequestQuery())->toContain('&per_page=5');
+    expect($this->api->getRequestQuery())->toContain('&include_totals=true');
 });
 
 test('getAllByAudience() issues an appropriate request', function(): void {
@@ -88,10 +88,10 @@ test('getAllByAudience() issues an appropriate request', function(): void {
 
     $this->endpoint->getAllByAudience($audience);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/client-grants');
 
-    $this->assertEquals('audience=' . $audience, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestQuery(null))->toEqual('audience=' . $audience);
 });
 
 test('getAllByClientId() issues an appropriate request', function(): void {
@@ -99,10 +99,10 @@ test('getAllByClientId() issues an appropriate request', function(): void {
 
     $this->endpoint->getAllByClientId($clientId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/client-grants', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/client-grants');
 
-    $this->assertEquals('client_id=' . $clientId, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestQuery(null))->toEqual('client_id=' . $clientId);
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -111,15 +111,15 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($grantId, [$scope]);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/client-grants/' . $grantId, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/client-grants/' . $grantId);
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('scope', $body);
-    $this->assertContains($scope, $body['scope']);
+    expect($body['scope'])->toContain($scope);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['scope' => [$scope]]), $body);
+    expect($body)->toEqual(json_encode(['scope' => [$scope]]));
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -127,6 +127,6 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($grantId);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/client-grants/' . $grantId, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/client-grants/' . $grantId);
 });

--- a/tests/Unit/API/Management/ClientsTest.php
+++ b/tests/Unit/API/Management/ClientsTest.php
@@ -2,96 +2,66 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.clients');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->clients();
+});
 
-/**
- * Class ClientsTest.
- */
-class ClientsTest extends TestCase
-{
-    /**
-     * Test getAll() request.
-     */
-    public function testGetAll(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->clients()->getAll(['client_id' => '__test_client_id__', 'app_type' => '__test_app_type__']);
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll(['client_id' => '__test_client_id__', 'app_type' => '__test_app_type__']);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/clients', $api->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/clients', $this->api->getRequestUrl());
 
-        $query = $api->getRequestQuery();
-        $this->assertStringContainsString('&client_id=__test_client_id__&app_type=__test_app_type__', $query);
-    }
+    $query = $this->api->getRequestQuery();
+    $this->assertStringContainsString('&client_id=__test_client_id__&app_type=__test_app_type__', $query);
+});
 
-    /**
-     * Test get() request.
-     */
-    public function testGet(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->clients()->get('__test_id__');
+test('get() issues an appropriate request', function(): void {
+    $this->endpoint->get('__test_id__');
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/clients/__test_id__', $api->getRequestUrl());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
+});
 
-    /**
-     * Test delete() request.
-     */
-    public function testDelete(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->clients()->delete('__test_id__');
+test('delete() issues an appropriate request', function(): void {
+    $this->endpoint->delete('__test_id__');
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $api->getRequestUrl());
-    }
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
+});
 
-    /**
-     * Test create() request.
-     */
-    public function testCreate(): void
-    {
-        $mock = (object) [
-            'name' => uniqid(),
-            'body'=> [
-                'app_type' => uniqid()
-            ]
-        ];
+test('create() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'name' => uniqid(),
+        'body'=> [
+            'app_type' => uniqid()
+        ]
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->clients()->create($mock->name, $mock->body);
+    $this->endpoint->create($mock->name, $mock->body);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/clients', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/clients', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($mock->name, $body['name']);
-        $this->assertArrayHasKey('app_type', $body);
-        $this->assertEquals($mock->body['app_type'], $body['app_type']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($mock->name, $body['name']);
+    $this->assertArrayHasKey('app_type', $body);
+    $this->assertEquals($mock->body['app_type'], $body['app_type']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(array_merge(['name' => $mock->name], $mock->body)), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(array_merge(['name' => $mock->name], $mock->body)), $body);
+});
 
-    /**
-     * Test update() request.
-     */
-    public function testUpdate(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->clients()->update('__test_id__', ['name' => '__test_new_name__']);
+test('update() issues an appropriate request', function(): void {
+    $this->endpoint->update('__test_id__', ['name' => '__test_new_name__']);
 
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $api->getRequestUrl());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals('__test_new_name__', $body['name']);
-    }
-}
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals('__test_new_name__', $body['name']);
+});

--- a/tests/Unit/API/Management/ClientsTest.php
+++ b/tests/Unit/API/Management/ClientsTest.php
@@ -11,25 +11,25 @@ beforeEach(function(): void {
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll(['client_id' => '__test_client_id__', 'app_type' => '__test_app_type__']);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/clients', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/clients');
 
     $query = $this->api->getRequestQuery();
-    $this->assertStringContainsString('&client_id=__test_client_id__&app_type=__test_app_type__', $query);
+    expect($query)->toContain('&client_id=__test_client_id__&app_type=__test_app_type__');
 });
 
 test('get() issues an appropriate request', function(): void {
     $this->endpoint->get('__test_id__');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/clients/__test_id__');
 });
 
 test('delete() issues an appropriate request', function(): void {
     $this->endpoint->delete('__test_id__');
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/clients/__test_id__');
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -42,26 +42,26 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($mock->name, $mock->body);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/clients', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/clients');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mock->name, $body['name']);
+    expect($body['name'])->toEqual($mock->name);
     $this->assertArrayHasKey('app_type', $body);
-    $this->assertEquals($mock->body['app_type'], $body['app_type']);
+    expect($body['app_type'])->toEqual($mock->body['app_type']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['name' => $mock->name], $mock->body)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mock->name], $mock->body)));
 });
 
 test('update() issues an appropriate request', function(): void {
     $this->endpoint->update('__test_id__', ['name' => '__test_new_name__']);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/clients/__test_id__', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/clients/__test_id__');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals('__test_new_name__', $body['name']);
+    expect($body['name'])->toEqual('__test_new_name__');
 });

--- a/tests/Unit/API/Management/ConnectionsTest.php
+++ b/tests/Unit/API/Management/ConnectionsTest.php
@@ -13,9 +13,9 @@ test('getAll() issues an appropriate request', function(): void {
 
     $this->endpoint->getAll([ 'strategy' => $strategy ]);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringContainsString('https://api.test.local/api/v2/connections', $this->api->getRequestUrl());
-    $this->assertStringContainsString('&strategy=' . $strategy, $this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toContain('https://api.test.local/api/v2/connections');
+    expect($this->api->getRequestQuery())->toContain('&strategy=' . $strategy);
 });
 
 test('get() issues an appropriate request', function(): void {
@@ -23,9 +23,9 @@ test('get() issues an appropriate request', function(): void {
 
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/connections/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -33,9 +33,9 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/connections/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('deleteUser() issues an appropriate request', function(): void {
@@ -44,9 +44,9 @@ test('deleteUser() issues an appropriate request', function(): void {
 
     $this->endpoint->deleteUser($id, $email);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringContainsString('https://api.test.local/api/v2/connections/' . $id . '/users', $this->api->getRequestUrl());
-    $this->assertEquals('email=' . rawurlencode($email), $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toContain('https://api.test.local/api/v2/connections/' . $id . '/users');
+    expect($this->api->getRequestQuery(null))->toEqual('email=' . rawurlencode($email));
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -63,14 +63,14 @@ test('create() issues an appropriate request', function(): void {
 
     $request_body = $this->api->getRequestBody();
 
-    $this->assertEquals($mock->name, $request_body['name']);
-    $this->assertEquals($mock->strategy, $request_body['strategy']);
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/connections', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($request_body['name'])->toEqual($mock->name);
+    expect($request_body['strategy'])->toEqual($mock->strategy);
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/connections');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'strategy' => $mock->strategy], $mock->body)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mock->name, 'strategy' => $mock->strategy], $mock->body)));
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -81,8 +81,8 @@ test('update() issues an appropriate request', function(): void {
 
     $request_body = $this->api->getRequestBody();
 
-    $this->assertEquals($update_data, $request_body);
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($request_body)->toEqual($update_data);
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/connections/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });

--- a/tests/Unit/API/Management/ConnectionsTest.php
+++ b/tests/Unit/API/Management/ConnectionsTest.php
@@ -2,122 +2,87 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.connections');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->connections();
+});
 
-/**
- * Class ConnectionsTest.
- */
-class ConnectionsTest extends TestCase
-{
-    /**
-     * Test a getAll() request.
-     */
-    public function testGetAll(): void
-    {
-        $strategy = 'test-strategy-01';
+test('getAll() issues an appropriate request', function(): void {
+    $strategy = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->getAll([ 'strategy' => $strategy ]);
+    $this->endpoint->getAll([ 'strategy' => $strategy ]);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringContainsString('https://api.test.local/api/v2/connections', $api->getRequestUrl());
-        $this->assertStringContainsString('&strategy=' . $strategy, $api->getRequestQuery());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringContainsString('https://api.test.local/api/v2/connections', $this->api->getRequestUrl());
+    $this->assertStringContainsString('&strategy=' . $strategy, $this->api->getRequestQuery());
+});
 
-    /**
-     * Test a get() request.
-     */
-    public function testGet(): void
-    {
-        $id = 'con_testConnection10';
+test('get() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->get($id);
+    $this->endpoint->get($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
 
-    /**
-     * Test a basic delete connection request.
-     */
-    public function testDelete(): void
-    {
-        $id = 'con_testConnection10';
+test('delete() issues an appropriate request', function(): void {
+    $id = 'con_testConnection10';
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->delete($id);
+    $this->endpoint->delete($id);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
 
-    /**
-     * Test a delete user for connection request.
-     */
-    public function testDeleteUser(): void
-    {
-        $id = 'con_testConnection10';
-        $email = 'con_testConnection10@auth0.com';
+test('deleteUser() issues an appropriate request', function(): void {
+    $id = 'con_testConnection10';
+    $email = 'con_testConnection10@auth0.com';
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->deleteUser($id, $email);
+    $this->endpoint->deleteUser($id, $email);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertStringContainsString('https://api.test.local/api/v2/connections/' . $id . '/users', $api->getRequestUrl());
-        $this->assertEquals('email=' . rawurlencode($email), $api->getRequestQuery(null));
-    }
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringContainsString('https://api.test.local/api/v2/connections/' . $id . '/users', $this->api->getRequestUrl());
+    $this->assertEquals('email=' . rawurlencode($email), $this->api->getRequestQuery(null));
+});
 
-    /**
-     * Test a basic connection create call.
-     */
-    public function testCreate(): void
-    {
-        $mock = (object) [
-            'name' => uniqid(),
-            'strategy' => uniqid(),
-            'body' => [
-                'test1' => uniqid(),
-                'test2' => uniqid()
-            ]
-        ];
+test('create() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'name' => uniqid(),
+        'strategy' => uniqid(),
+        'body' => [
+            'test1' => uniqid(),
+            'test2' => uniqid()
+        ]
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->create($mock->name, $mock->strategy, $mock->body);
+    $this->endpoint->create($mock->name, $mock->strategy, $mock->body);
 
-        $request_body = $api->getRequestBody();
+    $request_body = $this->api->getRequestBody();
 
-        $this->assertEquals($mock->name, $request_body['name']);
-        $this->assertEquals($mock->strategy, $request_body['strategy']);
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/connections', $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
+    $this->assertEquals($mock->name, $request_body['name']);
+    $this->assertEquals($mock->strategy, $request_body['strategy']);
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/connections', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'strategy' => $mock->strategy], $mock->body)), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'strategy' => $mock->strategy], $mock->body)), $body);
+});
 
-    /**
-     * Test a basic update request.
-     */
-    public function testUpdate(): void
-    {
-        $id = 'con_testConnection10';
-        $update_data = ['metadata' => ['meta1' => 'value1']];
+test('update() issues an appropriate request', function(): void {
+    $id = 'con_testConnection10';
+    $update_data = ['metadata' => ['meta1' => 'value1']];
 
-        $api = new MockManagementApi();
-        $api->mock()->connections()->update($id, $update_data);
+    $this->endpoint->update($id, $update_data);
 
-        $request_body = $api->getRequestBody();
+    $request_body = $this->api->getRequestBody();
 
-        $this->assertEquals($update_data, $request_body);
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
-}
+    $this->assertEquals($update_data, $request_body);
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/connections/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});

--- a/tests/Unit/API/Management/DeviceCredentialsTest.php
+++ b/tests/Unit/API/Management/DeviceCredentialsTest.php
@@ -46,8 +46,8 @@ test('create() issues valid requests', function(): void {
 
     $this->endpoint->create($deviceName, $type, $value, $deviceId, ['additional' => $additional]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/device-credentials', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/device-credentials');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('device_name', $body);
@@ -55,14 +55,14 @@ test('create() issues valid requests', function(): void {
     $this->assertArrayHasKey('value', $body);
     $this->assertArrayHasKey('device_id', $body);
     $this->assertArrayHasKey('additional', $body);
-    $this->assertEquals($deviceName, $body['device_name']);
-    $this->assertEquals($type, $body['type']);
-    $this->assertEquals($value, $body['value']);
-    $this->assertEquals($deviceId, $body['device_id']);
-    $this->assertEquals($additional, $body['additional']);
+    expect($body['device_name'])->toEqual($deviceName);
+    expect($body['type'])->toEqual($type);
+    expect($body['value'])->toEqual($value);
+    expect($body['device_id'])->toEqual($deviceId);
+    expect($body['additional'])->toEqual($additional);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['device_name' => $deviceName, 'type' => $type, 'value' => $value, 'device_id' => $deviceId, 'additional' => $additional]), $body);
+    expect($body)->toEqual(json_encode(['device_name' => $deviceName, 'type' => $type, 'value' => $value, 'device_id' => $deviceId, 'additional' => $additional]));
 });
 
 test('get() issues valid requests', function(): void {
@@ -72,12 +72,12 @@ test('get() issues valid requests', function(): void {
 
     $this->endpoint->get($userId, $clientId, $type);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/device-credentials', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/device-credentials');
 
-    $this->assertStringContainsString('&user_id=' . $userId, $this->api->getRequestQuery());
-    $this->assertStringContainsString('&client_id=' . $clientId, $this->api->getRequestQuery());
-    $this->assertStringContainsString('&type=' . $type, $this->api->getRequestQuery());
+    expect($this->api->getRequestQuery())->toContain('&user_id=' . $userId);
+    expect($this->api->getRequestQuery())->toContain('&client_id=' . $clientId);
+    expect($this->api->getRequestQuery())->toContain('&type=' . $type);
 });
 
 test('delete() issues valid requests', function(): void {
@@ -85,6 +85,6 @@ test('delete() issues valid requests', function(): void {
 
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/device-credentials/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/device-credentials/' . $id);
 });

--- a/tests/Unit/API/Management/DeviceCredentialsTest.php
+++ b/tests/Unit/API/Management/DeviceCredentialsTest.php
@@ -9,33 +9,20 @@ beforeEach(function(): void {
 });
 
 test('create() throws an error when missing deviceName', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceName'));
-
     $this->endpoint->create('', '', '', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceName'));
 
 test('create() throws an error when missing type', function(): void {
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'type'));
-
     $this->endpoint->create(uniqid(), '', '', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'type'));
 
 test('create() throws an error when missing value', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'value'));
-
     $this->endpoint->create(uniqid(), uniqid(), '', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'value'));
 
 test('create() throws an error when missing deviceId', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceId'));
-
     $this->endpoint->create(uniqid(), uniqid(), uniqid(), '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceId'));
 
 test('create() issues valid requests', function(): void {
     $deviceName = uniqid();

--- a/tests/Unit/API/Management/DeviceCredentialsTest.php
+++ b/tests/Unit/API/Management/DeviceCredentialsTest.php
@@ -2,63 +2,54 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Utility\Request\FilteredRequest;
-use Auth0\SDK\Utility\Request\PaginatedRequest;
-use Auth0\SDK\Utility\Request\RequestOptions;
-use Auth0\Tests\Utilities\MockManagementApi;
-
-uses()->group('management', 'devicecredentials');
+uses()->group('management', 'management.device_credentials');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
-
-    $this->filteredRequest = new FilteredRequest();
-    $this->paginatedRequest = new PaginatedRequest();
-    $this->requestOptions = new RequestOptions(
-        $this->filteredRequest,
-        $this->paginatedRequest
-    );
+    $this->endpoint = $this->api->mock()->deviceCredentials();
 });
 
-test('create() throws an error when missing required variables', function(): void {
-    $endpoint = $this->sdk->mock()->deviceCredentials();
-
+test('create() throws an error when missing deviceName', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceName'));
 
-    $endpoint->create('', '', '', '');
+    $this->endpoint->create('', '', '', '');
+});
+
+test('create() throws an error when missing type', function(): void {
 
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'type'));
 
-    $endpoint->create(uniqid(), '', '', '');
+    $this->endpoint->create(uniqid(), '', '', '');
+});
 
+test('create() throws an error when missing value', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'value'));
 
-    $endpoint->create(uniqid(), uniqid(), '', '');
+    $this->endpoint->create(uniqid(), uniqid(), '', '');
+});
 
+test('create() throws an error when missing deviceId', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'deviceId'));
 
-    $endpoint->create(uniqid(), uniqid(), uniqid(), '');
+    $this->endpoint->create(uniqid(), uniqid(), uniqid(), '');
 });
 
 test('create() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->deviceCredentials();
-
     $deviceName = uniqid();
     $type = uniqid();
     $value = uniqid();
     $deviceId = uniqid();
     $additional = uniqid();
 
-    $endpoint->create($deviceName, $type, $value, $deviceId, ['additional' => $additional]);
+    $this->endpoint->create($deviceName, $type, $value, $deviceId, ['additional' => $additional]);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/device-credentials', $this->sdk->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/device-credentials', $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('device_name', $body);
     $this->assertArrayHasKey('type', $body);
     $this->assertArrayHasKey('value', $body);
@@ -70,34 +61,30 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($deviceId, $body['device_id']);
     $this->assertEquals($additional, $body['additional']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['device_name' => $deviceName, 'type' => $type, 'value' => $value, 'device_id' => $deviceId, 'additional' => $additional]), $body);
 });
 
 test('get() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->deviceCredentials();
-
     $userId = uniqid();
     $clientId = uniqid();
     $type = uniqid();
 
-    $endpoint->get($userId, $clientId, $type);
+    $this->endpoint->get($userId, $clientId, $type);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/device-credentials', $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/device-credentials', $this->api->getRequestUrl());
 
-    $this->assertStringContainsString('&user_id=' . $userId, $this->sdk->getRequestQuery());
-    $this->assertStringContainsString('&client_id=' . $clientId, $this->sdk->getRequestQuery());
-    $this->assertStringContainsString('&type=' . $type, $this->sdk->getRequestQuery());
+    $this->assertStringContainsString('&user_id=' . $userId, $this->api->getRequestQuery());
+    $this->assertStringContainsString('&client_id=' . $clientId, $this->api->getRequestQuery());
+    $this->assertStringContainsString('&type=' . $type, $this->api->getRequestQuery());
 });
 
 test('delete() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->deviceCredentials();
-
     $id = uniqid();
 
-    $endpoint->delete($id);
+    $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/device-credentials/' . $id, $this->sdk->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/device-credentials/' . $id, $this->api->getRequestUrl());
 });

--- a/tests/Unit/API/Management/EmailTemplatesTest.php
+++ b/tests/Unit/API/Management/EmailTemplatesTest.php
@@ -59,8 +59,8 @@ test('create() issues valid requests', function(): void {
 
     $this->endpoint->create($template, $payload, $from, $subject, $syntax, true);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/email-templates');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('template', $body);
@@ -69,15 +69,15 @@ test('create() issues valid requests', function(): void {
     $this->assertArrayHasKey('subject', $body);
     $this->assertArrayHasKey('syntax', $body);
     $this->assertArrayHasKey('enabled', $body);
-    $this->assertEquals($template, $body['template']);
-    $this->assertEquals($payload, $body['body']);
-    $this->assertEquals($from, $body['from']);
-    $this->assertEquals($subject, $body['subject']);
-    $this->assertEquals($syntax, $body['syntax']);
-    $this->assertEquals(true, $body['enabled']);
+    expect($body['template'])->toEqual($template);
+    expect($body['body'])->toEqual($payload);
+    expect($body['from'])->toEqual($from);
+    expect($body['subject'])->toEqual($subject);
+    expect($body['syntax'])->toEqual($syntax);
+    expect($body['enabled'])->toEqual(true);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['template' => $template, 'body' => $payload, 'from' => $from, 'subject' => $subject, 'syntax' => $syntax, 'enabled' => true]), $body);
+    expect($body)->toEqual(json_encode(['template' => $template, 'body' => $payload, 'from' => $from, 'subject' => $subject, 'syntax' => $syntax, 'enabled' => true]));
 });
 
 test('get() issues valid requests', function(): void {
@@ -85,8 +85,8 @@ test('get() issues valid requests', function(): void {
 
     $this->endpoint->get($templateName);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/email-templates/' . $templateName);
 });
 
 test('update() issues valid requests', function(): void {
@@ -95,15 +95,15 @@ test('update() issues valid requests', function(): void {
 
     $this->endpoint->update($templateName, ['test' => $payload]);
 
-    $this->assertEquals('PUT', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PUT');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/email-templates/' . $templateName);
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $body);
-    $this->assertEquals($payload, $body['test']);
+    expect($body['test'])->toEqual($payload);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['test' => $payload]), $body);
+    expect($body)->toEqual(json_encode(['test' => $payload]));
 });
 
 test('patch() issues valid requests', function(): void {
@@ -112,13 +112,13 @@ test('patch() issues valid requests', function(): void {
 
     $this->endpoint->patch($templateName, ['test' => $payload]);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/email-templates/' . $templateName);
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $body);
-    $this->assertEquals($payload, $body['test']);
+    expect($body['test'])->toEqual($payload);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['test' => $payload]), $body);
+    expect($body)->toEqual(json_encode(['test' => $payload]));
 });

--- a/tests/Unit/API/Management/EmailTemplatesTest.php
+++ b/tests/Unit/API/Management/EmailTemplatesTest.php
@@ -9,46 +9,28 @@ beforeEach(function(): void {
 });
 
 test('create() throws an error when missing `template`', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'template'));
-
     $this->endpoint->create('', '', '', '', '', false);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'template'));
 
 
 test('create() throws an error when missing `body`', function(): void {
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
-
     $this->endpoint->create(uniqid(), '', '', '' , '', false);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
 
 
 test('create() throws an error when missing `from`', function(): void {
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'from'));
-
     $this->endpoint->create(uniqid(), uniqid(), '', '' , '', false);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'from'));
 
 
 test('create() throws an error when missing `subject`', function(): void {
-
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'subject'));
-
     $this->endpoint->create(uniqid(), uniqid(), uniqid(), '', '', false);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'subject'));
 
 
 test('create() throws an error when missing `syntax`', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'syntax'));
-
     $this->endpoint->create(uniqid(), uniqid(), uniqid(), uniqid(), '', false);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'syntax'));
 
 test('create() issues valid requests', function(): void {
     $template = uniqid();

--- a/tests/Unit/API/Management/EmailTemplatesTest.php
+++ b/tests/Unit/API/Management/EmailTemplatesTest.php
@@ -2,68 +2,67 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Utility\Request\FilteredRequest;
-use Auth0\SDK\Utility\Request\PaginatedRequest;
-use Auth0\SDK\Utility\Request\RequestOptions;
-use Auth0\Tests\Utilities\MockManagementApi;
-
-uses()->group('management', 'emailtemplates');
+uses()->group('management', 'management.email_templates');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
-
-    $this->filteredRequest = new FilteredRequest();
-    $this->paginatedRequest = new PaginatedRequest();
-    $this->requestOptions = new RequestOptions(
-        $this->filteredRequest,
-        $this->paginatedRequest
-    );
+    $this->endpoint = $this->api->mock()->emailTemplates();
 });
 
-test('create() throws an error when missing required variables', function(): void {
-    $endpoint = $this->sdk->mock()->emailTemplates();
-
+test('create() throws an error when missing `template`', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'template'));
 
-    $endpoint->create('', '', '', '', '', false);
+    $this->endpoint->create('', '', '', '', '', false);
+});
+
+
+test('create() throws an error when missing `body`', function(): void {
 
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
 
-    $endpoint->create(uniqid(), '', '', '' , '', false);
+    $this->endpoint->create(uniqid(), '', '', '' , '', false);
+});
+
+
+test('create() throws an error when missing `from`', function(): void {
 
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'from'));
 
-    $endpoint->create(uniqid(), uniqid(), '', '' , '', false);
+    $this->endpoint->create(uniqid(), uniqid(), '', '' , '', false);
+});
+
+
+test('create() throws an error when missing `subject`', function(): void {
 
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'subject'));
 
-    $endpoint->create(uniqid(), uniqid(), uniqid(), '', '', false);
+    $this->endpoint->create(uniqid(), uniqid(), uniqid(), '', '', false);
+});
 
+
+test('create() throws an error when missing `syntax`', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'syntax'));
 
-    $endpoint->create(uniqid(), uniqid(), uniqid(), uniqid(), '', false);
+    $this->endpoint->create(uniqid(), uniqid(), uniqid(), uniqid(), '', false);
 });
 
 test('create() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emailTemplates();
-
     $template = uniqid();
     $payload = uniqid();
     $from = uniqid();
     $subject = uniqid();
     $syntax = uniqid();
 
-    $endpoint->create($template, $payload, $from, $subject, $syntax, true);
+    $this->endpoint->create($template, $payload, $from, $subject, $syntax, true);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates', $this->sdk->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/email-templates', $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('template', $body);
     $this->assertArrayHasKey('body', $body);
     $this->assertArrayHasKey('from', $body);
@@ -77,55 +76,49 @@ test('create() issues valid requests', function(): void {
     $this->assertEquals($syntax, $body['syntax']);
     $this->assertEquals(true, $body['enabled']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['template' => $template, 'body' => $payload, 'from' => $from, 'subject' => $subject, 'syntax' => $syntax, 'enabled' => true]), $body);
 });
 
 test('get() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emailTemplates();
-
     $templateName = uniqid();
 
-    $endpoint->get($templateName);
+    $this->endpoint->get($templateName);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/email-templates/' . $templateName, $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
 });
 
 test('update() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emailTemplates();
-
     $templateName = uniqid();
     $payload = uniqid();
 
-    $endpoint->update($templateName, ['test' => $payload]);
+    $this->endpoint->update($templateName, ['test' => $payload]);
 
-    $this->assertEquals('PUT', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->sdk->getRequestUrl());
+    $this->assertEquals('PUT', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $body);
     $this->assertEquals($payload, $body['test']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['test' => $payload]), $body);
 });
 
 test('patch() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emailTemplates();
-
     $templateName = uniqid();
     $payload = uniqid();
 
-    $endpoint->patch($templateName, ['test' => $payload]);
+    $this->endpoint->patch($templateName, ['test' => $payload]);
 
-    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->sdk->getRequestUrl());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/email-templates/' . $templateName, $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $body);
     $this->assertEquals($payload, $body['test']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['test' => $payload]), $body);
 });

--- a/tests/Unit/API/Management/EmailsTest.php
+++ b/tests/Unit/API/Management/EmailsTest.php
@@ -2,41 +2,25 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Utility\Request\FilteredRequest;
-use Auth0\SDK\Utility\Request\PaginatedRequest;
-use Auth0\SDK\Utility\Request\RequestOptions;
-use Auth0\Tests\Utilities\MockManagementApi;
-
-uses()->group('management', 'emails');
+uses()->group('management', 'management.emails');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
-
-    $this->filteredRequest = new FilteredRequest();
-    $this->paginatedRequest = new PaginatedRequest();
-    $this->requestOptions = new RequestOptions(
-        $this->filteredRequest,
-        $this->paginatedRequest
-    );
+    $this->endpoint = $this->api->mock()->emails();
 });
 
 test('createProvider() throws an error when missing required arguments', function(): void {
-    $endpoint = $this->sdk->mock()->emails();
-
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
 
-    $endpoint->createProvider('', []);
+    $this->endpoint->createProvider('', []);
 
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
     $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'credentials'));
 
-    $endpoint->createProvider(uniqid(), []);
+    $this->endpoint->createProvider(uniqid(), []);
 });
 
 test('createProvider() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emails();
-
     $name = uniqid();
     $credentials = [
         'api_user' => uniqid(),
@@ -50,12 +34,12 @@ test('createProvider() issues valid requests', function(): void {
         'test2' => uniqid(),
     ];
 
-    $endpoint->createProvider($name, $credentials, ['additional' => $additional]);
+    $this->endpoint->createProvider($name, $credentials, ['additional' => $additional]);
 
-    $this->assertEquals('POST', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
@@ -64,22 +48,18 @@ test('createProvider() issues valid requests', function(): void {
     $this->assertEquals($credentials, $body['credentials']);
     $this->assertEquals($additional, $body['additional']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
 });
 
 test('getProvider() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emails();
+    $this->endpoint->getProvider();
 
-    $endpoint->getProvider();
-
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
 });
 
 test('updateProvider() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emails();
-
     $name = uniqid();
     $credentials = [
         'api_user' => uniqid(),
@@ -93,12 +73,12 @@ test('updateProvider() issues valid requests', function(): void {
         'test2' => uniqid(),
     ];
 
-    $endpoint->updateProvider($name, $credentials, ['additional' => $additional]);
+    $this->endpoint->updateProvider($name, $credentials, ['additional' => $additional]);
 
-    $this->assertEquals('PATCH', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
 
-    $body = $this->sdk->getRequestBody();
+    $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
@@ -107,15 +87,13 @@ test('updateProvider() issues valid requests', function(): void {
     $this->assertEquals($credentials, $body['credentials']);
     $this->assertEquals($additional, $body['additional']);
 
-    $body = $this->sdk->getRequestBodyAsString();
+    $body = $this->api->getRequestBodyAsString();
     $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
 });
 
 test('delete() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->emails();
+    $this->endpoint->deleteProvider();
 
-    $endpoint->deleteProvider();
-
-    $this->assertEquals('DELETE', $this->sdk->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->sdk->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
 });

--- a/tests/Unit/API/Management/EmailsTest.php
+++ b/tests/Unit/API/Management/EmailsTest.php
@@ -8,17 +8,13 @@ beforeEach(function(): void {
     $this->endpoint = $this->api->mock()->emails();
 });
 
-test('createProvider() throws an error when missing required arguments', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
-
+test('createProvider() throws an error when missing `name`', function(): void {
     $this->endpoint->createProvider('', []);
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
 
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'credentials'));
-
+test('createProvider() throws an error when missing `credentials`', function(): void {
     $this->endpoint->createProvider(uniqid(), []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'credentials'));
 
 test('createProvider() issues valid requests', function(): void {
     $name = uniqid();

--- a/tests/Unit/API/Management/EmailsTest.php
+++ b/tests/Unit/API/Management/EmailsTest.php
@@ -36,27 +36,27 @@ test('createProvider() issues valid requests', function(): void {
 
     $this->endpoint->createProvider($name, $credentials, ['additional' => $additional]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/emails/provider');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
-    $this->assertCount(5, $body['credentials']);
-    $this->assertEquals($name, $body['name']);
-    $this->assertEquals($credentials, $body['credentials']);
-    $this->assertEquals($additional, $body['additional']);
+    expect($body['credentials'])->toHaveCount(5);
+    expect($body['name'])->toEqual($name);
+    expect($body['credentials'])->toEqual($credentials);
+    expect($body['additional'])->toEqual($additional);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
+    expect($body)->toEqual(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]));
 });
 
 test('getProvider() issues valid requests', function(): void {
     $this->endpoint->getProvider();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/emails/provider');
 });
 
 test('updateProvider() issues valid requests', function(): void {
@@ -75,25 +75,25 @@ test('updateProvider() issues valid requests', function(): void {
 
     $this->endpoint->updateProvider($name, $credentials, ['additional' => $additional]);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/emails/provider');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
     $this->assertArrayHasKey('credentials', $body);
     $this->assertArrayHasKey('additional', $body);
-    $this->assertCount(5, $body['credentials']);
-    $this->assertEquals($name, $body['name']);
-    $this->assertEquals($credentials, $body['credentials']);
-    $this->assertEquals($additional, $body['additional']);
+    expect($body['credentials'])->toHaveCount(5);
+    expect($body['name'])->toEqual($name);
+    expect($body['credentials'])->toEqual($credentials);
+    expect($body['additional'])->toEqual($additional);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]), $body);
+    expect($body)->toEqual(json_encode(['name' => $name, 'credentials' => $credentials, 'additional' => $additional]));
 });
 
 test('delete() issues valid requests', function(): void {
     $this->endpoint->deleteProvider();
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/emails/provider', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/emails/provider');
 });

--- a/tests/Unit/API/Management/GrantsTest.php
+++ b/tests/Unit/API/Management/GrantsTest.php
@@ -11,9 +11,9 @@ beforeEach(function(): void {
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/grants');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('getAllByClientId() issues an appropriate request', function(): void {
@@ -21,9 +21,9 @@ test('getAllByClientId() issues an appropriate request', function(): void {
 
     $this->endpoint->getAllByClientId($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
-    $this->assertEquals('client_id=' . $id, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/grants');
+    expect($this->api->getRequestQuery(null))->toEqual('client_id=' . $id);
 });
 
 test('getAllByAudience() issues an appropriate request', function(): void {
@@ -31,9 +31,9 @@ test('getAllByAudience() issues an appropriate request', function(): void {
 
     $this->endpoint->getAllByAudience($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
-    $this->assertEquals('audience=' . $id, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/grants');
+    expect($this->api->getRequestQuery(null))->toEqual('audience=' . $id);
 });
 
 test('getAllByUserId() issues an appropriate request', function(): void {
@@ -41,9 +41,9 @@ test('getAllByUserId() issues an appropriate request', function(): void {
 
     $this->endpoint->getAllByUserId($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
-    $this->assertEquals('user_id=' . $id, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/grants');
+    expect($this->api->getRequestQuery(null))->toEqual('user_id=' . $id);
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -51,7 +51,7 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/grants/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/grants/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });

--- a/tests/Unit/API/Management/GrantsTest.php
+++ b/tests/Unit/API/Management/GrantsTest.php
@@ -2,86 +2,56 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.grants');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->grants();
+});
 
-/**
- * Class GrantsTest.
- */
-class GrantsTest extends TestCase
-{
-    /**
-     * Test that getAll requests properly.
-     */
-    public function testGet(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->grants()->getAll();
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll();
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/grants', $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
 
-    /**
-     * Test that getByClientId adds a client_id to the request.
-     */
-    public function testGetByClientId(): void
-    {
-        $id = uniqid();
+test('getAllByClientId() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->grants()->getAllByClientId($id);
+    $this->endpoint->getAllByClientId($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $api->getRequestUrl());
-        $this->assertEquals('client_id=' . $id, $api->getRequestQuery(null));
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
+    $this->assertEquals('client_id=' . $id, $this->api->getRequestQuery(null));
+});
 
-    /**
-     * Test that getByAudience adds an audience to the request.
-     */
-    public function testGetByAudience(): void
-    {
-        $id = uniqid();
+test('getAllByAudience() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->grants()->getAllByAudience($id);
+    $this->endpoint->getAllByAudience($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $api->getRequestUrl());
-        $this->assertEquals('audience=' . $id, $api->getRequestQuery(null));
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
+    $this->assertEquals('audience=' . $id, $this->api->getRequestQuery(null));
+});
 
-    /**
-     * Test that getByUserId adds an audience to the request.
-     */
-    public function testGetByUserId(): void
-    {
-        $id = uniqid();
+test('getAllByUserId() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->grants()->getAllByUserId($id);
+    $this->endpoint->getAllByUserId($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $api->getRequestUrl());
-        $this->assertEquals('user_id=' . $id, $api->getRequestQuery(null));
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/grants', $this->api->getRequestUrl());
+    $this->assertEquals('user_id=' . $id, $this->api->getRequestQuery(null));
+});
 
-    /**
-     * Test that delete requests properly.
-     */
-    public function testDelete(): void
-    {
-        $id = uniqid();
+test('delete() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->grants()->delete($id);
+    $this->endpoint->delete($id);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/grants/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
-}
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/grants/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});

--- a/tests/Unit/API/Management/GuardianTest.php
+++ b/tests/Unit/API/Management/GuardianTest.php
@@ -11,9 +11,9 @@ beforeEach(function(): void {
 test('getFactors() issues an appropriate request', function(): void {
     $this->endpoint->getFactors();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/guardian/factors', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/guardian/factors');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('getEnrollment() issues an appropriate request', function(): void {
@@ -21,9 +21,9 @@ test('getEnrollment() issues an appropriate request', function(): void {
 
     $this->endpoint->getEnrollment($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/guardian/enrollments/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('deleteEnrollment() issues an appropriate request', function(): void {
@@ -31,7 +31,7 @@ test('deleteEnrollment() issues an appropriate request', function(): void {
 
     $this->endpoint->deleteEnrollment($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/guardian/enrollments/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });

--- a/tests/Unit/API/Management/GuardianTest.php
+++ b/tests/Unit/API/Management/GuardianTest.php
@@ -2,56 +2,36 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.guardian');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->guardian();
+});
 
-/**
- * Class GuardianTest.
- */
-class GuardianTest extends TestCase
-{
-    /**
-     * Test that getFactors requests properly.
-     */
-    public function testGuardianGetFactor(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->guardian()->getFactors();
+test('getFactors() issues an appropriate request', function(): void {
+    $this->endpoint->getFactors();
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/guardian/factors', $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/guardian/factors', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
 
-    /**
-     * Test that getEnrollment requests properly.
-     */
-    public function testGuardianGetEnrollment(): void
-    {
-        $id = uniqid();
+test('getEnrollment() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->guardian()->getEnrollment($id);
+    $this->endpoint->getEnrollment($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
 
-    /**
-     * Test that deleteEnrollment requests properly.
-     */
-    public function testGuardianDeleteEnrollment(): void
-    {
-        $id = uniqid();
+test('deleteEnrollment() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->guardian()->deleteEnrollment($id);
+    $this->endpoint->deleteEnrollment($id);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
-    }
-}
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/guardian/enrollments/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});

--- a/tests/Unit/API/Management/JobsTest.php
+++ b/tests/Unit/API/Management/JobsTest.php
@@ -11,15 +11,15 @@ beforeEach(function(): void {
 test('get() issues an appropriate request', function(): void {
     $this->endpoint->get('__test_id__');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/jobs/__test_id__', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/jobs/__test_id__');
 });
 
 test('getErrors() issues an appropriate request', function(): void {
     $this->endpoint->getErrors('__test_id__');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/jobs/__test_id__/errors', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/jobs/__test_id__/errors');
 });
 
 test('createImportUsers() issues an appropriate request', function(): void {
@@ -36,35 +36,35 @@ test('createImportUsers() issues an appropriate request', function(): void {
         ]
     );
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/jobs/users-imports', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/jobs/users-imports');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertStringStartsWith('multipart/form-data', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toStartWith('multipart/form-data');
 
     $form_body = $this->api->getRequestBodyAsString();
     $form_body_arr = explode("\r\n", $form_body);
 
     // Test that the form data contains our import file content.
     $import_content = file_get_contents($importPath);
-    $this->assertStringContainsString('name="users"; filename="test-import-users-file.json"', $form_body);
-    $this->assertStringContainsString($import_content, $form_body);
+    expect($form_body)->toContain('name="users"; filename="test-import-users-file.json"');
+    expect($form_body)->toContain($import_content);
 
     $conn_id_key = array_search('Content-Disposition: form-data; name="connection_id"', $form_body_arr);
     $this->assertNotEmpty($conn_id_key);
-    $this->assertEquals('__test_conn_id__', $form_body_arr[$conn_id_key + $keyOffset]);
+    expect($form_body_arr[$conn_id_key + $keyOffset])->toEqual('__test_conn_id__');
 
     $upsert_key = array_search('Content-Disposition: form-data; name="upsert"', $form_body_arr);
     $this->assertNotEmpty($upsert_key);
-    $this->assertEquals('true', $form_body_arr[$upsert_key + $keyOffset]);
+    expect($form_body_arr[$upsert_key + $keyOffset])->toEqual('true');
 
     $email_key = array_search('Content-Disposition: form-data; name="send_completion_email"', $form_body_arr);
     $this->assertNotEmpty($email_key);
-    $this->assertEquals('true', $form_body_arr[$email_key + $keyOffset]);
+    expect($form_body_arr[$email_key + $keyOffset])->toEqual('true');
 
     $ext_id_key = array_search('Content-Disposition: form-data; name="external_id"', $form_body_arr);
     $this->assertNotEmpty($ext_id_key);
-    $this->assertEquals('__test_ext_id__', $form_body_arr[$ext_id_key + $keyOffset]);
+    expect($form_body_arr[$ext_id_key + $keyOffset])->toEqual('__test_ext_id__');
 });
 
 test('createExportUsers() issues an appropriate request', function(): void {
@@ -81,26 +81,26 @@ test('createExportUsers() issues an appropriate request', function(): void {
 
     $this->endpoint->createExportUsers($mock);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/jobs/users-exports', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/jobs/users-exports');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request_body = $this->api->getRequestBody();
 
     $this->assertNotEmpty($request_body['connection_id']);
-    $this->assertEquals($mock['connection_id'], $request_body['connection_id']);
+    expect($request_body['connection_id'])->toEqual($mock['connection_id']);
 
     $this->assertNotEmpty($request_body['limit']);
-    $this->assertEquals($mock['limit'], $request_body['limit']);
+    expect($request_body['limit'])->toEqual($mock['limit']);
 
     $this->assertNotEmpty($request_body['format']);
-    $this->assertEquals('json', $request_body['format']);
+    expect($request_body['format'])->toEqual('json');
 
     $this->assertNotEmpty($request_body['fields']);
-    $this->assertEquals([['name' => $mock['fields'][0]['name']]], $request_body['fields']);
+    expect($request_body['fields'])->toEqual([['name' => $mock['fields'][0]['name']]]);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode((object) $mock), $body);
+    expect($body)->toEqual(json_encode((object) $mock));
 });
 
 test('createSendVerificationEmail() issues an appropriate request', function(): void {
@@ -117,21 +117,21 @@ test('createSendVerificationEmail() issues an appropriate request', function(): 
 
     $this->endpoint->createSendVerificationEmail($mock->userId, $mock->body);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/jobs/verification-email', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/jobs/verification-email');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('user_id', $body);
-    $this->assertEquals($mock->userId, $body['user_id']);
+    expect($body['user_id'])->toEqual($mock->userId);
     $this->assertArrayHasKey('client_id', $body);
-    $this->assertEquals($mock->body['client_id'], $body['client_id']);
+    expect($body['client_id'])->toEqual($mock->body['client_id']);
     $this->assertArrayHasKey('identity', $body);
-    $this->assertEquals($mock->body['identity'], $body['identity']);
+    expect($body['identity'])->toEqual($mock->body['identity']);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['user_id' => $mock->userId], $mock->body)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['user_id' => $mock->userId], $mock->body)));
 });

--- a/tests/Unit/API/Management/LogStreamsTest.php
+++ b/tests/Unit/API/Management/LogStreamsTest.php
@@ -2,105 +2,88 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.log_streams');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->logStreams();
+});
 
-class LogStreamsTest extends TestCase
-{
-    public function testGetAll(): void
-    {
-        $api = new MockManagementApi();
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll();
 
-        $api->mock()->logStreams()->getAll();
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams', $this->api->getRequestUrl());
+});
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams', $api->getRequestUrl());
-    }
+test('get() issues an appropriate request', function(): void {
+    $this->endpoint->get('123');
 
-    public function testGet(): void
-    {
-        $api = new MockManagementApi();
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams/123', $this->api->getRequestUrl());
+});
 
-        $api->mock()->logStreams()->get('123');
+test('create() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'type' => uniqid(),
+        'sink' => [
+            'httpEndpoint' => uniqid(),
+            'httpContentFormat' => uniqid(),
+            'httpContentType' => uniqid(),
+            'httpAuthorization' => uniqid(),
+        ],
+        'name' => uniqid(),
+    ];
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams/123', $api->getRequestUrl());
-    }
+    $this->endpoint->create($mock->type, $mock->sink, $mock->name);
 
-    public function testThatCreateLogStreamRequestIsFormedCorrectly(): void
-    {
-        $mock = (object) [
-            'type' => uniqid(),
-            'sink' => [
-                'httpEndpoint' => uniqid(),
-                'httpContentFormat' => uniqid(),
-                'httpContentType' => uniqid(),
-                'httpAuthorization' => uniqid(),
-            ],
-            'name' => uniqid(),
-        ];
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/log-streams', $this->api->getRequestUrl());
 
-        $api = new MockManagementApi();
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $api->mock()->logStreams()->create($mock->type, $mock->sink, $mock->name);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($mock->name, $body['name']);
+    $this->assertArrayHasKey('type', $body);
+    $this->assertEquals($mock->type, $body['type']);
+    $this->assertArrayHasKey('sink', $body);
+    $this->assertEquals($mock->sink, $body['sink']);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/log-streams', $api->getRequestUrl());
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($mock), $body);
+});
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+test('update() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'id' => uniqid(),
+        'body' => [
+            'name' => uniqid()
+        ]
+    ];
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($mock->name, $body['name']);
-        $this->assertArrayHasKey('type', $body);
-        $this->assertEquals($mock->type, $body['type']);
-        $this->assertArrayHasKey('sink', $body);
-        $this->assertEquals($mock->sink, $body['sink']);
+    $this->endpoint->update($mock->id, $mock->body);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode($mock), $body);
-    }
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/log-streams/' . $mock->id, $this->api->getRequestUrl());
 
-    public function testUpdate(): void
-    {
-        $mock = (object) [
-            'id' => uniqid(),
-            'body' => [
-                'name' => uniqid()
-            ]
-        ];
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $api = new MockManagementApi();
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($mock->body['name'], $body['name']);
 
-        $api->mock()->logStreams()->update($mock->id, $mock->body);
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($mock->body), $body);
+});
 
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/log-streams/' . $mock->id, $api->getRequestUrl());
+test('delete() issues an appropriate request', function(): void {
+    $this->endpoint->delete('123');
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/log-streams/123', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($mock->body['name'], $body['name']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode($mock->body), $body);
-    }
-
-    public function testDelete(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->logStreams()->delete('123');
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/log-streams/123', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
-}
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});

--- a/tests/Unit/API/Management/LogStreamsTest.php
+++ b/tests/Unit/API/Management/LogStreamsTest.php
@@ -11,15 +11,15 @@ beforeEach(function(): void {
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/log-streams');
 });
 
 test('get() issues an appropriate request', function(): void {
     $this->endpoint->get('123');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/log-streams/123', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/log-streams/123');
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -36,22 +36,22 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($mock->type, $mock->sink, $mock->name);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/log-streams', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/log-streams');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mock->name, $body['name']);
+    expect($body['name'])->toEqual($mock->name);
     $this->assertArrayHasKey('type', $body);
-    $this->assertEquals($mock->type, $body['type']);
+    expect($body['type'])->toEqual($mock->type);
     $this->assertArrayHasKey('sink', $body);
-    $this->assertEquals($mock->sink, $body['sink']);
+    expect($body['sink'])->toEqual($mock->sink);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mock), $body);
+    expect($body)->toEqual(json_encode($mock));
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -64,26 +64,26 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($mock->id, $mock->body);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/log-streams/' . $mock->id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/log-streams/' . $mock->id);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mock->body['name'], $body['name']);
+    expect($body['name'])->toEqual($mock->body['name']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mock->body), $body);
+    expect($body)->toEqual(json_encode($mock->body));
 });
 
 test('delete() issues an appropriate request', function(): void {
     $this->endpoint->delete('123');
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/log-streams/123', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/log-streams/123');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });

--- a/tests/Unit/API/Management/LogsTest.php
+++ b/tests/Unit/API/Management/LogsTest.php
@@ -11,8 +11,8 @@ beforeEach(function(): void {
 test('getAll() issues valid requests', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/logs', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/logs');
 });
 
 test('get() issues valid requests', function(): void {
@@ -20,6 +20,6 @@ test('get() issues valid requests', function(): void {
 
     $this->endpoint->get($logId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/logs/' . $logId, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/logs/' . $logId);
 });

--- a/tests/Unit/API/Management/LogsTest.php
+++ b/tests/Unit/API/Management/LogsTest.php
@@ -2,33 +2,24 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Utility\Request\FilteredRequest;
-use Auth0\SDK\Utility\Request\PaginatedRequest;
-use Auth0\SDK\Utility\Request\RequestOptions;
-use Auth0\Tests\Utilities\MockManagementApi;
-
-uses()->group('management', 'logs');
+uses()->group('management', 'management.logs');
 
 beforeEach(function(): void {
-    $this->sdk = new MockManagementApi();
+    $this->endpoint = $this->api->mock()->logs();
 });
 
 test('getAll() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->logs();
+    $this->endpoint->getAll();
 
-    $endpoint->getAll();
-
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/logs', $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/logs', $this->api->getRequestUrl());
 });
 
 test('get() issues valid requests', function(): void {
-    $endpoint = $this->sdk->mock()->logs();
-
     $logId = uniqid();
 
-    $endpoint->get($logId);
+    $this->endpoint->get($logId);
 
-    $this->assertEquals('GET', $this->sdk->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/logs/' . $logId, $this->sdk->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/logs/' . $logId, $this->api->getRequestUrl());
 });

--- a/tests/Unit/API/Management/ManagementEndpointTest.php
+++ b/tests/Unit/API/Management/ManagementEndpointTest.php
@@ -25,18 +25,18 @@ beforeEach(function(): void {
 });
 
 test('getHttpClient() returns an HttpClient instance', function(): void {
-    $this->assertInstanceOf(HttpClient::class, $this->endpoint->getHttpClient());
+    expect($this->endpoint->getHttpClient())->toBeInstanceOf(HttpClient::class);
 });
 
 test('getLastRequest() returns null when no requests have been made', function(): void {
-    $this->assertNull($this->endpoint->getLastRequest());
+    expect($this->endpoint->getLastRequest())->toBeNull();
 });
 
 test('getLastRequest() returns an HttpRequest instance', function(): void {
     $client = new Users($this->httpClient);
     $client->getAll();
 
-    $this->assertInstanceOf(HttpRequest::class, $client->getLastRequest());
+    expect($client->getLastRequest())->toBeInstanceOf(HttpRequest::class);
 });
 
 test('getResponsePaginator() returns an HttpResponsePaginator instance', function(): void {
@@ -51,12 +51,12 @@ test('getResponsePaginator() returns an HttpResponsePaginator instance', functio
     $client = new Users($this->httpClient);
     $response = $client->getAll(null, new RequestOptions(null, new PaginatedRequest(0, 5, true)));
 
-    $this->assertInstanceOf(HttpResponsePaginator::class, $client->getResponsePaginator());
+    expect($client->getResponsePaginator())->toBeInstanceOf(HttpResponsePaginator::class);
 });
 
 test('getResponsePaginator() throws an exception when a request has not been made', function(): void {
     $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
     $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
 
-    $this->assertInstanceOf(HttpResponsePaginator::class, $this->endpoint->getResponsePaginator());
+    expect($this->endpoint->getResponsePaginator())->toBeInstanceOf(HttpResponsePaginator::class);
 });

--- a/tests/Unit/API/Management/ManagementEndpointTest.php
+++ b/tests/Unit/API/Management/ManagementEndpointTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\API\Management\ManagementEndpoint;
+use Auth0\SDK\API\Management\Users;
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Utility\HttpClient;
+use Auth0\SDK\Utility\HttpRequest;
+use Auth0\SDK\Utility\HttpResponsePaginator;
+use Auth0\SDK\Utility\Request\PaginatedRequest;
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\Tests\Utilities\HttpResponseGenerator;
+
+uses()->group('management', 'management.generic');
+
+beforeEach(function(): void {
+    $this->configuration = new SdkConfiguration([
+        'strategy' => 'none',
+        'domain' => 'api.local.test'
+    ]);
+
+    $this->httpClient = new HttpClient($this->configuration,  HttpClient::CONTEXT_GENERIC_CLIENT);
+    $this->endpoint = new class($this->httpClient) extends ManagementEndpoint {};
+});
+
+test('getHttpClient() returns an HttpClient instance', function(): void {
+    $this->assertInstanceOf(HttpClient::class, $this->endpoint->getHttpClient());
+});
+
+test('getLastRequest() returns null when no requests have been made', function(): void {
+    $this->assertNull($this->endpoint->getLastRequest());
+});
+
+test('getLastRequest() returns an HttpRequest instance', function(): void {
+    $client = new Users($this->httpClient);
+    $client->getAll();
+
+    $this->assertInstanceOf(HttpRequest::class, $client->getLastRequest());
+});
+
+test('getResponsePaginator() returns an HttpResponsePaginator instance', function(): void {
+    $this->httpClient->mockResponse(HttpResponseGenerator::create(json_encode([
+        'start' => 0,
+        'total' => 3,
+        'limit' => 3,
+        'length' => 3,
+        'users' => [uniqid(), uniqid(), uniqid()],
+    ])));
+
+    $client = new Users($this->httpClient);
+    $response = $client->getAll(null, new RequestOptions(null, new PaginatedRequest(0, 5, true)));
+
+    $this->assertInstanceOf(HttpResponsePaginator::class, $client->getResponsePaginator());
+});
+
+test('getResponsePaginator() throws an exception when a request has not been made', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
+
+    $this->assertInstanceOf(HttpResponsePaginator::class, $this->endpoint->getResponsePaginator());
+});

--- a/tests/Unit/API/Management/ManagementEndpointTest.php
+++ b/tests/Unit/API/Management/ManagementEndpointTest.php
@@ -55,8 +55,5 @@ test('getResponsePaginator() returns an HttpResponsePaginator instance', functio
 });
 
 test('getResponsePaginator() throws an exception when a request has not been made', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
-
     expect($this->endpoint->getResponsePaginator())->toBeInstanceOf(HttpResponsePaginator::class);
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -26,30 +26,30 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($mock->id, $mock->name, $mock->branding, $mock->metadata, $mock->body);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/organizations', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/organizations');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
 
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mock->id, $body['name']);
+    expect($body['name'])->toEqual($mock->id);
 
     $this->assertArrayHasKey('display_name', $body);
-    $this->assertEquals($mock->name, $body['display_name']);
+    expect($body['display_name'])->toEqual($mock->name);
 
     $this->assertArrayHasKey('branding', $body);
     $this->assertArrayHasKey('logo_url', $body['branding']);
-    $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
+    expect($body['branding']['logo_url'])->toEqual($mock->branding['logo_url']);
 
     $this->assertArrayHasKey('metadata', $body);
     $this->assertArrayHasKey('test', $body['metadata']);
-    $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+    expect($body['metadata']['test'])->toEqual($mock->metadata['test']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)));
 });
 
 test('create() throws an exception when an invalid `name` argument is used', function(): void {
@@ -86,30 +86,30 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($mock->id, $mock->name, $mock->displayName, $mock->branding, $mock->metadata, $mock->body);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/organizations/' . $mock->id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/organizations/' . $mock->id);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
 
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mock->name, $body['name']);
+    expect($body['name'])->toEqual($mock->name);
 
     $this->assertArrayHasKey('display_name', $body);
-    $this->assertEquals($mock->displayName, $body['display_name']);
+    expect($body['display_name'])->toEqual($mock->displayName);
 
     $this->assertArrayHasKey('branding', $body);
     $this->assertArrayHasKey('logo_url', $body['branding']);
-    $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
+    expect($body['branding']['logo_url'])->toEqual($mock->branding['logo_url']);
 
     $this->assertArrayHasKey('metadata', $body);
     $this->assertArrayHasKey('test', $body['metadata']);
-    $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+    expect($body['metadata']['test'])->toEqual($mock->metadata['test']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'display_name' => $mock->displayName, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mock->name, 'display_name' => $mock->displayName, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)));
 });
 
 test('update() throws an exception when an invalid `id` is used', function(): void {
@@ -129,11 +129,11 @@ test('update() throws an exception when an invalid `displayName` is used', funct
 test('delete() issues an appropriate request', function(): void {
     $this->endpoint->delete('test-organization');
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/organizations/test-organization', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/organizations/test-organization');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
 test('delete() throws an exception when an invalid `id` is used', function(): void {
@@ -146,15 +146,15 @@ test('delete() throws an exception when an invalid `id` is used', function(): vo
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations');
 });
 
 test('get() issues an appropriate request', function(): void {
     $this->endpoint->get('123');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/123', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/123');
 });
 
 test('get() throws an exception when an invalid `id` is used', function(): void {
@@ -167,8 +167,8 @@ test('get() throws an exception when an invalid `id` is used', function(): void 
 test('getByName() issues an appropriate request', function(): void {
     $this->endpoint->getByName('test-organization');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/name/test-organization', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/name/test-organization');
 });
 
 test('getByName() throws an exception when an invalid `name` is used', function(): void {
@@ -181,8 +181,8 @@ test('getByName() throws an exception when an invalid `name` is used', function(
 test('getEnabledConnections() issues an appropriate request', function(): void {
     $this->endpoint->getEnabledConnections('test-organization');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections');
 });
 
 test('getEnabledConnections() throws an exception when an invalid `id` is used', function(): void {
@@ -195,8 +195,8 @@ test('getEnabledConnections() throws an exception when an invalid `id` is used',
 test('getEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->getEnabledConnection('test-organization', 'test-connection');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection');
 });
 
 test('getEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
@@ -216,15 +216,15 @@ test('getEnabledConnection() throws an exception when an invalid `connectionId` 
 test('addEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->addEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('connection_id', $body);
-    $this->assertEquals('test-connection', $body['connection_id']);
+    expect($body['connection_id'])->toEqual('test-connection');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['connection_id' => 'test-connection', 'assign_membership_on_login' => true]), $body);
+    expect($body)->toEqual(json_encode(['connection_id' => 'test-connection', 'assign_membership_on_login' => true]));
 });
 
 test('addEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
@@ -244,18 +244,18 @@ test('addEnabledConnection() throws an exception when an invalid `connectionId` 
 test('updateEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->updateEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('assign_membership_on_login', $body);
-    $this->assertTrue($body['assign_membership_on_login']);
+    expect($body['assign_membership_on_login'])->toBeTrue();
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['assign_membership_on_login' => true]), $body);
+    expect($body)->toEqual(json_encode(['assign_membership_on_login' => true]));
 });
 
 test('updateEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
@@ -275,8 +275,8 @@ test('updateEnabledConnection() throws an exception when an invalid `connectionI
 test('removeEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->removeEnabledConnection('test-organization', 'test-connection');
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection');
 });
 
 test('removeEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
@@ -296,8 +296,8 @@ test('removeEnabledConnection() throws an exception when an invalid `connectionI
 test('getMembers() issues an appropriate request', function(): void {
     $this->endpoint->getMembers('test-organization');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members');
 });
 
 test('getMembers() throws an exception when an invalid `id` is used', function(): void {
@@ -310,18 +310,18 @@ test('getMembers() throws an exception when an invalid `id` is used', function()
 test('addMembers() issues an appropriate request', function(): void {
     $this->endpoint->addMembers('test-organization', ['test-user']);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('members', $body);
-    $this->assertContains('test-user', $body['members']);
+    expect($body['members'])->toContain('test-user');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
+    expect($body)->toEqual(json_encode(['members' => ['test-user']]));
 });
 
 test('addMembers() throws an exception when an invalid `id` is used', function(): void {
@@ -341,15 +341,15 @@ test('addMembers() throws an exception when an invalid `members` is used', funct
 test('removeMembers() issues an appropriate request', function(): void {
     $this->endpoint->removeMembers('test-organization', ['test-user']);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('members', $body);
-    $this->assertContains('test-user', $body['members']);
+    expect($body['members'])->toContain('test-user');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
+    expect($body)->toEqual(json_encode(['members' => ['test-user']]));
 });
 
 test('removeMembers() throws an exception when an invalid `id` is used', function(): void {
@@ -369,8 +369,8 @@ test('removeMembers() throws an exception when an invalid `members` is used', fu
 test('getMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->getMemberRoles('test-organization', 'test-user');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles');
 });
 
 test('getMemberRoles() throws an exception when an invalid `id` is used', function(): void {
@@ -390,18 +390,18 @@ test('getMemberRoles() throws an exception when an invalid `userId` is used', fu
 test('addMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->addMemberRoles('test-organization', 'test-user', ['test-role']);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('roles', $body);
-    $this->assertContains('test-role', $body['roles']);
+    expect($body['roles'])->toContain('test-role');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
+    expect($body)->toEqual(json_encode(['roles' => ['test-role']]));
 });
 
 test('addMemberRoles() throws an exception when an invalid `id` is used', function(): void {
@@ -428,15 +428,15 @@ test('addMemberRoles() throws an exception when an invalid `roles` is used', fun
 test('removeMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->removeMemberRoles('test-organization', 'test-user', ['test-role']);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('roles', $body);
-    $this->assertContains('test-role', $body['roles']);
+    expect($body['roles'])->toContain('test-role');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
+    expect($body)->toEqual(json_encode(['roles' => ['test-role']]));
 });
 
 test('removeMemberRoles() throws an exception when an invalid `id` is used', function(): void {
@@ -463,8 +463,8 @@ test('removeMemberRoles() throws an exception when an invalid `roles` is used', 
 test('getInvitations() issues an appropriate request', function(): void {
     $this->endpoint->getInvitations('test-organization');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/invitations');
 });
 
 test('getInvitations() throws an exception when an invalid `id` is used', function(): void {
@@ -477,8 +477,8 @@ test('getInvitations() throws an exception when an invalid `id` is used', functi
 test('getInvitation() issues an appropriate request', function(): void {
     $this->endpoint->getInvitation('test-organization', 'test-invitation');
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation');
 });
 
 test('getInvitation() throws an exception when an invalid `id` is used', function(): void {
@@ -503,24 +503,24 @@ test('createInvitation() issues an appropriate request', function(): void {
         ['email' => 'email@test.com']
     );
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/invitations');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('client_id', $body);
-    $this->assertEquals('test-client', $body['client_id']);
+    expect($body['client_id'])->toEqual('test-client');
     $this->assertArrayHasKey('inviter', $body);
     $this->assertArrayHasKey('name', $body['inviter']);
-    $this->assertEquals('Test Sender', $body['inviter']['name']);
+    expect($body['inviter']['name'])->toEqual('Test Sender');
     $this->assertArrayHasKey('invitee', $body);
     $this->assertArrayHasKey('email', $body['invitee']);
-    $this->assertEquals('email@test.com', $body['invitee']['email']);
+    expect($body['invitee']['email'])->toEqual('email@test.com');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['client_id' => 'test-client', 'inviter' => ['name' => 'Test Sender'], 'invitee' => ['email' => 'email@test.com']]), $body);
+    expect($body)->toEqual(json_encode(['client_id' => 'test-client', 'inviter' => ['name' => 'Test Sender'], 'invitee' => ['email' => 'email@test.com']]));
 });
 
 test('createInvitation() throws an exception when an invalid `id` is used', function(): void {
@@ -568,8 +568,8 @@ test('createInvitation() throws an exception when an invalid `invitee.email` is 
 test('deleteInvitation() issues an appropriate request', function(): void {
     $this->endpoint->deleteInvitation('test-organization', 'test-invitation');
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation');
 });
 
 test('deleteInvitation() throws an exception when an invalid `id` is used', function(): void {

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -1,964 +1,587 @@
 <?php
-
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.organizations');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->organizations();
+});
 
-/**
- * Class OrganizationsTest.
- * Tests the Auth0\SDK\API\Management\Organizations class.
- *
- * @group unit
- * @group management
- * @group organizations
- */
-class OrganizationsTest extends TestCase
-{
-    /**
-     * Test that create organization request is formed correctly.
-     */
-    public function testThatCreateOrganizationRequestIsFormedCorrectly(): void
-    {
-        $mock = (object) [
-            'id' => uniqid(),
-            'name' => uniqid(),
-            'branding' => [
-                'logo_url' => uniqid(),
-            ],
-            'metadata' => [
-                'test' => uniqid()
-            ],
-            'body' => [
-                'additional' => [
-                    'testing' => uniqid()
-                ]
+test('create() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'id' => uniqid(),
+        'name' => uniqid(),
+        'branding' => [
+            'logo_url' => uniqid(),
+        ],
+        'metadata' => [
+            'test' => uniqid()
+        ],
+        'body' => [
+            'additional' => [
+                'testing' => uniqid()
             ]
-        ];
+        ]
+    ];
 
-        $api = new MockManagementApi();
+    $this->endpoint->create($mock->id, $mock->name, $mock->branding, $mock->metadata, $mock->body);
 
-        $api->mock()->organizations()->create($mock->id, $mock->name, $mock->branding, $mock->metadata, $mock->body);
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/organizations', $this->api->getRequestUrl());
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/organizations', $api->getRequestUrl());
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $body = $this->api->getRequestBody();
 
-        $body = $api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($mock->id, $body['name']);
 
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($mock->id, $body['name']);
+    $this->assertArrayHasKey('display_name', $body);
+    $this->assertEquals($mock->name, $body['display_name']);
 
-        $this->assertArrayHasKey('display_name', $body);
-        $this->assertEquals($mock->name, $body['display_name']);
+    $this->assertArrayHasKey('branding', $body);
+    $this->assertArrayHasKey('logo_url', $body['branding']);
+    $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
 
-        $this->assertArrayHasKey('branding', $body);
-        $this->assertArrayHasKey('logo_url', $body['branding']);
-        $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
+    $this->assertArrayHasKey('metadata', $body);
+    $this->assertArrayHasKey('test', $body['metadata']);
+    $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
 
-        $this->assertArrayHasKey('metadata', $body);
-        $this->assertArrayHasKey('test', $body['metadata']);
-        $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
+});
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
-    }
+test('create() throws an exception when an invalid `name` argument is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
 
-    /**
-     * Test that create organization request with empty name throws exception.
-     */
-    public function testThatCreateOrganizationRequestWithEmptyNameThrowsException(): void
-    {
-        $api = new MockManagementApi();
+    $this->endpoint->create('', '');
+});
 
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
+test('create() throws an exception when an invalid `displayName` argument is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
 
-        $api->mock()->organizations()->create('', '');
-    }
+    $this->endpoint->create('test-organization', '');
+});
 
-    /**
-     * Test that create organization request with empty display name throws exception.
-     */
-    public function testThatCreateOrganizationRequestWithEmptyDisplayNameThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
-
-        $api->mock()->organizations()->create('test-organization', '');
-    }
-
-    /**
-     * Test that update organization request is formed correctly.
-     */
-    public function testThatUpdateOrganizationRequestIsFormedCorrectly(): void
-    {
-        $mock = (object) [
-            'id' => uniqid(),
-            'name' => uniqid(),
-            'displayName' => uniqid(),
-            'branding' => [
-                'logo_url' => uniqid(),
-            ],
-            'metadata' => [
-                'test' => uniqid()
-            ],
-            'body' => [
-                'additional' => [
-                    'testing' => uniqid()
-                ]
+test('update() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'id' => uniqid(),
+        'name' => uniqid(),
+        'displayName' => uniqid(),
+        'branding' => [
+            'logo_url' => uniqid(),
+        ],
+        'metadata' => [
+            'test' => uniqid()
+        ],
+        'body' => [
+            'additional' => [
+                'testing' => uniqid()
             ]
-        ];
+        ]
+    ];
 
-        $api = new MockManagementApi();
+    $this->endpoint->update($mock->id, $mock->name, $mock->displayName, $mock->branding, $mock->metadata, $mock->body);
 
-        $api->mock()->organizations()->update($mock->id, $mock->name, $mock->displayName, $mock->branding, $mock->metadata, $mock->body);
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/organizations/' . $mock->id, $this->api->getRequestUrl());
 
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/organizations/' . $mock->id, $api->getRequestUrl());
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $body = $this->api->getRequestBody();
 
-        $body = $api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($mock->name, $body['name']);
 
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($mock->name, $body['name']);
+    $this->assertArrayHasKey('display_name', $body);
+    $this->assertEquals($mock->displayName, $body['display_name']);
 
-        $this->assertArrayHasKey('display_name', $body);
-        $this->assertEquals($mock->displayName, $body['display_name']);
+    $this->assertArrayHasKey('branding', $body);
+    $this->assertArrayHasKey('logo_url', $body['branding']);
+    $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
 
-        $this->assertArrayHasKey('branding', $body);
-        $this->assertArrayHasKey('logo_url', $body['branding']);
-        $this->assertEquals($mock->branding['logo_url'], $body['branding']['logo_url']);
+    $this->assertArrayHasKey('metadata', $body);
+    $this->assertArrayHasKey('test', $body['metadata']);
+    $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
 
-        $this->assertArrayHasKey('metadata', $body);
-        $this->assertArrayHasKey('test', $body['metadata']);
-        $this->assertEquals($mock->metadata['test'], $body['metadata']['test']);
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'display_name' => $mock->displayName, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
+});
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(array_merge(['name' => $mock->name, 'display_name' => $mock->displayName, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)), $body);
-    }
+test('update() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
-    /**
-     * Test that update organization request with empty id throws exception.
-     */
-    public function testThatUpdateOrganizationRequestWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
+    $this->endpoint->update('', '', '');
+});
 
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+test('update() throws an exception when an invalid `displayName` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
 
-        $api->mock()->organizations()->update('', '', '');
-    }
+    $this->endpoint->update('test-organization', '', '');
+});
 
-    /**
-     * Test that update organization request with empty display name throws exception.
-     */
-    public function testThatUpdateOrganizationRequestWithEmptyDisplayNameThrowsException(): void
-    {
-        $api = new MockManagementApi();
+test('delete() issues an appropriate request', function(): void {
+    $this->endpoint->delete('test-organization');
 
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/organizations/test-organization', $this->api->getRequestUrl());
 
-        $api->mock()->organizations()->update('test-organization', '', '');
-    }
-
-    /**
-     * Test that delete organization request is formed correctly.
-     */
-    public function testThatDeleteOrganizationRequestIsFormedCorrectly(): void
-    {
-        $api = new MockManagementApi();
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});
 
-        $api->mock()->organizations()->delete('test-organization');
+test('delete() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/organizations/test-organization', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
-
-    /**
-     * Test that delete organization request with empty id throws exception.
-     */
-    public function testThatDeleteOrganizationRequestWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
+    $this->endpoint->delete('');
+});
 
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->delete('');
-    }
-
-    /**
-     * Test that get all request is formed properly.
-     */
-    public function testThatGetAllRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getAll();
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get request is formed properly.
-     */
-    public function testThatGetRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->get('123');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/123', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get with empty id throws exception.
-     */
-    public function testThatGetWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->get('');
-    }
-
-    /**
-     * Test that get by name request is formed properly.
-     */
-    public function testThatGetByNameRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getByName('test-organization');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/name/test-organization', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get by name with empty id throws exception.
-     */
-    public function testThatGetByNameWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
-
-        $api->mock()->organizations()->getByName('');
-    }
-
-    /**
-     * Test that get enabled connections request is formed properly.
-     */
-    public function testThatGetEnabledConnectionsRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getEnabledConnections('test-organization');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get enabled connections with empty id throws exception.
-     */
-    public function testThatGetEnabledConnectionsWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getEnabledConnections('');
-    }
-
-    /**
-     * Test that get enabled connection request is formed properly.
-     */
-    public function testThatGetEnabledConnectionRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getEnabledConnection('test-organization', 'test-connection');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get enabled connection with empty id throws exception.
-     */
-    public function testThatGetEnabledConnectionWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getEnabledConnection('', '');
-    }
-
-    /**
-     * Test that get enabled connection with empty connection throws exception.
-     */
-    public function testThatGetEnabledConnectionWithEmptyConnectionThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
-        $api->mock()->organizations()->getEnabledConnection('test-organization', '');
-    }
-
-    /**
-     * Test that add enabled connection request is formed properly.
-     */
-    public function testThatAddEnabledConnectionRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->addEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $api->getRequestUrl());
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('connection_id', $body);
-        $this->assertEquals('test-connection', $body['connection_id']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['connection_id' => 'test-connection', 'assign_membership_on_login' => true]), $body);
-    }
-
-    /**
-     * Test that add enabled connection with empty id throws exception.
-     */
-    public function testThatAddEnabledConnectionWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->addEnabledConnection('', '', ['assign_membership_on_login' => true]);
-    }
-
-    /**
-     * Test that add enabled connection with empty connection throws exception.
-     */
-    public function testThatAddEnabledConnectionWithEmptyConnectionThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
-        $api->mock()->organizations()->addEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
-    }
-
-    /**
-     * Test that update enabled connection request is formed properly.
-     */
-    public function testThatUpdateEnabledConnectionRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->updateEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
-
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('assign_membership_on_login', $body);
-        $this->assertTrue($body['assign_membership_on_login']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['assign_membership_on_login' => true]), $body);
-    }
-
-    /**
-     * Test that update enabled connection with empty id throws exception.
-     */
-    public function testThatUpdateEnabledConnectionWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->updateEnabledConnection('', '', ['assign_membership_on_login' => true]);
-    }
-
-    /**
-     * Test that update enabled connection with empty connection throws exception.
-     */
-    public function testThatUpdateEnabledConnectionWithEmptyConnectionThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
-        $api->mock()->organizations()->updateEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
-    }
-
-    /**
-     * Test that remove enabled connection request is formed properly.
-     */
-    public function testThatRemoveEnabledConnectionRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->removeEnabledConnection('test-organization', 'test-connection');
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $api->getRequestUrl());
-    }
-
-    /**
-     * Test hat remove enabled connection with empty id throws exception.
-     */
-    public function testThatRemoveEnabledConnectionWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->removeEnabledConnection('', '');
-    }
-
-    /**
-     * Test that remove enabled connection with empty connection throws exception.
-     */
-    public function testThatRemoveEnabledConnectionWithEmptyConnectionThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
-        $api->mock()->organizations()->removeEnabledConnection('test-organization', '');
-    }
-
-    /**
-     * Test that get members request is formed properly.
-     */
-    public function testThatGetMembersRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getMembers('test-organization');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get members with empty id throws exception.
-     */
-    public function testThatGetMembersWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getMembers('');
-    }
-
-    /**
-     * Test that add members request is formed properly.
-     */
-    public function testThatAddMembersRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->addMembers('test-organization', ['test-user']);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('members', $body);
-        $this->assertContains('test-user', $body['members']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
-    }
-
-    /**
-     * Test that add members request with empty id throws exception.
-     */
-    public function testThatAddMembersWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->addMembers('', []);
-    }
-
-    /**
-     * Test that add members with empty users throws exception.
-     */
-    public function testThatAddMembersWithEmptyUsersThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
-
-        $api->mock()->organizations()->addMembers('test-organization', []);
-    }
-
-    /**
-     * Test that remove members request is formed properly.
-     */
-    public function testThatRemoveMembersRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->removeMembers('test-organization', ['test-user']);
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $api->getRequestUrl());
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('members', $body);
-        $this->assertContains('test-user', $body['members']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
-    }
-
-    /**
-     * Test that remove members with empty id throws exception.
-     */
-    public function testThatRemoveMembersWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->removeMembers('', []);
-    }
-
-    /**
-     * Test that remove members with empty users throws exception.
-     */
-    public function testThatRemoveMembersWithEmptyUsersThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
-
-        $api->mock()->organizations()->removeMembers('test-organization', []);
-    }
-
-    /**
-     * Test that get member roles request is formed properly.
-     */
-    public function testThatGetMemberRolesRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getMemberRoles('test-organization', 'test-user');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get member roles with empty id throws exception.
-     */
-    public function testThatGetMemberRolesWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getMemberRoles('', '');
-    }
-
-    /**
-     * Test that get member roles with empty user throws exception.
-     */
-    public function testThatGetMemberRolesWithEmptyUserThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
-        $api->mock()->organizations()->getMemberRoles('test-organization', '');
-    }
-
-    /**
-     * Test that add member roles request is formed properly.
-     */
-    public function testThatAddMemberRolesRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->addMemberRoles('test-organization', 'test-user', ['test-role']);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('roles', $body);
-        $this->assertContains('test-role', $body['roles']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
-    }
-
-    /**
-     * Test that add member roles with empty id throws exception.
-     */
-    public function testThatAddMemberRolesWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->addMemberRoles('', '', []);
-    }
-
-    /**
-     * Test that add member roles with empty user throws exception.
-     */
-    public function testThatAddMemberRolesWithEmptyUserThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
-        $api->mock()->organizations()->addMemberRoles('test-organization', '', []);
-    }
-
-    /**
-     * Test that add member roles with empty roles throws exception.
-     */
-    public function testThatAddMemberRolesWithEmptyRolesThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
-
-        $api->mock()->organizations()->addMemberRoles('test-organization', 'test-rule', []);
-    }
-
-    /**
-     * Test that remove member roles request is formed properly.
-     */
-    public function testThatRemoveMemberRolesRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->removeMemberRoles('test-organization', 'test-user', ['test-role']);
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $api->getRequestUrl());
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('roles', $body);
-        $this->assertContains('test-role', $body['roles']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
-    }
-
-    /**
-     * Test that remove member roles with empty id throws exception.
-     */
-    public function testThatRemoveMemberRolesWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->removeMemberRoles('', '', []);
-    }
-
-    /**
-     * Test that remove member roles with empty user throws exception.
-     */
-    public function testThatRemoveMemberRolesWithEmptyUserThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
-        $api->mock()->organizations()->removeMemberRoles('test-organization', '', []);
-    }
-
-    /**
-     * Test that remove member roles with empty roles throws exception.
-     */
-    public function testThatRemoveMemberRolesWithEmptyRolesThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
-
-        $api->mock()->organizations()->removeMemberRoles('test-organization', 'test-rule', []);
-    }
-
-    /**
-     * Test that get invitations request is formed properly.
-     */
-    public function testThatGetInvitationsRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getInvitations('test-organization');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get invitations with empty id throws exception.
-     */
-    public function testThatGetInvitationsWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getInvitations('');
-    }
-
-    /**
-     * Test that get invitation request is formed properly.
-     */
-    public function testThatGetInvitationRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->getInvitation('test-organization', 'test-invitation');
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that get invitation with empty id throws exception.
-     */
-    public function testThatGetInvitationWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->getInvitation('', '');
-    }
-
-    /**
-     * Test that get invitation with empty invitation throws exception.
-     */
-    public function testThatGetInvitationWithEmptyInvitationThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
-
-        $api->mock()->organizations()->getInvitation('test-organization', '');
-    }
-
-    /**
-     * Test that create invitation request is formed properly.
-     */
-    public function testThatCreateInvitationRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->createInvitation(
-            'test-organization',
-            'test-client',
-            ['name' => 'Test Sender'],
-            ['email' => 'email@test.com']
-        );
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('client_id', $body);
-        $this->assertEquals('test-client', $body['client_id']);
-        $this->assertArrayHasKey('inviter', $body);
-        $this->assertArrayHasKey('name', $body['inviter']);
-        $this->assertEquals('Test Sender', $body['inviter']['name']);
-        $this->assertArrayHasKey('invitee', $body);
-        $this->assertArrayHasKey('email', $body['invitee']);
-        $this->assertEquals('email@test.com', $body['invitee']['email']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['client_id' => 'test-client', 'inviter' => ['name' => 'Test Sender'], 'invitee' => ['email' => 'email@test.com']]), $body);
-    }
-
-    /**
-     * Test that create invitation with empty id throws exception.
-     */
-    public function testThatCreateInvitationWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->createInvitation('', '', [], []);
-    }
-
-    /**
-     * Test that create invitation with empty client throws exception.
-     */
-    public function testThatCreateInvitationWithEmptyClientThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
-
-        $api->mock()->organizations()->createInvitation('test-organization', '', [], []);
-    }
-
-    /**
-     * Test that create invitation with empty inviter throws exception.
-     */
-    public function testThatCreateInvitationWithEmptyInviterThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter'));
-
-        $api->mock()->organizations()->createInvitation('test-organization', 'test-client', [], []);
-    }
-
-    /**
-     * Test that create invitation with empty invitee throws exception.
-     */
-    public function testThatCreateInvitationWithEmptyInviteeThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee'));
-
-        $api->mock()->organizations()->createInvitation('test-organization', 'test-client', ['test' => 'test'], []);
-    }
-
-    /**
-     * Test that create invitation with malformed inviter throws exception.
-     */
-    public function testThatCreateInvitationWithMalformedInviterThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter.name'));
-
-        $api->mock()->organizations()->createInvitation('test-organization', 'test-client', ['test' => 'test'], ['test' => 'test']);
-    }
-
-    /**
-     * Test that create invitation with malformed invitee throws exception.
-     */
-    public function testThatCreateInvitationWithMalformedInviteeThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee.email'));
-
-        $api->mock()->organizations()->createInvitation('test-organization', 'test-client', ['name' => 'Test Sender'], ['test' => 'test']);
-    }
-
-    /**
-     * Test that delete invitation request is formed properly.
-     */
-    public function testThatDeleteInvitationRequestIsFormedProperly(): void
-    {
-        $api = new MockManagementApi();
-
-        $api->mock()->organizations()->deleteInvitation('test-organization', 'test-invitation');
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $api->getRequestUrl());
-    }
-
-    /**
-     * Test that delete invitation with empty id throws exception.
-     */
-    public function testThatDeleteInvitationWithEmptyIdThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
-        $api->mock()->organizations()->deleteInvitation('', '');
-    }
-
-    /**
-     * Test that delete invitation with empty client throws exception.
-     */
-    public function testThatDeleteInvitationWithEmptyClientThrowsException(): void
-    {
-        $api = new MockManagementApi();
-
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
-
-        $api->mock()->organizations()->deleteInvitation('test-organization', '');
-    }
-}
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll();
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations', $this->api->getRequestUrl());
+});
+
+test('get() issues an appropriate request', function(): void {
+    $this->endpoint->get('123');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/123', $this->api->getRequestUrl());
+});
+
+test('get() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->get('');
+});
+
+test('getByName() issues an appropriate request', function(): void {
+    $this->endpoint->getByName('test-organization');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/name/test-organization', $this->api->getRequestUrl());
+});
+
+test('getByName() throws an exception when an invalid `name` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
+
+    $this->endpoint->getByName('');
+});
+
+test('getEnabledConnections() issues an appropriate request', function(): void {
+    $this->endpoint->getEnabledConnections('test-organization');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $this->api->getRequestUrl());
+});
+
+test('getEnabledConnections() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getEnabledConnections('');
+});
+
+test('getEnabledConnection() issues an appropriate request', function(): void {
+    $this->endpoint->getEnabledConnection('test-organization', 'test-connection');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+});
+
+test('getEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getEnabledConnection('', '');
+});
+
+test('getEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
+
+    $this->endpoint->getEnabledConnection('test-organization', '');
+});
+
+test('addEnabledConnection() issues an appropriate request', function(): void {
+    $this->endpoint->addEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections', $this->api->getRequestUrl());
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('connection_id', $body);
+    $this->assertEquals('test-connection', $body['connection_id']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['connection_id' => 'test-connection', 'assign_membership_on_login' => true]), $body);
+});
+
+test('addEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->addEnabledConnection('', '', ['assign_membership_on_login' => true]);
+});
+
+test('addEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
+
+    $this->endpoint->addEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
+});
+
+test('updateEnabledConnection() issues an appropriate request', function(): void {
+    $this->endpoint->updateEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
+
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('assign_membership_on_login', $body);
+    $this->assertTrue($body['assign_membership_on_login']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['assign_membership_on_login' => true]), $body);
+});
+
+test('updateEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->updateEnabledConnection('', '', ['assign_membership_on_login' => true]);
+});
+
+test('updateEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
+
+    $this->endpoint->updateEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
+});
+
+test('removeEnabledConnection() issues an appropriate request', function(): void {
+    $this->endpoint->removeEnabledConnection('test-organization', 'test-connection');
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/enabled_connections/test-connection', $this->api->getRequestUrl());
+});
+
+test('removeEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->removeEnabledConnection('', '');
+});
+
+test('removeEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
+
+    $this->endpoint->removeEnabledConnection('test-organization', '');
+});
+
+test('getMembers() issues an appropriate request', function(): void {
+    $this->endpoint->getMembers('test-organization');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+});
+
+test('getMembers() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getMembers('');
+});
+
+test('addMembers() issues an appropriate request', function(): void {
+    $this->endpoint->addMembers('test-organization', ['test-user']);
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('members', $body);
+    $this->assertContains('test-user', $body['members']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
+});
+
+test('addMembers() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->addMembers('', []);
+});
+
+test('addMembers() throws an exception when an invalid `members` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
+
+    $this->endpoint->addMembers('test-organization', []);
+});
+
+test('removeMembers() issues an appropriate request', function(): void {
+    $this->endpoint->removeMembers('test-organization', ['test-user']);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members', $this->api->getRequestUrl());
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('members', $body);
+    $this->assertContains('test-user', $body['members']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['members' => ['test-user']]), $body);
+});
+
+test('removeMembers() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->removeMembers('', []);
+});
+
+test('removeMembers() throws an exception when an invalid `members` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
+
+    $this->endpoint->removeMembers('test-organization', []);
+});
+
+test('getMemberRoles() issues an appropriate request', function(): void {
+    $this->endpoint->getMemberRoles('test-organization', 'test-user');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+});
+
+test('getMemberRoles() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getMemberRoles('', '');
+});
+
+test('getMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
+
+    $this->endpoint->getMemberRoles('test-organization', '');
+});
+
+test('addMemberRoles() issues an appropriate request', function(): void {
+    $this->endpoint->addMemberRoles('test-organization', 'test-user', ['test-role']);
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('roles', $body);
+    $this->assertContains('test-role', $body['roles']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
+});
+
+test('addMemberRoles() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->addMemberRoles('', '', []);
+});
+
+test('addMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
+
+    $this->endpoint->addMemberRoles('test-organization', '', []);
+});
+
+test('addMemberRoles() throws an exception when an invalid `roles` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
+
+    $this->endpoint->addMemberRoles('test-organization', 'test-rule', []);
+});
+
+test('removeMemberRoles() issues an appropriate request', function(): void {
+    $this->endpoint->removeMemberRoles('test-organization', 'test-user', ['test-role']);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/members/test-user/roles', $this->api->getRequestUrl());
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('roles', $body);
+    $this->assertContains('test-role', $body['roles']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['roles' => ['test-role']]), $body);
+});
+
+test('removeMemberRoles() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->removeMemberRoles('', '', []);
+});
+
+test('removeMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
+
+    $this->endpoint->removeMemberRoles('test-organization', '', []);
+});
+
+test('removeMemberRoles() throws an exception when an invalid `roles` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
+
+    $this->endpoint->removeMemberRoles('test-organization', 'test-rule', []);
+});
+
+test('getInvitations() issues an appropriate request', function(): void {
+    $this->endpoint->getInvitations('test-organization');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $this->api->getRequestUrl());
+});
+
+test('getInvitations() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getInvitations('');
+});
+
+test('getInvitation() issues an appropriate request', function(): void {
+    $this->endpoint->getInvitation('test-organization', 'test-invitation');
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $this->api->getRequestUrl());
+});
+
+test('getInvitation() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->getInvitation('', '');
+});
+
+test('getInvitation() throws an exception when an invalid `invitationId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
+
+    $this->endpoint->getInvitation('test-organization', '');
+});
+
+test('createInvitation() issues an appropriate request', function(): void {
+    $this->endpoint->createInvitation(
+        'test-organization',
+        'test-client',
+        ['name' => 'Test Sender'],
+        ['email' => 'email@test.com']
+    );
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('client_id', $body);
+    $this->assertEquals('test-client', $body['client_id']);
+    $this->assertArrayHasKey('inviter', $body);
+    $this->assertArrayHasKey('name', $body['inviter']);
+    $this->assertEquals('Test Sender', $body['inviter']['name']);
+    $this->assertArrayHasKey('invitee', $body);
+    $this->assertArrayHasKey('email', $body['invitee']);
+    $this->assertEquals('email@test.com', $body['invitee']['email']);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['client_id' => 'test-client', 'inviter' => ['name' => 'Test Sender'], 'invitee' => ['email' => 'email@test.com']]), $body);
+});
+
+test('createInvitation() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->createInvitation('', '', [], []);
+});
+
+test('createInvitation() throws an exception when an invalid `clientId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
+
+    $this->endpoint->createInvitation('test-organization', '', [], []);
+});
+
+test('createInvitation() throws an exception when an invalid `inviter` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter'));
+
+    $this->endpoint->createInvitation('test-organization', 'test-client', [], []);
+});
+
+test('createInvitation() throws an exception when an invalid `invitee` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee'));
+
+    $this->endpoint->createInvitation('test-organization', 'test-client', ['test' => 'test'], []);
+});
+
+test('createInvitation() throws an exception when an invalid `inviter.name` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter.name'));
+
+    $this->endpoint->createInvitation('test-organization', 'test-client', ['test' => 'test'], ['test' => 'test']);
+});
+
+test('createInvitation() throws an exception when an invalid `invitee.email` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee.email'));
+
+    $this->endpoint->createInvitation('test-organization', 'test-client', ['name' => 'Test Sender'], ['test' => 'test']);
+});
+
+test('deleteInvitation() issues an appropriate request', function(): void {
+    $this->endpoint->deleteInvitation('test-organization', 'test-invitation');
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/organizations/test-organization/invitations/test-invitation', $this->api->getRequestUrl());
+});
+
+test('deleteInvitation() throws an exception when an invalid `id` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
+
+    $this->endpoint->deleteInvitation('', '');
+});
+
+test('deleteInvitation() throws an exception when an invalid `invitationId` is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
+
+    $this->endpoint->deleteInvitation('test-organization', '');
+});

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 uses()->group('management', 'management.organizations');

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -54,18 +54,12 @@ test('create() issues an appropriate request', function(): void {
 });
 
 test('create() throws an exception when an invalid `name` argument is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
-
     $this->endpoint->create('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
 
 test('create() throws an exception when an invalid `displayName` argument is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
-
     $this->endpoint->create('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
 
 test('update() issues an appropriate request', function(): void {
     $mock = (object) [
@@ -114,18 +108,12 @@ test('update() issues an appropriate request', function(): void {
 });
 
 test('update() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->update('', '', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('update() throws an exception when an invalid `displayName` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
-
     $this->endpoint->update('test-organization', '', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'displayName'));
 
 test('delete() issues an appropriate request', function(): void {
     $this->endpoint->delete('test-organization');
@@ -138,11 +126,8 @@ test('delete() issues an appropriate request', function(): void {
 });
 
 test('delete() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->delete('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll();
@@ -159,11 +144,8 @@ test('get() issues an appropriate request', function(): void {
 });
 
 test('get() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->get('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getByName() issues an appropriate request', function(): void {
     $this->endpoint->getByName('test-organization');
@@ -173,11 +155,8 @@ test('getByName() issues an appropriate request', function(): void {
 });
 
 test('getByName() throws an exception when an invalid `name` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
-
     $this->endpoint->getByName('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'name'));
 
 test('getEnabledConnections() issues an appropriate request', function(): void {
     $this->endpoint->getEnabledConnections('test-organization');
@@ -187,11 +166,8 @@ test('getEnabledConnections() issues an appropriate request', function(): void {
 });
 
 test('getEnabledConnections() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getEnabledConnections('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->getEnabledConnection('test-organization', 'test-connection');
@@ -201,18 +177,12 @@ test('getEnabledConnection() issues an appropriate request', function(): void {
 });
 
 test('getEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getEnabledConnection('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
     $this->endpoint->getEnabledConnection('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
 
 test('addEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->addEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
@@ -229,18 +199,12 @@ test('addEnabledConnection() issues an appropriate request', function(): void {
 });
 
 test('addEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->addEnabledConnection('', '', ['assign_membership_on_login' => true]);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('addEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
     $this->endpoint->addEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
 
 test('updateEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->updateEnabledConnection('test-organization', 'test-connection', ['assign_membership_on_login' => true]);
@@ -260,18 +224,12 @@ test('updateEnabledConnection() issues an appropriate request', function(): void
 });
 
 test('updateEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->updateEnabledConnection('', '', ['assign_membership_on_login' => true]);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('updateEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
     $this->endpoint->updateEnabledConnection('test-organization', '', ['assign_membership_on_login' => true]);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
 
 test('removeEnabledConnection() issues an appropriate request', function(): void {
     $this->endpoint->removeEnabledConnection('test-organization', 'test-connection');
@@ -281,18 +239,12 @@ test('removeEnabledConnection() issues an appropriate request', function(): void
 });
 
 test('removeEnabledConnection() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->removeEnabledConnection('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('removeEnabledConnection() throws an exception when an invalid `connectionId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
-
     $this->endpoint->removeEnabledConnection('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'connectionId'));
 
 test('getMembers() issues an appropriate request', function(): void {
     $this->endpoint->getMembers('test-organization');
@@ -302,11 +254,8 @@ test('getMembers() issues an appropriate request', function(): void {
 });
 
 test('getMembers() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getMembers('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('addMembers() issues an appropriate request', function(): void {
     $this->endpoint->addMembers('test-organization', ['test-user']);
@@ -326,18 +275,12 @@ test('addMembers() issues an appropriate request', function(): void {
 });
 
 test('addMembers() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->addMembers('', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('addMembers() throws an exception when an invalid `members` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
-
     $this->endpoint->addMembers('test-organization', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
 
 test('removeMembers() issues an appropriate request', function(): void {
     $this->endpoint->removeMembers('test-organization', ['test-user']);
@@ -354,18 +297,12 @@ test('removeMembers() issues an appropriate request', function(): void {
 });
 
 test('removeMembers() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->removeMembers('', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('removeMembers() throws an exception when an invalid `members` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
-
     $this->endpoint->removeMembers('test-organization', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'members'));
 
 test('getMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->getMemberRoles('test-organization', 'test-user');
@@ -375,18 +312,12 @@ test('getMemberRoles() issues an appropriate request', function(): void {
 });
 
 test('getMemberRoles() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getMemberRoles('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
     $this->endpoint->getMemberRoles('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
 
 test('addMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->addMemberRoles('test-organization', 'test-user', ['test-role']);
@@ -406,25 +337,16 @@ test('addMemberRoles() issues an appropriate request', function(): void {
 });
 
 test('addMemberRoles() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->addMemberRoles('', '', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('addMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
     $this->endpoint->addMemberRoles('test-organization', '', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
 
 test('addMemberRoles() throws an exception when an invalid `roles` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
-
     $this->endpoint->addMemberRoles('test-organization', 'test-rule', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
 
 test('removeMemberRoles() issues an appropriate request', function(): void {
     $this->endpoint->removeMemberRoles('test-organization', 'test-user', ['test-role']);
@@ -441,25 +363,16 @@ test('removeMemberRoles() issues an appropriate request', function(): void {
 });
 
 test('removeMemberRoles() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->removeMemberRoles('', '', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('removeMemberRoles() throws an exception when an invalid `userId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
-
     $this->endpoint->removeMemberRoles('test-organization', '', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'userId'));
 
 test('removeMemberRoles() throws an exception when an invalid `roles` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
-
     $this->endpoint->removeMemberRoles('test-organization', 'test-rule', []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'roles'));
 
 test('getInvitations() issues an appropriate request', function(): void {
     $this->endpoint->getInvitations('test-organization');
@@ -469,11 +382,8 @@ test('getInvitations() issues an appropriate request', function(): void {
 });
 
 test('getInvitations() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getInvitations('');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getInvitation() issues an appropriate request', function(): void {
     $this->endpoint->getInvitation('test-organization', 'test-invitation');
@@ -483,18 +393,12 @@ test('getInvitation() issues an appropriate request', function(): void {
 });
 
 test('getInvitation() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->getInvitation('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('getInvitation() throws an exception when an invalid `invitationId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
-
     $this->endpoint->getInvitation('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
 
 test('createInvitation() issues an appropriate request', function(): void {
     $this->endpoint->createInvitation(
@@ -525,46 +429,28 @@ test('createInvitation() issues an appropriate request', function(): void {
 });
 
 test('createInvitation() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->createInvitation('', '', [], []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('createInvitation() throws an exception when an invalid `clientId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
-
     $this->endpoint->createInvitation('test-organization', '', [], []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'clientId'));
 
 test('createInvitation() throws an exception when an invalid `inviter` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter'));
-
     $this->endpoint->createInvitation('test-organization', 'test-client', [], []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter'));
 
 test('createInvitation() throws an exception when an invalid `invitee` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee'));
-
     $this->endpoint->createInvitation('test-organization', 'test-client', ['test' => 'test'], []);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee'));
 
 test('createInvitation() throws an exception when an invalid `inviter.name` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter.name'));
-
     $this->endpoint->createInvitation('test-organization', 'test-client', ['test' => 'test'], ['test' => 'test']);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'inviter.name'));
 
 test('createInvitation() throws an exception when an invalid `invitee.email` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee.email'));
-
     $this->endpoint->createInvitation('test-organization', 'test-client', ['name' => 'Test Sender'], ['test' => 'test']);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitee.email'));
 
 test('deleteInvitation() issues an appropriate request', function(): void {
     $this->endpoint->deleteInvitation('test-organization', 'test-invitation');
@@ -574,15 +460,9 @@ test('deleteInvitation() issues an appropriate request', function(): void {
 });
 
 test('deleteInvitation() throws an exception when an invalid `id` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
-
     $this->endpoint->deleteInvitation('', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'id'));
 
 test('deleteInvitation() throws an exception when an invalid `invitationId` is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));
-
     $this->endpoint->deleteInvitation('test-organization', '');
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'invitationId'));

--- a/tests/Unit/API/Management/ResourceServersTest.php
+++ b/tests/Unit/API/Management/ResourceServersTest.php
@@ -11,18 +11,18 @@ beforeEach(function(): void {
 test('create() issues an appropriate request', function(string $identifier, array $body): void {
     $this->endpoint->create($identifier, $body);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/resource-servers', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/resource-servers');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('identifier', $request);
-    $this->assertEquals($identifier, $request['identifier']);
+    expect($request['identifier'])->toEqual($identifier);
     $this->assertArrayHasKey('test', $request);
-    $this->assertEquals($body['test'], $request['test']);
+    expect($request['test'])->toEqual($body['test']);
 
     $request = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['identifier' => $identifier] + $body), $request);
+    expect($request)->toEqual(json_encode(['identifier' => $identifier] + $body));
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => [ 'test' => uniqid() ],
@@ -31,17 +31,17 @@ test('create() issues an appropriate request', function(string $identifier, arra
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/resource-servers', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/resource-servers');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('get() issues an appropriate request', function(string $id): void {
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/resource-servers/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['mocked id' => [
     fn() => uniqid(),
 ]]);
@@ -49,16 +49,16 @@ test('get() issues an appropriate request', function(string $id): void {
 test('update() issues an appropriate request', function(string $id, array $body): void {
     $this->endpoint->update($id, $body);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/resource-servers/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $request);
-    $this->assertEquals($body['test'], $request['test']);
+    expect($request['test'])->toEqual($body['test']);
 
     $request = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($body), $request);
+    expect($request)->toEqual(json_encode($body));
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => [ 'test' => uniqid() ],
@@ -67,9 +67,9 @@ test('update() issues an appropriate request', function(string $id, array $body)
 test('delete() issues an appropriate request', function(string $id): void {
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/resource-servers/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['mocked id' => [
     fn() => uniqid(),
 ]]);

--- a/tests/Unit/API/Management/ResourceServersTest.php
+++ b/tests/Unit/API/Management/ResourceServersTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.resource_servers');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->resourceServers();
+});
+
+test('create() issues an appropriate request', function(string $identifier, array $body): void {
+    $this->endpoint->create($identifier, $body);
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/resource-servers', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+
+    $request = $this->api->getRequestBody();
+    $this->assertArrayHasKey('identifier', $request);
+    $this->assertEquals($identifier, $request['identifier']);
+    $this->assertArrayHasKey('test', $request);
+    $this->assertEquals($body['test'], $request['test']);
+
+    $request = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['identifier' => $identifier] + $body), $request);
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => [ 'test' => uniqid() ],
+]]);
+
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll();
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/resource-servers', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
+
+test('get() issues an appropriate request', function(string $id): void {
+    $this->endpoint->get($id);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+})->with(['mocked id' => [
+    fn() => uniqid(),
+]]);
+
+test('update() issues an appropriate request', function(string $id, array $body): void {
+    $this->endpoint->update($id, $body);
+
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+
+    $request = $this->api->getRequestBody();
+    $this->assertArrayHasKey('test', $request);
+    $this->assertEquals($body['test'], $request['test']);
+
+    $request = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($body), $request);
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => [ 'test' => uniqid() ],
+]]);
+
+test('delete() issues an appropriate request', function(string $id): void {
+    $this->endpoint->delete($id);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/resource-servers/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+})->with(['mocked id' => [
+    fn() => uniqid(),
+]]);

--- a/tests/Unit/API/Management/RolesTest.php
+++ b/tests/Unit/API/Management/RolesTest.php
@@ -11,11 +11,11 @@ beforeEach(function(): void {
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll(['name_filter' => '__test_name_filter__']);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/roles');
 
     $query = $this->api->getRequestQuery();
-    $this->assertStringContainsString('name_filter=__test_name_filter__', $query);
+    expect($query)->toContain('name_filter=__test_name_filter__');
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -23,17 +23,17 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($id, ['description' => '__test_description__']);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($id, $body['name']);
+    expect($body['name'])->toEqual($id);
     $this->assertArrayHasKey('description', $body);
-    $this->assertEquals('__test_description__', $body['description']);
+    expect($body['description'])->toEqual('__test_description__');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['name' => $id, 'description' => '__test_description__']), $body);
+    expect($body)->toEqual(json_encode(['name' => $id, 'description' => '__test_description__']));
 });
 
 test('get() issues an appropriate request', function(): void {
@@ -41,8 +41,8 @@ test('get() issues an appropriate request', function(): void {
 
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' . $id);
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -50,8 +50,8 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' . $id);
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -59,15 +59,15 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($id, ['name' => '__test_new_name__']);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' . $id);
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals('__test_new_name__', $body['name']);
+    expect($body['name'])->toEqual('__test_new_name__');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['name' => '__test_new_name__']), $body);
+    expect($body)->toEqual(json_encode(['name' => '__test_new_name__']));
 });
 
 test('getPermissions() issues an appropriate request', function(): void {
@@ -75,8 +75,8 @@ test('getPermissions() issues an appropriate request', function(): void {
 
     $this->endpoint->getPermissions($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/roles/' . $id . '/permissions');
 });
 
 test('addPermissions() issues an appropriate request', function(): void {
@@ -89,16 +89,16 @@ test('addPermissions() issues an appropriate request', function(): void {
         ],
     ]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' . $id . '/permissions');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('permissions', $body);
-    $this->assertCount(1, $body['permissions']);
+    expect($body['permissions'])->toHaveCount(1);
     $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-    $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
+    expect($body['permissions'][0]['permission_name'])->toEqual('__test_permission_name__');
     $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-    $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
+    expect($body['permissions'][0]['resource_server_identifier'])->toEqual('__test_server_id__');
 });
 
 test('removePermissions() issues an appropriate request', function(): void {
@@ -111,16 +111,16 @@ test('removePermissions() issues an appropriate request', function(): void {
         ],
     ]);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' . $id . '/permissions');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('permissions', $body);
-    $this->assertCount(1, $body['permissions']);
+    expect($body['permissions'])->toHaveCount(1);
     $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-    $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
+    expect($body['permissions'][0]['permission_name'])->toEqual('__test_permission_name__');
     $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-    $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
+    expect($body['permissions'][0]['resource_server_identifier'])->toEqual('__test_server_id__');
 });
 
 test('getUsers() issues an appropriate request', function(): void {
@@ -128,8 +128,8 @@ test('getUsers() issues an appropriate request', function(): void {
 
     $this->endpoint->getUsers($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/users', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/roles/' . $id . '/users');
 });
 
 test('addUsers() issues an appropriate request', function(): void {
@@ -137,15 +137,15 @@ test('addUsers() issues an appropriate request', function(): void {
 
     $this->endpoint->addUsers($id, ['strategy|1234567890', 'strategy|0987654321']);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/roles/' .$id . '/users', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/roles/' .$id . '/users');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('users', $body);
-    $this->assertCount(2, $body['users']);
-    $this->assertContains('strategy|1234567890', $body['users']);
-    $this->assertContains('strategy|0987654321', $body['users']);
+    expect($body['users'])->toHaveCount(2);
+    expect($body['users'])->toContain('strategy|1234567890');
+    expect($body['users'])->toContain('strategy|0987654321');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['users' => ['strategy|1234567890', 'strategy|0987654321']]), $body);
+    expect($body)->toEqual(json_encode(['users' => ['strategy|1234567890', 'strategy|0987654321']]));
 });

--- a/tests/Unit/API/Management/RolesTest.php
+++ b/tests/Unit/API/Management/RolesTest.php
@@ -2,205 +2,150 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.roles');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->roles();
+});
 
-/**
- * Class RolesMocked.
- */
-class RolesTest extends TestCase
-{
-    /**
-     * Test a basic getAll roles call.
-     */
-    public function testGetAll(): void
-    {
-        $api = new MockManagementApi();
-        $api->mock()->roles()->getAll(['name_filter' => '__test_name_filter__']);
+test('getAll() issues an appropriate request', function(): void {
+    $this->endpoint->getAll(['name_filter' => '__test_name_filter__']);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/roles', $api->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/roles', $this->api->getRequestUrl());
 
-        $query = $api->getRequestQuery();
-        $this->assertStringContainsString('name_filter=__test_name_filter__', $query);
-    }
+    $query = $this->api->getRequestQuery();
+    $this->assertStringContainsString('name_filter=__test_name_filter__', $query);
+});
 
-    /**
-     * Test create role is requested properly.
-     */
-    public function testCreate(): void
-    {
-        $id = uniqid();
+test('create() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->create($id, ['description' => '__test_description__']);
+    $this->endpoint->create($id, ['description' => '__test_description__']);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals($id, $body['name']);
-        $this->assertArrayHasKey('description', $body);
-        $this->assertEquals('__test_description__', $body['description']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals($id, $body['name']);
+    $this->assertArrayHasKey('description', $body);
+    $this->assertEquals('__test_description__', $body['description']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['name' => $id, 'description' => '__test_description__']), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['name' => $id, 'description' => '__test_description__']), $body);
+});
 
-    /**
-     * Test a get role call.
-     */
-    public function testGet(): void
-    {
-        $id = uniqid();
+test('get() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->get($id);
+    $this->endpoint->get($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $api->getRequestUrl());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
+});
 
-    /**
-     * Test a delete role call.
-     */
-    public function testDelete(): void
-    {
-        $id = uniqid();
+test('delete() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->delete($id);
+    $this->endpoint->delete($id);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $api->getRequestUrl());
-    }
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
+});
 
-    /**
-     * Test an update role call.
-     */
-    public function testUpdate(): void
-    {
-        $id = uniqid();
+test('update() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->update($id, ['name' => '__test_new_name__']);
+    $this->endpoint->update($id, ['name' => '__test_new_name__']);
 
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $api->getRequestUrl());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id, $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('name', $body);
-        $this->assertEquals('__test_new_name__', $body['name']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    $this->assertEquals('__test_new_name__', $body['name']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['name' => '__test_new_name__']), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['name' => '__test_new_name__']), $body);
+});
 
-    /**
-     * Test a get role permissions call.
-     */
-    public function testGetPermissions(): void
-    {
-        $id = uniqid();
+test('getPermissions() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->getPermissions($id);
+    $this->endpoint->getPermissions($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/permissions', $api->getRequestUrl());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
+});
 
-    /**
-     * Test an add role permissions call.
-     */
-    public function testAddPermissions(): void
-    {
-        $id = uniqid();
+test('addPermissions() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->addPermissions($id, [
-            [
-                'permission_name' => '__test_permission_name__',
-                'resource_server_identifier' => '__test_server_id__',
-            ],
-        ]);
+    $this->endpoint->addPermissions($id, [
+        [
+            'permission_name' => '__test_permission_name__',
+            'resource_server_identifier' => '__test_server_id__',
+        ],
+    ]);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('permissions', $body);
-        $this->assertCount(1, $body['permissions']);
-        $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-        $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
-        $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-        $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
-    }
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('permissions', $body);
+    $this->assertCount(1, $body['permissions']);
+    $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
+    $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
+    $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
+    $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
+});
 
-    /**
-     * Test a delete role permissions call.
-     */
-    public function testRemovePermissions(): void
-    {
-        $id = uniqid();
+test('removePermissions() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->removePermissions($id, [
-            [
-                'permission_name' => '__test_permission_name__',
-                'resource_server_identifier' => '__test_server_id__',
-            ],
-        ]);
+    $this->endpoint->removePermissions($id, [
+        [
+            'permission_name' => '__test_permission_name__',
+            'resource_server_identifier' => '__test_server_id__',
+        ],
+    ]);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $api->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' . $id . '/permissions', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('permissions', $body);
-        $this->assertCount(1, $body['permissions']);
-        $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-        $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
-        $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-        $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
-    }
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('permissions', $body);
+    $this->assertCount(1, $body['permissions']);
+    $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
+    $this->assertEquals('__test_permission_name__', $body['permissions'][0]['permission_name']);
+    $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
+    $this->assertEquals('__test_server_id__', $body['permissions'][0]['resource_server_identifier']);
+});
 
-    /**
-     * Test a paginated get role users call.
-     */
-    public function testGetUsers(): void
-    {
-        $id = uniqid();
+test('getUsers() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->getUsers($id);
+    $this->endpoint->getUsers($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/users', $api->getRequestUrl());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/roles/' . $id . '/users', $this->api->getRequestUrl());
+});
 
-    /**
-     * Test an add role user call.
-     */
-    public function testAddUsers(): void
-    {
-        $id = uniqid();
+test('addUsers() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->roles()->addUsers($id, ['strategy|1234567890', 'strategy|0987654321']);
+    $this->endpoint->addUsers($id, ['strategy|1234567890', 'strategy|0987654321']);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/roles/' .$id . '/users', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/roles/' .$id . '/users', $this->api->getRequestUrl());
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('users', $body);
-        $this->assertCount(2, $body['users']);
-        $this->assertContains('strategy|1234567890', $body['users']);
-        $this->assertContains('strategy|0987654321', $body['users']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('users', $body);
+    $this->assertCount(2, $body['users']);
+    $this->assertContains('strategy|1234567890', $body['users']);
+    $this->assertContains('strategy|0987654321', $body['users']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['users' => ['strategy|1234567890', 'strategy|0987654321']]), $body);
-    }
-}
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['users' => ['strategy|1234567890', 'strategy|0987654321']]), $body);
+});

--- a/tests/Unit/API/Management/RulesTest.php
+++ b/tests/Unit/API/Management/RulesTest.php
@@ -11,11 +11,11 @@ beforeEach(function(): void {
 test('getAll() issues an appropriate request', function(): void {
     $this->endpoint->getAll(['enabled' => true]);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/rules', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/rules');
 
     $query = $this->api->getRequestQuery();
-    $this->assertStringContainsString('enabled=true', $query);
+    expect($query)->toContain('enabled=true');
 });
 
 test('get() issues an appropriate request', function(): void {
@@ -23,8 +23,8 @@ test('get() issues an appropriate request', function(): void {
 
     $this->endpoint->get($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/rules/' . $mockupId, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/rules/' . $mockupId);
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -32,8 +32,8 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($mockupId);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/rules/' . $mockupId, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/rules/' . $mockupId);
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -45,24 +45,24 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($mockup->name, $mockup->script, $mockup->query);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/rules', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/rules');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
-    $this->assertEquals($mockup->name, $body['name']);
+    expect($body['name'])->toEqual($mockup->name);
 
     $this->assertArrayHasKey('script', $body);
-    $this->assertEquals($mockup->script, $body['script']);
+    expect($body['script'])->toEqual($mockup->script);
 
     $this->assertArrayHasKey('test_parameter', $body);
-    $this->assertEquals($mockup->query['test_parameter'], $body['test_parameter']);
+    expect($body['test_parameter'])->toEqual($mockup->query['test_parameter']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['name' => $mockup->name, 'script' => $mockup->script], $mockup->query)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mockup->name, 'script' => $mockup->script], $mockup->query)));
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -73,16 +73,16 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($mockup->id, $mockup->query);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/rules/' . $mockup->id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/rules/' . $mockup->id);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('test_parameter', $body);
-    $this->assertEquals($mockup->query['test_parameter'], $body['test_parameter']);
+    expect($body['test_parameter'])->toEqual($mockup->query['test_parameter']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mockup->query), $body);
+    expect($body)->toEqual(json_encode($mockup->query));
 });

--- a/tests/Unit/API/Management/StatsTest.php
+++ b/tests/Unit/API/Management/StatsTest.php
@@ -11,18 +11,18 @@ beforeEach(function(): void {
 test('getActiveUsers() issues an appropriate request', function(): void {
     $this->endpoint->getActiveUsers();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/stats/active-users', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/stats/active-users');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('getDaily() issues an appropriate request', function(string $from, string $to): void {
     $this->endpoint->getDaily($from, $to);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/stats/daily', $this->api->getRequestUrl());
-    $this->assertStringContainsString('from=' . $from, $this->api->getRequestQuery(null));
-    $this->assertStringContainsString('to=' . $to, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/stats/daily');
+    expect($this->api->getRequestQuery(null))->toContain('from=' . $from);
+    expect($this->api->getRequestQuery(null))->toContain('to=' . $to);
 })->with(['mocked id' => [
     fn() => uniqid(),
     fn() => uniqid(),

--- a/tests/Unit/API/Management/StatsTest.php
+++ b/tests/Unit/API/Management/StatsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.stats');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->stats();
+});
+
+test('getActiveUsers() issues an appropriate request', function(): void {
+    $this->endpoint->getActiveUsers();
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/stats/active-users', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
+
+test('getDaily() issues an appropriate request', function(string $from, string $to): void {
+    $this->endpoint->getDaily($from, $to);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/stats/daily', $this->api->getRequestUrl());
+    $this->assertStringContainsString('from=' . $from, $this->api->getRequestQuery(null));
+    $this->assertStringContainsString('to=' . $to, $this->api->getRequestQuery(null));
+})->with(['mocked id' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);

--- a/tests/Unit/API/Management/TenantsTest.php
+++ b/tests/Unit/API/Management/TenantsTest.php
@@ -11,24 +11,24 @@ beforeEach(function(): void {
 test('get() issues an appropriate request', function(): void {
     $this->endpoint->getSettings();
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/tenants/settings', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/tenants/settings');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 });
 
 test('update() issues an appropriate request', function(array $body): void {
     $this->endpoint->updateSettings($body);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/tenants/settings', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/tenants/settings');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $request = $this->api->getRequestBody();
     $this->assertArrayHasKey('test', $request);
-    $this->assertEquals($body['test'], $request['test']);
+    expect($request['test'])->toEqual($body['test']);
 
     $request = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($body), $request);
+    expect($request)->toEqual(json_encode($body));
 })->with(['mocked data' => [
     fn() => [ 'test' => uniqid() ],
 ]]);

--- a/tests/Unit/API/Management/TenantsTest.php
+++ b/tests/Unit/API/Management/TenantsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.tenants');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->tenants();
+});
+
+test('get() issues an appropriate request', function(): void {
+    $this->endpoint->getSettings();
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/tenants/settings', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+});
+
+test('update() issues an appropriate request', function(array $body): void {
+    $this->endpoint->updateSettings($body);
+
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/tenants/settings', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+
+    $request = $this->api->getRequestBody();
+    $this->assertArrayHasKey('test', $request);
+    $this->assertEquals($body['test'], $request['test']);
+
+    $request = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($body), $request);
+})->with(['mocked data' => [
+    fn() => [ 'test' => uniqid() ],
+]]);

--- a/tests/Unit/API/Management/TicketsTest.php
+++ b/tests/Unit/API/Management/TicketsTest.php
@@ -19,21 +19,21 @@ test('createEmailVerification() issues an appropriate request', function(): void
 
     $this->endpoint->createEmailVerification($mock->userId, ['identity' => $mock->identity]);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/tickets/email-verification', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/tickets/email-verification');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('user_id', $body);
-    $this->assertEquals($mock->userId, $body['user_id']);
+    expect($body['user_id'])->toEqual($mock->userId);
     $this->assertArrayHasKey('identity', $body);
-    $this->assertEquals($mock->identity, $body['identity']);
+    expect($body['identity'])->toEqual($mock->identity);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(['user_id' => $mock->userId, 'identity' => $mock->identity]), $body);
+    expect($body)->toEqual(json_encode(['user_id' => $mock->userId, 'identity' => $mock->identity]));
 });
 
 test('createPasswordChange() issues an appropriate request', function(): void {
@@ -48,27 +48,27 @@ test('createPasswordChange() issues an appropriate request', function(): void {
 
     $this->endpoint->createPasswordChange($mock);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/tickets/password-change');
+    expect($this->api->getRequestQuery())->toBeEmpty();
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('user_id', $body);
-    $this->assertEquals($mock['user_id'], $body['user_id']);
+    expect($body['user_id'])->toEqual($mock['user_id']);
     $this->assertArrayHasKey('new_password', $body);
-    $this->assertEquals($mock['new_password'], $body['new_password']);
+    expect($body['new_password'])->toEqual($mock['new_password']);
     $this->assertArrayHasKey('result_url', $body);
-    $this->assertEquals($mock['result_url'], $body['result_url']);
+    expect($body['result_url'])->toEqual($mock['result_url']);
     $this->assertArrayHasKey('connection_id', $body);
-    $this->assertEquals($mock['connection_id'], $body['connection_id']);
+    expect($body['connection_id'])->toEqual($mock['connection_id']);
     $this->assertArrayHasKey('ttl_sec', $body);
-    $this->assertEquals($mock['ttl_sec'], $body['ttl_sec']);
+    expect($body['ttl_sec'])->toEqual($mock['ttl_sec']);
     $this->assertArrayHasKey('client_id', $body);
-    $this->assertEquals($mock['client_id'], $body['client_id']);
+    expect($body['client_id'])->toEqual($mock['client_id']);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mock), $body);
+    expect($body)->toEqual(json_encode($mock));
 });

--- a/tests/Unit/API/Management/TicketsTest.php
+++ b/tests/Unit/API/Management/TicketsTest.php
@@ -2,81 +2,73 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.tickets');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->tickets();
+});
 
-class TicketsTest extends TestCase
-{
-    public function testCreateEmailVerification(): void
-    {
-        $mock = (object) [
-            'userId' => uniqid(),
-            'identity' => [
-                'user_id' => '__test_secondary_user_id__',
-                'provider' => '__test_provider__',
-            ],
-        ];
+test('createEmailVerification() issues an appropriate request', function(): void {
+    $mock = (object) [
+        'userId' => uniqid(),
+        'identity' => [
+            'user_id' => '__test_secondary_user_id__',
+            'provider' => '__test_provider__',
+        ],
+    ];
 
-        $api = new MockManagementApi();
+    $this->endpoint->createEmailVerification($mock->userId, ['identity' => $mock->identity]);
 
-        $api->mock()->tickets()->createEmailVerification($mock->userId, ['identity' => $mock->identity]);
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/tickets/email-verification', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/tickets/email-verification', $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('user_id', $body);
+    $this->assertEquals($mock->userId, $body['user_id']);
+    $this->assertArrayHasKey('identity', $body);
+    $this->assertEquals($mock->identity, $body['identity']);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('user_id', $body);
-        $this->assertEquals($mock->userId, $body['user_id']);
-        $this->assertArrayHasKey('identity', $body);
-        $this->assertEquals($mock->identity, $body['identity']);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(['user_id' => $mock->userId, 'identity' => $mock->identity]), $body);
+});
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(['user_id' => $mock->userId, 'identity' => $mock->identity]), $body);
-    }
+test('createPasswordChange() issues an appropriate request', function(): void {
+    $mock = [
+        'user_id' => uniqid(),
+        'new_password' => uniqid(),
+        'result_url' => uniqid(),
+        'connection_id' => uniqid(),
+        'ttl_sec' => uniqid(),
+        'client_id' => uniqid(),
+    ];
 
-    public function testCreatePasswordChange(): void
-    {
-        $mock = [
-            'user_id' => uniqid(),
-            'new_password' => uniqid(),
-            'result_url' => uniqid(),
-            'connection_id' => uniqid(),
-            'ttl_sec' => uniqid(),
-            'client_id' => uniqid(),
-        ];
+    $this->endpoint->createPasswordChange($mock);
 
-        $api = new MockManagementApi();
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
 
-        $api->mock()->tickets()->createPasswordChange($mock);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('user_id', $body);
+    $this->assertEquals($mock['user_id'], $body['user_id']);
+    $this->assertArrayHasKey('new_password', $body);
+    $this->assertEquals($mock['new_password'], $body['new_password']);
+    $this->assertArrayHasKey('result_url', $body);
+    $this->assertEquals($mock['result_url'], $body['result_url']);
+    $this->assertArrayHasKey('connection_id', $body);
+    $this->assertEquals($mock['connection_id'], $body['connection_id']);
+    $this->assertArrayHasKey('ttl_sec', $body);
+    $this->assertEquals($mock['ttl_sec'], $body['ttl_sec']);
+    $this->assertArrayHasKey('client_id', $body);
+    $this->assertEquals($mock['client_id'], $body['client_id']);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/tickets/password-change', $api->getRequestUrl());
-        $this->assertEmpty($api->getRequestQuery());
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('user_id', $body);
-        $this->assertEquals($mock['user_id'], $body['user_id']);
-        $this->assertArrayHasKey('new_password', $body);
-        $this->assertEquals($mock['new_password'], $body['new_password']);
-        $this->assertArrayHasKey('result_url', $body);
-        $this->assertEquals($mock['result_url'], $body['result_url']);
-        $this->assertArrayHasKey('connection_id', $body);
-        $this->assertEquals($mock['connection_id'], $body['connection_id']);
-        $this->assertArrayHasKey('ttl_sec', $body);
-        $this->assertEquals($mock['ttl_sec'], $body['ttl_sec']);
-        $this->assertArrayHasKey('client_id', $body);
-        $this->assertEquals($mock['client_id'], $body['client_id']);
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode($mock), $body);
-    }
-}
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($mock), $body);
+});

--- a/tests/Unit/API/Management/UserBlocksTest.php
+++ b/tests/Unit/API/Management/UserBlocksTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses()->group('management', 'management.tenants');
+uses()->group('management', 'management.user_blocks');
 
 beforeEach(function(): void {
     $this->endpoint = $this->api->mock()->userBlocks();

--- a/tests/Unit/API/Management/UserBlocksTest.php
+++ b/tests/Unit/API/Management/UserBlocksTest.php
@@ -11,9 +11,9 @@ beforeEach(function(): void {
 test('get() issues an appropriate request', function(string $id): void {
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/user-blocks/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/user-blocks/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['mocked id' => [
     fn() => uniqid(),
 ]]);
@@ -21,9 +21,9 @@ test('get() issues an appropriate request', function(string $id): void {
 test('delete() issues an appropriate request', function(string $id): void {
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/user-blocks/' . $id, $this->api->getRequestUrl());
-    $this->assertEmpty($this->api->getRequestQuery());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/user-blocks/' . $id);
+    expect($this->api->getRequestQuery())->toBeEmpty();
 })->with(['mocked id' => [
     fn() => uniqid(),
 ]]);
@@ -31,9 +31,9 @@ test('delete() issues an appropriate request', function(string $id): void {
 test('getByIdentifier() issues an appropriate request', function(string $identifier): void {
     $this->endpoint->getByIdentifier($identifier);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/user-blocks', $this->api->getRequestUrl());
-    $this->assertStringContainsString('identifier=' . $identifier, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/user-blocks');
+    expect($this->api->getRequestQuery(null))->toContain('identifier=' . $identifier);
 })->with(['mocked identifier' => [
     fn() => uniqid(),
 ]]);
@@ -41,9 +41,9 @@ test('getByIdentifier() issues an appropriate request', function(string $identif
 test('deleteByIdentifier() issues an appropriate request', function(string $identifier): void {
     $this->endpoint->deleteByIdentifier($identifier);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/user-blocks', $this->api->getRequestUrl());
-    $this->assertStringContainsString('identifier=' . $identifier, $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/user-blocks');
+    expect($this->api->getRequestQuery(null))->toContain('identifier=' . $identifier);
 })->with(['mocked identifier' => [
     fn() => uniqid(),
 ]]);

--- a/tests/Unit/API/Management/UserBlocksTest.php
+++ b/tests/Unit/API/Management/UserBlocksTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.tenants');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->userBlocks();
+});
+
+test('get() issues an appropriate request', function(string $id): void {
+    $this->endpoint->get($id);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/user-blocks/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+})->with(['mocked id' => [
+    fn() => uniqid(),
+]]);
+
+test('delete() issues an appropriate request', function(string $id): void {
+    $this->endpoint->delete($id);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/user-blocks/' . $id, $this->api->getRequestUrl());
+    $this->assertEmpty($this->api->getRequestQuery());
+})->with(['mocked id' => [
+    fn() => uniqid(),
+]]);
+
+test('getByIdentifier() issues an appropriate request', function(string $identifier): void {
+    $this->endpoint->getByIdentifier($identifier);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/user-blocks', $this->api->getRequestUrl());
+    $this->assertStringContainsString('identifier=' . $identifier, $this->api->getRequestQuery(null));
+})->with(['mocked identifier' => [
+    fn() => uniqid(),
+]]);
+
+test('deleteByIdentifier() issues an appropriate request', function(string $identifier): void {
+    $this->endpoint->deleteByIdentifier($identifier);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/user-blocks', $this->api->getRequestUrl());
+    $this->assertStringContainsString('identifier=' . $identifier, $this->api->getRequestQuery(null));
+})->with(['mocked identifier' => [
+    fn() => uniqid(),
+]]);

--- a/tests/Unit/API/Management/UsersByEmailTest.php
+++ b/tests/Unit/API/Management/UsersByEmailTest.php
@@ -11,9 +11,9 @@ beforeEach(function(): void {
 test('get() issues an appropriate request', function(string $email): void {
     $this->endpoint->get($email);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users-by-email', $this->api->getRequestUrl());
-    $this->assertStringContainsString(http_build_query(['email' => $email], '', '&', PHP_QUERY_RFC1738), $this->api->getRequestQuery(null));
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users-by-email');
+    expect($this->api->getRequestQuery(null))->toContain(http_build_query(['email' => $email], '', '&', PHP_QUERY_RFC1738));
 })->with(['mocked id' => [
     fn() => uniqid() . '@somewhere.somehow',
 ]]);

--- a/tests/Unit/API/Management/UsersByEmailTest.php
+++ b/tests/Unit/API/Management/UsersByEmailTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.users_by_email');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->usersByEmail();
+});
+
+test('get() issues an appropriate request', function(string $email): void {
+    $this->endpoint->get($email);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users-by-email', $this->api->getRequestUrl());
+    $this->assertStringContainsString(http_build_query(['email' => $email], '', '&', PHP_QUERY_RFC1738), $this->api->getRequestQuery(null));
+})->with(['mocked id' => [
+    fn() => uniqid() . '@somewhere.somehow',
+]]);

--- a/tests/Unit/API/Management/UsersTest.php
+++ b/tests/Unit/API/Management/UsersTest.php
@@ -13,11 +13,11 @@ test('getAll() issues an appropriate request', function(): void {
 
     $this->endpoint->getAll(['test' => $id]);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users');
 
     $query = $this->api->getRequestQuery();
-    $this->assertStringContainsString('&test=' . $id, $query);
+    expect($query)->toContain('&test=' . $id);
 });
 
 test('get() issues an appropriate request', function(): void {
@@ -25,8 +25,8 @@ test('get() issues an appropriate request', function(): void {
 
     $this->endpoint->get($id);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $id);
 });
 
 test('update() issues an appropriate request', function(): void {
@@ -42,21 +42,21 @@ test('update() issues an appropriate request', function(): void {
 
     $this->endpoint->update($mockup->id, $mockup->query);
 
-    $this->assertEquals('PATCH', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('given_name', $body);
-    $this->assertEquals($mockup->query['given_name'], $body['given_name']);
+    expect($body['given_name'])->toEqual($mockup->query['given_name']);
     $this->assertArrayHasKey('user_metadata', $body);
     $this->assertArrayHasKey('__test_meta_key__', $body['user_metadata']);
-    $this->assertEquals($mockup->query['user_metadata']['__test_meta_key__'], $body['user_metadata']['__test_meta_key__']);
+    expect($body['user_metadata']['__test_meta_key__'])->toEqual($mockup->query['user_metadata']['__test_meta_key__']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mockup->query), $body);
+    expect($body)->toEqual(json_encode($mockup->query));
 });
 
 test('create() issues an appropriate request', function(): void {
@@ -70,22 +70,22 @@ test('create() issues an appropriate request', function(): void {
 
     $this->endpoint->create($mockup->connection, $mockup->query);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('connection', $body);
-    $this->assertEquals($mockup->connection, $body['connection']);
+    expect($body['connection'])->toEqual($mockup->connection);
     $this->assertArrayHasKey('email', $body);
-    $this->assertEquals($mockup->query['email'], $body['email']);
+    expect($body['email'])->toEqual($mockup->query['email']);
     $this->assertArrayHasKey('password', $body);
-    $this->assertEquals($mockup->query['password'], $body['password']);
+    expect($body['password'])->toEqual($mockup->query['password']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode(array_merge(['connection' => $mockup->connection], $mockup->query)), $body);
+    expect($body)->toEqual(json_encode(array_merge(['connection' => $mockup->connection], $mockup->query)));
 });
 
 test('delete() issues an appropriate request', function(): void {
@@ -93,11 +93,11 @@ test('delete() issues an appropriate request', function(): void {
 
     $this->endpoint->delete($id);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $id);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
 test('linkAccount() issues an appropriate request', function(): void {
@@ -112,22 +112,22 @@ test('linkAccount() issues an appropriate request', function(): void {
 
     $this->endpoint->linkAccount($mockup->id, $mockup->query);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/identities');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('provider', $body);
-    $this->assertEquals($mockup->query['provider'], $body['provider']);
+    expect($body['provider'])->toEqual($mockup->query['provider']);
     $this->assertArrayHasKey('connection_id', $body);
-    $this->assertEquals($mockup->query['connection_id'], $body['connection_id']);
+    expect($body['connection_id'])->toEqual($mockup->query['connection_id']);
     $this->assertArrayHasKey('user_id', $body);
-    $this->assertEquals($mockup->query['user_id'], $body['user_id']);
+    expect($body['user_id'])->toEqual($mockup->query['user_id']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals(json_encode($mockup->query), $body);
+    expect($body)->toEqual(json_encode($mockup->query));
 });
 
 test('unlinkAccount() issues an appropriate request', function(): void {
@@ -139,11 +139,11 @@ test('unlinkAccount() issues an appropriate request', function(): void {
 
     $this->endpoint->unlinkAccount($mockup->id, $mockup->provider, $mockup->identity);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities/' . $mockup->provider . '/' . $mockup->identity, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/identities/' . $mockup->provider . '/' . $mockup->identity);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
 test('deleteMultifactorProvider() issues an appropriate request', function(): void {
@@ -154,11 +154,11 @@ test('deleteMultifactorProvider() issues an appropriate request', function(): vo
 
     $this->endpoint->deleteMultifactorProvider($mockup->id, $mockup->provider);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/multifactor/' . $mockup->provider, $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/multifactor/' . $mockup->provider);
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
 test('getRoles() issues an appropriate request', function(): void {
@@ -166,8 +166,8 @@ test('getRoles() issues an appropriate request', function(): void {
 
     $this->endpoint->getRoles($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users/' . $mockupId . '/roles');
 });
 
 test('removeRoles() issues an appropriate request', function(): void {
@@ -181,20 +181,20 @@ test('removeRoles() issues an appropriate request', function(): void {
 
     $this->endpoint->removeRoles($mockup->id, $mockup->roles);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/roles');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('roles', $body);
-    $this->assertCount(2, $body['roles']);
-    $this->assertEquals($mockup->roles[0], $body['roles'][0]);
-    $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+    expect($body['roles'])->toHaveCount(2);
+    expect($body['roles'][0])->toEqual($mockup->roles[0]);
+    expect($body['roles'][1])->toEqual($mockup->roles[1]);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
+    expect($body)->toEqual('{"roles":' . json_encode($mockup->roles) . '}');
 });
 
 test('addRoles() issues an appropriate request', function(): void {
@@ -208,20 +208,20 @@ test('addRoles() issues an appropriate request', function(): void {
 
     $this->endpoint->addRoles($mockup->id, $mockup->roles);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/roles');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('roles', $body);
-    $this->assertCount(2, $body['roles']);
-    $this->assertEquals($mockup->roles[0], $body['roles'][0]);
-    $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+    expect($body['roles'])->toHaveCount(2);
+    expect($body['roles'][0])->toEqual($mockup->roles[0]);
+    expect($body['roles'][1])->toEqual($mockup->roles[1]);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
+    expect($body)->toEqual('{"roles":' . json_encode($mockup->roles) . '}');
 });
 
 test('getEnrollments() issues an appropriate request', function(): void {
@@ -229,8 +229,8 @@ test('getEnrollments() issues an appropriate request', function(): void {
 
     $this->endpoint->getEnrollments($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/enrollments', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockupId . '/enrollments');
 });
 
 test('getPermissions() issues an appropriate request', function(): void {
@@ -238,8 +238,8 @@ test('getPermissions() issues an appropriate request', function(): void {
 
     $this->endpoint->getPermissions($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users/' . $mockupId . '/permissions');
 });
 
 test('removePermissions() issues an appropriate request', function(): void {
@@ -255,22 +255,22 @@ test('removePermissions() issues an appropriate request', function(): void {
 
     $this->endpoint->removePermissions($mockup->id, $mockup->permissions);
 
-    $this->assertEquals('DELETE', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('permissions', $body);
-    $this->assertCount(1, $body['permissions']);
+    expect($body['permissions'])->toHaveCount(1);
     $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-    $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
+    expect($body['permissions'][0]['permission_name'])->toEqual($mockup->permissions[0]['permission_name']);
     $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-    $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
+    expect($body['permissions'][0]['resource_server_identifier'])->toEqual($mockup->permissions[0]['resource_server_identifier']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
+    expect($body)->toEqual('{"permissions":' . json_encode($mockup->permissions) . '}');
 });
 
 test('addPermissions() issues an appropriate request', function(): void {
@@ -286,22 +286,22 @@ test('addPermissions() issues an appropriate request', function(): void {
 
     $this->endpoint->addPermissions($mockup->id, $mockup->permissions);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('permissions', $body);
-    $this->assertCount(1, $body['permissions']);
+    expect($body['permissions'])->toHaveCount(1);
     $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-    $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
+    expect($body['permissions'][0]['permission_name'])->toEqual($mockup->permissions[0]['permission_name']);
     $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-    $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
+    expect($body['permissions'][0]['resource_server_identifier'])->toEqual($mockup->permissions[0]['resource_server_identifier']);
 
     $body = $this->api->getRequestBodyAsString();
-    $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
+    expect($body)->toEqual('{"permissions":' . json_encode($mockup->permissions) . '}');
 });
 
 test('getLogs() issues an appropriate request', function(): void {
@@ -309,8 +309,8 @@ test('getLogs() issues an appropriate request', function(): void {
 
     $this->endpoint->getLogs($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/logs', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users/' . $mockupId . '/logs');
 });
 
 test('getOrganizations() issues an appropriate request', function(): void {
@@ -318,8 +318,8 @@ test('getOrganizations() issues an appropriate request', function(): void {
 
     $this->endpoint->getOrganizations($mockupId);
 
-    $this->assertEquals('GET', $this->api->getRequestMethod());
-    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/organizations', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://api.test.local/api/v2/users/' . $mockupId . '/organizations');
 });
 
 test('createRecoveryCode() issues an appropriate request', function(): void {
@@ -327,11 +327,11 @@ test('createRecoveryCode() issues an appropriate request', function(): void {
 
     $this->endpoint->createRecoveryCode($mockupId);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/recovery-code-regeneration', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockupId . '/recovery-code-regeneration');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
 test('invalidateBrowsers() issues an appropriate request', function(): void {
@@ -339,9 +339,9 @@ test('invalidateBrowsers() issues an appropriate request', function(): void {
 
     $this->endpoint->invalidateBrowsers($mockupId);
 
-    $this->assertEquals('POST', $this->api->getRequestMethod());
-    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/multifactor/actions/invalidate-remember-browser', $this->api->getRequestUrl());
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/users/' . $mockupId . '/multifactor/actions/invalidate-remember-browser');
 
     $headers = $this->api->getRequestHeaders();
-    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    expect($headers['Content-Type'][0])->toEqual('application/json');
 });

--- a/tests/Unit/API/Management/UsersTest.php
+++ b/tests/Unit/API/Management/UsersTest.php
@@ -2,446 +2,346 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\API\Management;
+uses()->group('management', 'management.users');
 
-use Auth0\Tests\Utilities\MockManagementApi;
-use PHPUnit\Framework\TestCase;
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->users();
+});
 
-/**
- * Class UsersTest.
- */
-class UsersTest extends TestCase
-{
-    /**
-     * Test getAll() request.
-     */
-    public function testGetAll(): void
-    {
-        $id = uniqid();
+test('getAll() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->getAll(['test' => $id]);
+    $this->endpoint->getAll(['test' => $id]);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/users', $api->getRequestUrl());
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users', $this->api->getRequestUrl());
 
-        $query = $api->getRequestQuery();
-        $this->assertStringContainsString('&test=' . $id, $query);
-    }
+    $query = $this->api->getRequestQuery();
+    $this->assertStringContainsString('&test=' . $id, $query);
+});
 
-    /**
-     * Test get() request.
-     */
-    public function testGet(): void
-    {
-        $id = uniqid();
+test('get() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->get($id);
+    $this->endpoint->get($id);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $api->getRequestUrl());
-    }
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $this->api->getRequestUrl());
+});
 
-    /**
-     * Test update() request.
-     */
-    public function testUpdate(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'query' => [
-                'given_name' => uniqid(),
-                'user_metadata' => [
-                    '__test_meta_key__' => uniqid(),
-                ],
+test('update() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'query' => [
+            'given_name' => uniqid(),
+            'user_metadata' => [
+                '__test_meta_key__' => uniqid(),
             ],
-        ];
+        ],
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->update($mockup->id, $mockup->query);
+    $this->endpoint->update($mockup->id, $mockup->query);
 
-        $this->assertEquals('PATCH', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id, $api->getRequestUrl());
+    $this->assertEquals('PATCH', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id, $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('given_name', $body);
-        $this->assertEquals($mockup->query['given_name'], $body['given_name']);
-        $this->assertArrayHasKey('user_metadata', $body);
-        $this->assertArrayHasKey('__test_meta_key__', $body['user_metadata']);
-        $this->assertEquals($mockup->query['user_metadata']['__test_meta_key__'], $body['user_metadata']['__test_meta_key__']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('given_name', $body);
+    $this->assertEquals($mockup->query['given_name'], $body['given_name']);
+    $this->assertArrayHasKey('user_metadata', $body);
+    $this->assertArrayHasKey('__test_meta_key__', $body['user_metadata']);
+    $this->assertEquals($mockup->query['user_metadata']['__test_meta_key__'], $body['user_metadata']['__test_meta_key__']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode($mockup->query), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($mockup->query), $body);
+});
 
-    /**
-     * Test create() request.
-     */
-    public function testCreate(): void
-    {
-        $mockup = (object) [
-            'connection' => uniqid(),
-            'query' => [
-                'email' => uniqid(),
-                'password' => uniqid(),
-            ],
-        ];
+test('create() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'connection' => uniqid(),
+        'query' => [
+            'email' => uniqid(),
+            'password' => uniqid(),
+        ],
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->create($mockup->connection, $mockup->query);
+    $this->endpoint->create($mockup->connection, $mockup->query);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users', $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('connection', $body);
-        $this->assertEquals($mockup->connection, $body['connection']);
-        $this->assertArrayHasKey('email', $body);
-        $this->assertEquals($mockup->query['email'], $body['email']);
-        $this->assertArrayHasKey('password', $body);
-        $this->assertEquals($mockup->query['password'], $body['password']);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('connection', $body);
+    $this->assertEquals($mockup->connection, $body['connection']);
+    $this->assertArrayHasKey('email', $body);
+    $this->assertEquals($mockup->query['email'], $body['email']);
+    $this->assertArrayHasKey('password', $body);
+    $this->assertEquals($mockup->query['password'], $body['password']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode(array_merge(['connection' => $mockup->connection], $mockup->query)), $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode(array_merge(['connection' => $mockup->connection], $mockup->query)), $body);
+});
 
-    /**
-     * Test delete() request.
-     */
-    public function testDelete(): void
-    {
-        $id = uniqid();
+test('delete() issues an appropriate request', function(): void {
+    $id = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->delete($id);
+    $this->endpoint->delete($id);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $api->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $id, $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});
 
-    /**
-     * Test linkAccount() request.
-     */
-    public function testLinkAccount(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'query' => [
-                'provider' => uniqid(),
-                'connection_id' => uniqid(),
-                'user_id' => uniqid(),
-            ],
-        ];
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->linkAccount($mockup->id, $mockup->query);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('provider', $body);
-        $this->assertEquals($mockup->query['provider'], $body['provider']);
-        $this->assertArrayHasKey('connection_id', $body);
-        $this->assertEquals($mockup->query['connection_id'], $body['connection_id']);
-        $this->assertArrayHasKey('user_id', $body);
-        $this->assertEquals($mockup->query['user_id'], $body['user_id']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals(json_encode($mockup->query), $body);
-    }
-
-    /**
-     * Test unlinkAccount() request.
-     */
-    public function testUnlinkAccount(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
+test('linkAccount() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'query' => [
             'provider' => uniqid(),
-            'identity' => uniqid(),
-        ];
+            'connection_id' => uniqid(),
+            'user_id' => uniqid(),
+        ],
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->unlinkAccount($mockup->id, $mockup->provider, $mockup->identity);
+    $this->endpoint->linkAccount($mockup->id, $mockup->query);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities/' . $mockup->provider . '/' . $mockup->identity, $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities', $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-    /**
-     * Test deleteMultifactorProvider() request.
-     */
-    public function testDeleteMultifactorProvider(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'provider' => uniqid(),
-        ];
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('provider', $body);
+    $this->assertEquals($mockup->query['provider'], $body['provider']);
+    $this->assertArrayHasKey('connection_id', $body);
+    $this->assertEquals($mockup->query['connection_id'], $body['connection_id']);
+    $this->assertArrayHasKey('user_id', $body);
+    $this->assertEquals($mockup->query['user_id'], $body['user_id']);
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->deleteMultifactorProvider($mockup->id, $mockup->provider);
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals(json_encode($mockup->query), $body);
+});
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/multifactor/' . $mockup->provider, $api->getRequestUrl());
+test('unlinkAccount() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'provider' => uniqid(),
+        'identity' => uniqid(),
+    ];
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
+    $this->endpoint->unlinkAccount($mockup->id, $mockup->provider, $mockup->identity);
 
-    /**
-     * Test getRoles() request.
-     */
-    public function testThatGetRolesRequestIsFormattedProperly(): void
-    {
-        $mockupId = uniqid();
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/identities/' . $mockup->provider . '/' . $mockup->identity, $this->api->getRequestUrl());
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->getRoles($mockupId);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/roles', $api->getRequestUrl());
-    }
+test('deleteMultifactorProvider() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'provider' => uniqid(),
+    ];
 
-    /**
-     * Test removeRoles() request.
-     */
-    public function testRemoveRoles(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'roles' => [
-                uniqid(),
-                uniqid(),
+    $this->endpoint->deleteMultifactorProvider($mockup->id, $mockup->provider);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/multifactor/' . $mockup->provider, $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});
+
+test('getRoles() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
+
+    $this->endpoint->getRoles($mockupId);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/roles', $this->api->getRequestUrl());
+});
+
+test('removeRoles() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'roles' => [
+            uniqid(),
+            uniqid(),
+        ],
+    ];
+
+    $this->endpoint->removeRoles($mockup->id, $mockup->roles);
+
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('roles', $body);
+    $this->assertCount(2, $body['roles']);
+    $this->assertEquals($mockup->roles[0], $body['roles'][0]);
+    $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
+});
+
+test('addRoles() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'roles' => [
+            uniqid(),
+            uniqid(),
+        ],
+    ];
+
+    $this->endpoint->addRoles($mockup->id, $mockup->roles);
+
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $this->api->getRequestUrl());
+
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('roles', $body);
+    $this->assertCount(2, $body['roles']);
+    $this->assertEquals($mockup->roles[0], $body['roles'][0]);
+    $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
+});
+
+test('getEnrollments() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
+
+    $this->endpoint->getEnrollments($mockupId);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/enrollments', $this->api->getRequestUrl());
+});
+
+test('getPermissions() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
+
+    $this->endpoint->getPermissions($mockupId);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/permissions', $this->api->getRequestUrl());
+});
+
+test('removePermissions() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'permissions' => [
+            [
+                'permission_name' => 'test:' . uniqid(),
+                'resource_server_identifier' => uniqid(),
             ],
-        ];
+        ],
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->removeRoles($mockup->id, $mockup->roles);
+    $this->endpoint->removePermissions($mockup->id, $mockup->permissions);
 
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $api->getRequestUrl());
+    $this->assertEquals('DELETE', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('roles', $body);
-        $this->assertCount(2, $body['roles']);
-        $this->assertEquals($mockup->roles[0], $body['roles'][0]);
-        $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('permissions', $body);
+    $this->assertCount(1, $body['permissions']);
+    $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
+    $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
+    $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
+    $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
+});
 
-    /**
-     * Test addRoles() request.
-     */
-    public function testAddRoles(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'roles' => [
-                uniqid(),
-                uniqid(),
+test('addPermissions() issues an appropriate request', function(): void {
+    $mockup = (object) [
+        'id' => uniqid(),
+        'permissions' => [
+            [
+                'permission_name' => 'test:' . uniqid(),
+                'resource_server_identifier' => uniqid(),
             ],
-        ];
+        ],
+    ];
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->addRoles($mockup->id, $mockup->roles);
+    $this->endpoint->addPermissions($mockup->id, $mockup->permissions);
 
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/roles', $api->getRequestUrl());
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $this->api->getRequestUrl());
 
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
 
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('roles', $body);
-        $this->assertCount(2, $body['roles']);
-        $this->assertEquals($mockup->roles[0], $body['roles'][0]);
-        $this->assertEquals($mockup->roles[1], $body['roles'][1]);
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('permissions', $body);
+    $this->assertCount(1, $body['permissions']);
+    $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
+    $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
+    $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
+    $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
 
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals('{"roles":' . json_encode($mockup->roles) . '}', $body);
-    }
+    $body = $this->api->getRequestBodyAsString();
+    $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
+});
 
-    /**
-     * Test getEnrollments() request.
-     */
-    public function testGetEnrollments(): void
-    {
+test('getLogs() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
+
+    $this->endpoint->getLogs($mockupId);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/logs', $this->api->getRequestUrl());
+});
+
+test('getOrganizations() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
+
+    $this->endpoint->getOrganizations($mockupId);
+
+    $this->assertEquals('GET', $this->api->getRequestMethod());
+    $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/organizations', $this->api->getRequestUrl());
+});
+
+test('createRecoveryCode() issues an appropriate request', function(): void {
         $mockupId = uniqid();
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->getEnrollments($mockupId);
+    $this->endpoint->createRecoveryCode($mockupId);
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/enrollments', $api->getRequestUrl());
-    }
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/recovery-code-regeneration', $this->api->getRequestUrl());
 
-    /**
-     * Test getPermissions() request.
-     */
-    public function testGetPermissions(): void
-    {
-        $mockupId = uniqid();
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->getPermissions($mockupId);
+test('invalidateBrowsers() issues an appropriate request', function(): void {
+    $mockupId = uniqid();
 
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/permissions', $api->getRequestUrl());
-    }
+    $this->endpoint->invalidateBrowsers($mockupId);
 
-    /**
-     * Test removePermissions() request.
-     */
-    public function testRemovePermissions(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'permissions' => [
-                [
-                    'permission_name' => 'test:' . uniqid(),
-                    'resource_server_identifier' => uniqid(),
-                ],
-            ],
-        ];
+    $this->assertEquals('POST', $this->api->getRequestMethod());
+    $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/multifactor/actions/invalidate-remember-browser', $this->api->getRequestUrl());
 
-        $api = new MockManagementApi();
-        $api->mock()->users()->removePermissions($mockup->id, $mockup->permissions);
-
-        $this->assertEquals('DELETE', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('permissions', $body);
-        $this->assertCount(1, $body['permissions']);
-        $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-        $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
-        $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-        $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
-    }
-
-    /**
-     * Test addPermissions() request.
-     */
-    public function testThatAddPermissionsRequestIsFormattedProperly(): void
-    {
-        $mockup = (object) [
-            'id' => uniqid(),
-            'permissions' => [
-                [
-                    'permission_name' => 'test:' . uniqid(),
-                    'resource_server_identifier' => uniqid(),
-                ],
-            ],
-        ];
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->addPermissions($mockup->id, $mockup->permissions);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockup->id . '/permissions', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-
-        $body = $api->getRequestBody();
-        $this->assertArrayHasKey('permissions', $body);
-        $this->assertCount(1, $body['permissions']);
-        $this->assertArrayHasKey('permission_name', $body['permissions'][0]);
-        $this->assertEquals($mockup->permissions[0]['permission_name'], $body['permissions'][0]['permission_name']);
-        $this->assertArrayHasKey('resource_server_identifier', $body['permissions'][0]);
-        $this->assertEquals($mockup->permissions[0]['resource_server_identifier'], $body['permissions'][0]['resource_server_identifier']);
-
-        $body = $api->getRequestBodyAsString();
-        $this->assertEquals('{"permissions":' . json_encode($mockup->permissions) . '}', $body);
-    }
-
-    /**
-     * Test getLogs() request.
-     */
-    public function testGetLogs(): void
-    {
-        $mockupId = uniqid();
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->getLogs($mockupId);
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/logs', $api->getRequestUrl());
-    }
-
-    /**
-     * Test getOrganizations() request.
-     */
-    public function testGetOrganizations(): void
-    {
-        $mockupId = uniqid();
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->getOrganizations($mockupId);
-
-        $this->assertEquals('GET', $api->getRequestMethod());
-        $this->assertStringStartsWith('https://api.test.local/api/v2/users/' . $mockupId . '/organizations', $api->getRequestUrl());
-    }
-
-    /**
-     * Test createRecoveryCode() request.
-     */
-    public function testThatCreateRecoveryCodeRequestIsFormattedProperly(): void
-    {
-        $mockupId = uniqid();
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->createRecoveryCode($mockupId);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/recovery-code-regeneration', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
-
-    /**
-     * Test invalidateBrowsers() request.
-     */
-    public function testInvalidateBrowsers(): void
-    {
-        $mockupId = uniqid();
-
-        $api = new MockManagementApi();
-        $api->mock()->users()->invalidateBrowsers($mockupId);
-
-        $this->assertEquals('POST', $api->getRequestMethod());
-        $this->assertEquals('https://api.test.local/api/v2/users/' . $mockupId . '/multifactor/actions/invalidate-remember-browser', $api->getRequestUrl());
-
-        $headers = $api->getRequestHeaders();
-        $this->assertEquals('application/json', $headers['Content-Type'][0]);
-    }
-}
+    $headers = $this->api->getRequestHeaders();
+    $this->assertEquals('application/json', $headers['Content-Type'][0]);
+});

--- a/tests/Unit/API/ManagementTest.php
+++ b/tests/Unit/API/ManagementTest.php
@@ -8,16 +8,11 @@ use Auth0\SDK\Auth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Auth0\Tests\Utilities\TokenGenerator;
-use Http\Discovery\Psr18ClientDiscovery;
-use Http\Discovery\Strategy\MockClientStrategy;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 uses()->group('management');
 
 beforeEach(function(): void {
-    // Allow mock HttpClient to be auto-discovered for use in testing.
-    Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);
-
     $this->configuration = new SdkConfiguration([
         'domain' => 'https://test-domain.auth0.com',
         'cookieSecret' => uniqid(),

--- a/tests/Unit/API/ManagementTest.php
+++ b/tests/Unit/API/ManagementTest.php
@@ -6,6 +6,7 @@ use Auth0\SDK\API\Authentication;
 use Auth0\SDK\API\Management;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Utility\HttpRequest;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Auth0\Tests\Utilities\TokenGenerator;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -166,6 +167,14 @@ test('usersByEmail() returns an instance of Auth0\SDK\API\Management\UsersByEmai
     $class = $this->sdk->management()->usersByEmail();
 
     expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\UsersByEmail::class);
+});
+
+test('getLastRequest() returns an HttpRequest or null', function(): void {
+    expect($this->sdk->management()->getLastRequest())->toBeNull();
+
+    $this->sdk->management()->users()->getAll();
+
+    expect($this->sdk->management()->getLastRequest())->toBeInstanceOf(HttpRequest::class);
 });
 
 test('Magic method throws an exception when an invalid class is requested', function(): void {

--- a/tests/Unit/API/ManagementTest.php
+++ b/tests/Unit/API/ManagementTest.php
@@ -28,20 +28,13 @@ beforeEach(function(): void {
 });
 
 test('__construct() fails without a configuration', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
-
     new Management(null);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
 
 test('getHttpClient() fails without a managementToken, if client id and secret are not configured', function(): void {
     $this->configuration->setManagementToken(null);
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_MANAGEMENT_KEY);
-
     $this->sdk->management()->blacklists();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_MANAGEMENT_KEY);
 
 test('blacklists() returns an instance of Auth0\SDK\API\Management\Blacklists', function(): void {
     $class = $this->sdk->management()->blacklists();
@@ -176,11 +169,8 @@ test('usersByEmail() returns an instance of Auth0\SDK\API\Management\UsersByEmai
 });
 
 test('Magic method throws an exception when an invalid class is requested', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_UNKNOWN_METHOD, 'example'));
-
     $class = $this->sdk->management()->example();
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_UNKNOWN_METHOD, 'example'));
 
 test('Caching of management tokens works.', function(): void {
     $managementToken = uniqid();

--- a/tests/Unit/API/ManagementTest.php
+++ b/tests/Unit/API/ManagementTest.php
@@ -46,133 +46,133 @@ test('getHttpClient() fails without a managementToken, if client id and secret a
 test('blacklists() returns an instance of Auth0\SDK\API\Management\Blacklists', function(): void {
     $class = $this->sdk->management()->blacklists();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Blacklists::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Blacklists::class);
 });
 
 test('clients() returns an instance of Auth0\SDK\API\Management\Clients', function(): void {
     $class = $this->sdk->management()->clients();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Clients::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Clients::class);
 });
 
 test('clientGrants() returns an instance of Auth0\SDK\API\Management\ClientGrants', function(): void {
     $class = $this->sdk->management()->clientGrants();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\ClientGrants::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\ClientGrants::class);
 });
 
 test('connections() returns an instance of Auth0\SDK\API\Management\Connections', function(): void {
     $class = $this->sdk->management()->connections();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Connections::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Connections::class);
 });
 
 test('deviceCredentials() returns an instance of Auth0\SDK\API\Management\DeviceCredentials', function(): void {
     $class = $this->sdk->management()->deviceCredentials();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\DeviceCredentials::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\DeviceCredentials::class);
 });
 
 test('emails() returns an instance of Auth0\SDK\API\Management\Emails', function(): void {
     $class = $this->sdk->management()->emails();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Emails::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Emails::class);
 });
 
 test('emailTemplates() returns an instance of Auth0\SDK\API\Management\EmailTemplates', function(): void {
     $class = $this->sdk->management()->emailTemplates();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\EmailTemplates::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\EmailTemplates::class);
 });
 
 test('grants() returns an instance of Auth0\SDK\API\Management\Grants', function(): void {
     $class = $this->sdk->management()->grants();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Grants::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Grants::class);
 });
 
 test('guardian() returns an instance of Auth0\SDK\API\Management\Guardian', function(): void {
     $class = $this->sdk->management()->guardian();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Guardian::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Guardian::class);
 });
 
 test('jobs() returns an instance of Auth0\SDK\API\Management\Jobs', function(): void {
     $class = $this->sdk->management()->jobs();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Jobs::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Jobs::class);
 });
 
 test('logs() returns an instance of Auth0\SDK\API\Management\Logs', function(): void {
     $class = $this->sdk->management()->logs();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Logs::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Logs::class);
 });
 
 test('logStreams() returns an instance of Auth0\SDK\API\Management\LogStreams', function(): void {
     $class = $this->sdk->management()->logStreams();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\LogStreams::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\LogStreams::class);
 });
 
 test('organizations() returns an instance of Auth0\SDK\API\Management\Organizations', function(): void {
     $class = $this->sdk->management()->organizations();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Organizations::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Organizations::class);
 });
 
 test('roles() returns an instance of Auth0\SDK\API\Management\Roles', function(): void {
     $class = $this->sdk->management()->roles();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Roles::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Roles::class);
 });
 
 test('rules() returns an instance of Auth0\SDK\API\Management\Rules', function(): void {
     $class = $this->sdk->management()->rules();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Rules::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Rules::class);
 });
 
 test('resourceServers() returns an instance of Auth0\SDK\API\Management\ResourceServers', function(): void {
     $class = $this->sdk->management()->resourceServers();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\ResourceServers::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\ResourceServers::class);
 });
 
 test('stats() returns an instance of Auth0\SDK\API\Management\Stats', function(): void {
     $class = $this->sdk->management()->stats();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Stats::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Stats::class);
 });
 
 test('tenants() returns an instance of Auth0\SDK\API\Management\Tenants', function(): void {
     $class = $this->sdk->management()->tenants();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Tenants::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Tenants::class);
 });
 
 test('tickets() returns an instance of Auth0\SDK\API\Management\Tickets', function(): void {
     $class = $this->sdk->management()->tickets();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Tickets::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Tickets::class);
 });
 
 test('userBlocks() returns an instance of Auth0\SDK\API\Management\UserBlocks', function(): void {
     $class = $this->sdk->management()->userBlocks();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\UserBlocks::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\UserBlocks::class);
 });
 
 test('users() returns an instance of Auth0\SDK\API\Management\Users', function(): void {
     $class = $this->sdk->management()->users();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Users::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Users::class);
 });
 
 test('usersByEmail() returns an instance of Auth0\SDK\API\Management\UsersByEmail', function(): void {
     $class = $this->sdk->management()->usersByEmail();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\UsersByEmail::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\UsersByEmail::class);
 });
 
 test('Magic method throws an exception when an invalid class is requested', function(): void {
@@ -195,7 +195,7 @@ test('Caching of management tokens works.', function(): void {
 
     $class = $this->sdk->management()->blacklists();
 
-    $this->assertInstanceOf(\Auth0\SDK\API\Management\Blacklists::class, $class);
+    expect($class)->toBeInstanceOf(\Auth0\SDK\API\Management\Blacklists::class);
 });
 
 test('A client credential exchange occurs if a managementToken is not configured, but a client id and secret are', function(): void {
@@ -214,5 +214,5 @@ test('A client credential exchange occurs if a managementToken is not configured
 
     $this->sdk->management()->getHttpClient($authentication);
 
-    $this->assertEquals('1.2.3', $cache->getItem('managementAccessToken')->get());
+    expect($cache->getItem('managementAccessToken')->get())->toEqual('1.2.3');
 });

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -2,746 +2,575 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit;
-
-use Auth0\SDK\Auth0;
-use Auth0\SDK\Contract\StoreInterface;
-use Auth0\SDK\Store\SessionStore;
-use Auth0\SDK\Utility\Shortcut;
-use Auth0\Tests\Utilities\HttpResponseGenerator;
-use Auth0\Tests\Utilities\TokenGenerator;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-
-/**
- * Class Auth0Test.
- */
-class Auth0Test extends TestCase
-{
-    /**
-     * Basic Auth0 class config options.
-     */
-    public static array $baseConfig;
-
-    /**
-     * Runs before each test begins.
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        self::$baseConfig = [
-            'domain' => '__test_domain__',
-            'clientId' => '__test_client_id__',
-            'cookieSecret' => uniqid(),
-            'clientSecret' => '__test_client_secret__',
-            'redirectUri' => '__test_redirect_uri__',
-        ];
-    }
-
-    /**
-     * Runs after each test completes.
-     */
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        $_GET = [];
-        $_COOKIE = [];
-    }
-
-    /**
-     * Test that the exchange call returns false before making any HTTP calls if no code is present.
-     */
-    public function testThatExchangeReturnsFalseIfNoCodePresent(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-        $this->assertFalse($auth0->exchange());
-    }
-
-    /**
-     * Test that the exchanges fails when there is not a stored nonce value.
-     */
-    public function testThatExchangeFailsWithNoStoredNonce(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-        ]);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-        $httpClient->mockResponse(HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","refresh_token":"4.5.6"}'));
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier', '__test_code_verifier__');
-
-        $this->expectException(\Auth0\SDK\Exception\StateException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_NONCE);
-
-        $auth0->exchange();
-    }
-
-    /**
-     * Test that the exchanges fails when there is not a stored nonce value.
-     */
-    public function testThatExchangeFailsWhenPkceIsEnabledAndNoCodeVerifierWasFound(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  null);
-
-        $this->expectException(\Auth0\SDK\Exception\StateException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_CODE_VERIFIER);
-
-        $auth0->exchange();
-    }
-
-    /**
-     * Test that the exchanges succeeds when there is both and access token and an ID token present.
-     */
-    public function testThatExchangeSucceedsWithIdToken(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-        ]);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","refresh_token":"4.5.6"}'),
-            HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-        $this->assertArrayHasKey('sub', $auth0->getUser());
-        $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
-        $this->assertEquals($token, $auth0->getIdToken());
-        $this->assertEquals('1.2.3', $auth0->getAccessToken());
-        $this->assertEquals('4.5.6', $auth0->getRefreshToken());
-    }
-
-    /**
-     * Test that the exchanges succeeds when there is only an access token.
-     */
-    public function testThatExchangeSucceedsWithNoIdToken(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
-            HttpResponseGenerator::create('{"sub":"123"}')
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-        $this->assertArrayHasKey('sub', $auth0->getUser());
-        $this->assertEquals('123', $auth0->getUser()['sub']);
-        $this->assertEquals('1.2.3', $auth0->getAccessToken());
-        $this->assertEquals('4.5.6', $auth0->getRefreshToken());
-    }
-
-    /**
-     * Test that the exchanges succeeds when PKCE is enabled.
-     */
-    public function testThatExchangeSucceedsWithPkceEnabled(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
-            HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-        $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
-        $this->assertEquals('1.2.3', $auth0->getAccessToken());
-        $this->assertEquals('4.5.6', $auth0->getRefreshToken());
-    }
-
-    /**
-     * Test that the exchanges succeeds when PKCE is disabled.
-     */
-    public function testThatExchangeSucceedsWithoutPkceEnabled(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig + [
-            'usePkce' => false,
-        ]);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
-            HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-
-        $this->assertTrue($auth0->exchange());
-        $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
-        $this->assertEquals('1.2.3', $auth0->getAccessToken());
-        $this->assertEquals('4.5.6', $auth0->getRefreshToken());
-    }
-
-    /**
-     * Test that the skip_userinfo config option uses the ID token instead of calling /userinfo.
-     */
-    public function testThatExchangeSkipsUserinfo(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-        ]);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '"}'),
-            HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-        $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
-        $this->assertEquals($token, $auth0->getIdToken());
-        $this->assertEquals('1.2.3', $auth0->getAccessToken());
-    }
-
-    /**
-     * Test that renew() fails if there is no refresh_token stored.
-     */
-    public function testThatRenewTokensFailsIfThereIsNoRefreshToken(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3"}'),
-            HttpResponseGenerator::create('{}')
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-
-        $this->expectException(\Auth0\SDK\Exception\StateException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN);
-
-        $auth0->renew();
-    }
-
-    /**
-     * Test that renew() fails if the API response is invalid.
-     */
-    public function testThatRenewTokensFailsIfNoAccessTokenReturned(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4"}'),
-            HttpResponseGenerator::create('{}'),
-            HttpResponseGenerator::create('{}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-
-        $this->expectException(\Auth0\SDK\Exception\StateException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_ACCESS_TOKEN);
-
-        $auth0->renew();
-    }
-
-    /**
-     * Test that renew() succeeds with non-empty access_token and refresh_token stored.
-     */
-    public function testThatRenewTokensSucceeds(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-        ]);
-
-        $httpClient = $auth0->authentication()->getHttpClient();
-
-        $httpClient->mockResponses([
-            HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4","id_token":"' . $token . '"}'),
-            HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '"}'),
-        ]);
-
-        $_GET['code'] = uniqid();
-        $_GET['state'] = '__test_state__';
-
-        $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-        $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
-
-        $this->assertTrue($auth0->exchange());
-
-        $auth0->renew(['scope' => 'openid']);
-        $request = $httpClient->getLastRequest()->getLastRequest();
-        parse_str($request->getBody()->__toString(), $requestBody);
-
-        $this->assertEquals('__test_access_token__', $auth0->getAccessToken());
-        $this->assertEquals($token, $auth0->getIdToken());
-
-        $this->assertEquals('openid', $requestBody['scope']);
-        $this->assertEquals('__test_client_secret__', $requestBody['client_secret']);
-        $this->assertEquals('__test_client_id__', $requestBody['client_id']);
-        $this->assertEquals('2.3.4', $requestBody['refresh_token']);
-        $this->assertEquals('https://__test_domain__/oauth/token', $request->getUri()->__toString());
-    }
-
-    /**
-     * Test that get login url uses default values.
-     */
-    public function testThatGetLoginUrlUsesDefaultValues(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $parsed_url = parse_url($auth0->authentication()->getLoginLink(uniqid()));
-
-        $this->assertEquals('https', $parsed_url['scheme']);
-        $this->assertEquals('__test_domain__', $parsed_url['host']);
-        $this->assertEquals('/authorize', $parsed_url['path']);
-
-        $url_query = explode('&', $parsed_url['query']);
-
-        $this->assertContains('scope=openid%20profile%20email', $url_query);
-        $this->assertContains('response_type=code', $url_query);
-        $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
-        $this->assertContains('client_id=__test_client_id__', $url_query);
-    }
-
-    /**
-     * Test that get login url adds values.
-     */
-    public function testThatGetLoginUrlAddsValues(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $custom_params = [
-            'connection' => '__test_connection__',
-            'prompt' => 'none',
-            'audience' => '__test_audience__',
-            'state' => '__test_state__',
-            'invitation' => '__test_invitation__',
-        ];
-
-        $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, $custom_params);
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-        $url_query = explode('&', $parsed_url_query);
-
-        $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
-        $this->assertContains('client_id=__test_client_id__', $url_query);
-        $this->assertContains('connection=__test_connection__', $url_query);
-        $this->assertContains('prompt=none', $url_query);
-        $this->assertContains('audience=__test_audience__', $url_query);
-        $this->assertContains('state=__test_state__', $url_query);
-        $this->assertContains('invitation=__test_invitation__', $url_query);
-    }
-
-    /**
-     * Test that get login url overrides default values.
-     */
-    public function testThatGetLoginUrlOverridesDefaultValues(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $override_params = [
-            'scope' => 'openid profile email',
-            'response_type' => 'id_token',
-            'response_mode' => 'form_post',
-        ];
-
-        $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, $override_params);
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-        $url_query = explode('&', $parsed_url_query);
-
-        $this->assertContains('scope=openid%20profile%20email', $url_query);
-        $this->assertContains('response_type=id_token', $url_query);
-        $this->assertContains('response_mode=form_post', $url_query);
-        $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
-        $this->assertContains('client_id=__test_client_id__', $url_query);
-    }
-
-    /**
-     * Test that get login url generates state and nonce.
-     */
-    public function testThatGetLoginUrlGeneratesStateAndNonce(): void
-    {
-        $custom_config = self::$baseConfig;
-
-        $auth0 = new Auth0($custom_config);
-
-        $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, ['nonce' => uniqid()]);
-
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-
-        $this->assertStringContainsString('state=', $auth_url);
-        $this->assertStringContainsString('nonce=', $auth_url);
-    }
-
-    /**
-     * Test that get login url generates challenge and challenge method when PKCE is enabled.
-     */
-    public function testThatLoginGeneratesChallengeAndChallengeMethodWhenPkceIsEnabled(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $auth_url = $auth0->login(uniqid());
-
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-        $url_query = explode('&', $parsed_url_query);
-
-        $this->assertStringContainsString('code_challenge=', $parsed_url_query);
-        $this->assertContains('code_challenge_method=S256', $url_query);
-    }
-
-    /**
-     * Test that invitation parameters are extracted.
-     */
-    public function testThatInvitationParametersAreExtracted(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $_GET['invitation'] = '__test_invitation__';
-        $_GET['organization'] = '__test_organization__';
-        $_GET['organization_name'] = '__test_organization_name__';
-
-        $extracted = $auth0->getInvitationParameters();
-
-        $this->assertIsObject($extracted, 'Invitation parameters were not extracted from the $_GET (environment variable seeded with query parameters during a GET request) successfully.');
-
-        $this->assertObjectHasAttribute('invitation', $extracted);
-        $this->assertObjectHasAttribute('organization', $extracted);
-        $this->assertObjectHasAttribute('organizationName', $extracted);
-
-        $this->assertEquals($extracted->invitation, '__test_invitation__');
-        $this->assertEquals($extracted->organization, '__test_organization__');
-        $this->assertEquals($extracted->organizationName, '__test_organization_name__');
-    }
-
-    /**
-     * Test that invitation parameters aren't extracted when incomplete..
-     */
-    public function testThatInvitationParametersArentExtractedWhenIncomplete(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig);
-
-        $_GET['invitation'] = '__test_invitation__';
-
-        $extracted = $auth0->getInvitationParameters();
-
-        $this->assertIsNotObject($extracted);
-    }
-
-    /**
-     * Test that max age is set in login url from initial config.
-     */
-    public function testThatMaxAgeIsSetInLoginUrlFromInitialConfig(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenMaxAge' => 1000,
-        ]);
-
-        $auth_url = $auth0->login(uniqid());
-
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-        $url_query = explode('&', $parsed_url_query);
-
-        $this->assertContains('max_age=1000', $url_query);
-    }
-
-    /**
-     * Test that max age is overridden in login url.
-     */
-    public function testThatMaxAgeIsOverriddenInLoginUrl(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenMaxAge' => 1000,
-        ]);
-
-        $auth_url = $auth0->login(uniqid(), [
-            'max_age' => 1001,
-        ]);
-
-        $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
-        $url_query = explode('&', $parsed_url_query);
-
-        $this->assertContains('max_age=1001', $url_query);
-    }
-
-    /**
-     * Test that ID Token is persisted when set.
-     */
-    public function testThatIdTokenIsPersistedWhenSet(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-        ]);
-
-        $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
-
-        $auth0->setIdToken($token);
-
-        $this->assertEquals($token, $auth0->getIdToken());
-        $this->assertEquals($token, $auth0->configuration()->getSessionStorage()->get('idToken'));
-    }
-
-    /**
-     * Test that ID Token auth time is checked when set.
-     */
-    public function testThatIdTokenAuthTimeIsCheckedWhenSet(): void
-    {
-        $now = time();
-        $maxAge = 10;
-        $drift = 100;
-
-        $token = (new TokenGenerator())->withHs256([
-            'auth_time' => $now - $drift,
-        ]);
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-            'tokenMaxAge' => $maxAge,
-            'tokenLeeway' => 0,
-        ]);
-
-        $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUTH_TIME_CLAIM, time(), $now - $drift + $maxAge));
-
-        $auth0->decode($token, null, null, null, null, null, $now);
-    }
-
-    /**
-     * Test that ID Token Organization is checked when set.
-     */
-    public function testThatIdTokenOrganizationIsCheckedWhenSet(): void
-    {
-        $token = (new TokenGenerator())->withHs256();
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-            'organization' => ['org8675309'],
-        ]);
-
-        $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_ORG_ID_CLAIM);
-
-        $auth0->decode($token);
-    }
-
-    /**
-     * Test that ID Token Organization is successful when matched.
-     */
-    public function testThatIdTokenOrganizationSuccessWhenMatched(): void
-    {
-        $orgId = 'org8675309';
-
-        $token = (new TokenGenerator())->withHs256([
-            'org_id' => $orgId,
-        ]);
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-            'organization' => [$orgId],
-        ]);
-
-        $decoded = $auth0->decode($token);
-
-        $this->assertEquals($orgId, $decoded->getOrganization());
-    }
-
-    /**
-     * Test that ID Token Organization fails when mismatched.
-     */
-    public function testThatIdTokenOrganizationFailsWhenMismatched(): void
-    {
-        $expectedOrgId = uniqid();
-        $tokenOrgId = uniqid();
-
-        $token = (new TokenGenerator())->withHs256([
-            'org_id' => $tokenOrgId,
-        ]);
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-            'organization' => [$expectedOrgId],
-        ]);
-
-        $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-        $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_ORG_ID_CLAIM, $expectedOrgId, $tokenOrgId));
-
-        $auth0->decode($token);
-    }
-
-    /**
-     * Test that ID Token leeway from constructor is used.
-     */
-    public function testThatIdTokenLeewayFromConstructorIsUsed(): void
-    {
-        $token = (new TokenGenerator())->withHs256([
-            'exp' => time() - 100,
-        ]);
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenAlgorithm' => 'HS256',
-            'tokenLeeway' => 120,
-        ]);
-
-        $auth0->setIdToken($token);
-        $this->assertEquals($token, $auth0->getIdToken());
-    }
-
-    /**
-     * Test that cache handler can be set.
-     */
-    public function testThatCacheHandlerCanBeSet(): void
-    {
-        $cacheKey = hash('sha256', 'https://test.auth0.com/.well-known/jwks.json');
-        $mockJwks = [
-            '__test_kid__' => [
-                'x5c' => ['123'],
-            ],
-        ];
-
-        $pool = new ArrayAdapter();
-        $item = $pool->getItem($cacheKey);
-        $item->set($mockJwks);
-        $pool->save($item);
-
-        $auth0 = new Auth0(self::$baseConfig + [
-            'tokenCache' => $pool,
-        ]);
-
-        $cachedJwks = $pool->getItem($cacheKey)->get();
-        $this->assertNotEmpty($cachedJwks);
-        $this->assertArrayHasKey('__test_kid__', $cachedJwks);
-        $this->assertEquals($mockJwks, $cachedJwks);
-
-        // Ignore that we can't verify using this mock cert, just that it was attempted.
-        $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-        $this->expectExceptionMessage('Cannot verify signature');
-
-        $auth0->decode((new TokenGenerator())->withRs256([], null, ['kid' => '__test_kid__']));
-    }
-
-    /**
-     * Test that passed in store interface is used.
-     */
-    public function testThatPassedInStoreInterfaceIsUsed(): void
-    {
-        $storeMock = new class () implements StoreInterface {
-            /**
-             * Example of an empty store.
-             *
-             * @param string      $key     An example key.
-             * @param string|null $default An example default value.
-             *
-             * @return mixed
-             */
-            public function get(
-                string $key,
-                ?string $default = null
-            ) {
-                $response = '__test_custom_store__' . $key . '__';
-
-                if ($key === 'user' || $key === 'accessTokenScope') {
-                    return [ $response ];
-                }
-
-                return $response;
+use Auth0\SDK\Configuration\SdkConfiguration;
+
+uses()->group('auth0');
+
+beforeEach(function(): void {
+    $_GET = [];
+    $_COOKIE = [];
+
+    $this->configuration = [
+        'domain' => '__test_domain__',
+        'clientId' => '__test_client_id__',
+        'cookieSecret' => uniqid(),
+        'clientSecret' => '__test_client_secret__',
+        'redirectUri' => '__test_redirect_uri__',
+    ];
+});
+
+it('does not persist user data when configured so', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + ['persistUser' => false]);
+    $auth0->setUser(['sub' => '__test_user__']);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + ['persistUser' => false]);
+    $this->assertNull($auth0->getUser());
+});
+
+
+it('uses the configured session storage handler', function(): void {
+    $storeMock = new class () implements \Auth0\SDK\Contract\StoreInterface {
+        /**
+         * Example of an empty store.
+         *
+         * @param string      $key     An example key.
+         * @param string|null $default An example default value.
+         *
+         * @return mixed
+         */
+        public function get(
+            string $key,
+            ?string $default = null
+        ) {
+            $response = '__test_custom_store__' . $key . '__';
+
+            if ($key === 'user' || $key === 'accessTokenScope') {
+                return [ $response ];
             }
 
-            public function set(
-                string $key,
-                $value
-            ): void {
-            }
+            return $response;
+        }
 
-            public function delete(
-                string $key
-            ): void {
-            }
+        public function set(
+            string $key,
+            $value
+        ): void {
+        }
 
-            public function deleteAll(): void
-            {
-            }
-        };
+        public function delete(
+            string $key
+        ): void {
+        }
 
-        $auth0 = new Auth0(self::$baseConfig + ['sessionStorage' => $storeMock]);
-        $auth0->setUser(['sub' => '__test_user__']);
+        public function deleteAll(): void
+        {
+        }
+    };
 
-        $auth0 = new Auth0(self::$baseConfig + ['sessionStorage' => $storeMock]);
-        $this->assertEquals(['__test_custom_store__user__'], $auth0->getUser());
-    }
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + ['sessionStorage' => $storeMock]);
+    $auth0->setUser(['sub' => '__test_user__']);
 
-    /**
-     * Test that no user persistence uses empty store.
-     */
-    public function testThatNoUserPersistenceWorks(): void
-    {
-        $auth0 = new Auth0(self::$baseConfig + ['persistUser' => false]);
-        $auth0->setUser(['sub' => '__test_user__']);
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + ['sessionStorage' => $storeMock]);
+    $this->assertEquals(['__test_custom_store__user__'], $auth0->getUser());
+});
 
-        $auth0 = new Auth0(self::$baseConfig + ['persistUser' => false]);
-        $this->assertNull($auth0->getUser());
-    }
-}
+test('exchange() returns false if no code is present', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+    $this->assertFalse($auth0->exchange());
+});
+
+test('exchange() returns false if no nonce is stored', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponse(\Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","refresh_token":"4.5.6"}'));
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier', '__test_code_verifier__');
+
+    $this->expectException(\Auth0\SDK\Exception\StateException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_NONCE);
+
+    $auth0->exchange();
+});
+
+test('exchange() throws an exception if no code verified was found', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  null);
+
+    $this->expectException(\Auth0\SDK\Exception\StateException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_CODE_VERIFIER);
+
+    $auth0->exchange();
+});
+
+test('exchange() succeeds with a valid id token', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","refresh_token":"4.5.6"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+    $this->assertArrayHasKey('sub', $auth0->getUser());
+    $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
+    $this->assertEquals($token, $auth0->getIdToken());
+    $this->assertEquals('1.2.3', $auth0->getAccessToken());
+    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+});
+
+test('exchange() succeeds with no id token', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"sub":"123"}')
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+    $this->assertArrayHasKey('sub', $auth0->getUser());
+    $this->assertEquals('123', $auth0->getUser()['sub']);
+    $this->assertEquals('1.2.3', $auth0->getAccessToken());
+    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+});
+
+test('exchange() succeeds with pkce disabled', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'usePkce' => false,
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+
+    $this->assertTrue($auth0->exchange());
+    $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
+    $this->assertEquals('1.2.3', $auth0->getAccessToken());
+    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+});
+
+test('exchange() skips hitting userinfo endpoint', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+    $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
+    $this->assertEquals($token, $auth0->getIdToken());
+    $this->assertEquals('1.2.3', $auth0->getAccessToken());
+});
+
+test('renew() throws an exception if there is no refresh token available', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{}')
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+
+    $this->expectException(\Auth0\SDK\Exception\StateException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN);
+
+    $auth0->renew();
+});
+
+test('renew() throws an exception if no access token is returned', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+
+    $this->expectException(\Auth0\SDK\Exception\StateException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_ACCESS_TOKEN);
+
+    $auth0->renew();
+});
+
+test('renew() succeeds under expected and valid conditions', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4","id_token":"' . $token . '"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '"}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
+
+    $this->assertTrue($auth0->exchange());
+
+    $auth0->renew(['scope' => 'openid']);
+    $request = $httpClient->getLastRequest()->getLastRequest();
+    parse_str($request->getBody()->__toString(), $requestBody);
+
+    $this->assertEquals('__test_access_token__', $auth0->getAccessToken());
+    $this->assertEquals($token, $auth0->getIdToken());
+
+    $this->assertEquals('openid', $requestBody['scope']);
+    $this->assertEquals('__test_client_secret__', $requestBody['client_secret']);
+    $this->assertEquals('__test_client_id__', $requestBody['client_id']);
+    $this->assertEquals('2.3.4', $requestBody['refresh_token']);
+    $this->assertEquals('https://__test_domain__/oauth/token', $request->getUri()->__toString());
+});
+
+test('getLoginLink() returns expected default value', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $parsed_url = parse_url($auth0->authentication()->getLoginLink(uniqid()));
+
+    $this->assertEquals('https', $parsed_url['scheme']);
+    $this->assertEquals('__test_domain__', $parsed_url['host']);
+    $this->assertEquals('/authorize', $parsed_url['path']);
+
+    $url_query = explode('&', $parsed_url['query']);
+
+    $this->assertContains('scope=openid%20profile%20email', $url_query);
+    $this->assertContains('response_type=code', $url_query);
+    $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
+    $this->assertContains('client_id=__test_client_id__', $url_query);
+});
+
+test('getLoginLink() returns expected value when supplying parameters', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $custom_params = [
+        'connection' => '__test_connection__',
+        'prompt' => 'none',
+        'audience' => '__test_audience__',
+        'state' => '__test_state__',
+        'invitation' => '__test_invitation__',
+    ];
+
+    $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, $custom_params);
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+    $url_query = explode('&', $parsed_url_query);
+
+    $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
+    $this->assertContains('client_id=__test_client_id__', $url_query);
+    $this->assertContains('connection=__test_connection__', $url_query);
+    $this->assertContains('prompt=none', $url_query);
+    $this->assertContains('audience=__test_audience__', $url_query);
+    $this->assertContains('state=__test_state__', $url_query);
+    $this->assertContains('invitation=__test_invitation__', $url_query);
+});
+
+test('getLoginLink() returns expected value when overriding defaults', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $override_params = [
+        'scope' => 'openid profile email',
+        'response_type' => 'id_token',
+        'response_mode' => 'form_post',
+    ];
+
+    $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, $override_params);
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+    $url_query = explode('&', $parsed_url_query);
+
+    $this->assertContains('scope=openid%20profile%20email', $url_query);
+    $this->assertContains('response_type=id_token', $url_query);
+    $this->assertContains('response_mode=form_post', $url_query);
+    $this->assertContains('redirect_uri=__test_redirect_uri__', $url_query);
+    $this->assertContains('client_id=__test_client_id__', $url_query);
+});
+
+test('getLoginLink() assigns a nonce and state', function(): void {
+    $custom_config = $this->configuration;
+
+    $auth0 = new \Auth0\SDK\Auth0($custom_config);
+
+    $auth_url = $auth0->authentication()->getLoginLink(uniqid(), null, ['nonce' => uniqid()]);
+
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+
+    $this->assertStringContainsString('state=', $auth_url);
+    $this->assertStringContainsString('nonce=', $auth_url);
+});
+
+test('login() assigns a challenge and challenge method when PKCE is enabled', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $auth_url = $auth0->login(uniqid());
+
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+    $url_query = explode('&', $parsed_url_query);
+
+    $this->assertStringContainsString('code_challenge=', $parsed_url_query);
+    $this->assertContains('code_challenge_method=S256', $url_query);
+});
+
+test('login() assigns `max_age` from default values', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenMaxAge' => 1000,
+    ]);
+
+    $auth_url = $auth0->login(uniqid());
+
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+    $url_query = explode('&', $parsed_url_query);
+
+    $this->assertContains('max_age=1000', $url_query);
+});
+
+test('login() assigns `max_age` from overridden values', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenMaxAge' => 1000,
+    ]);
+
+    $auth_url = $auth0->login(uniqid(), [
+        'max_age' => 1001,
+    ]);
+
+    $parsed_url_query = parse_url($auth_url, PHP_URL_QUERY);
+    $url_query = explode('&', $parsed_url_query);
+
+    $this->assertContains('max_age=1001', $url_query);
+});
+
+test('getInvitationParameters() returns request parameters when valid', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $_GET['invitation'] = '__test_invitation__';
+    $_GET['organization'] = '__test_organization__';
+    $_GET['organization_name'] = '__test_organization_name__';
+
+    $extracted = $auth0->getInvitationParameters();
+
+    $this->assertIsObject($extracted, 'Invitation parameters were not extracted from the $_GET (environment variable seeded with query parameters during a GET request) successfully.');
+
+    $this->assertObjectHasAttribute('invitation', $extracted);
+    $this->assertObjectHasAttribute('organization', $extracted);
+    $this->assertObjectHasAttribute('organizationName', $extracted);
+
+    $this->assertEquals($extracted->invitation, '__test_invitation__');
+    $this->assertEquals($extracted->organization, '__test_organization__');
+    $this->assertEquals($extracted->organizationName, '__test_organization_name__');
+});
+
+test('getInvitationParameters() does not return invalid request parameters', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $_GET['invitation'] = '__test_invitation__';
+
+    $this->assertIsNotObject($auth0->getInvitationParameters());
+});
+
+test('setIdToken() properly stores data', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
+
+    $auth0->setIdToken($token);
+
+    $this->assertEquals($token, $auth0->getIdToken());
+    $this->assertEquals($token, $auth0->configuration()->getSessionStorage()->get('idToken'));
+});
+
+test('setIdToken() uses `tokenLeeway` configuration', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256([
+        'exp' => time() - 100,
+    ]);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'tokenLeeway' => 120,
+    ]);
+
+    $auth0->setIdToken($token);
+    $this->assertEquals($token, $auth0->getIdToken());
+});
+
+test('decode() uses the configured cache handler', function(): void {
+    $cacheKey = hash('sha256', 'https://test.auth0.com/.well-known/jwks.json');
+    $mockJwks = [
+        '__test_kid__' => [
+            'x5c' => ['123'],
+        ],
+    ];
+
+    $pool = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+    $item = $pool->getItem($cacheKey);
+    $item->set($mockJwks);
+    $pool->save($item);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenCache' => $pool,
+    ]);
+
+    $cachedJwks = $pool->getItem($cacheKey)->get();
+    $this->assertNotEmpty($cachedJwks);
+    $this->assertArrayHasKey('__test_kid__', $cachedJwks);
+    $this->assertEquals($mockJwks, $cachedJwks);
+
+    // Ignore that we can't verify using this mock cert, just that it was attempted.
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage('Cannot verify signature');
+
+    $auth0->decode((new \Auth0\Tests\Utilities\TokenGenerator())->withRs256([], null, ['kid' => '__test_kid__']));
+});
+
+test('decode() compares `auth_time` against `tokenMaxAge` configuration', function(): void {
+    $now = time();
+    $maxAge = 10;
+    $drift = 100;
+
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256([
+        'auth_time' => $now - $drift,
+    ]);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'tokenMaxAge' => $maxAge,
+        'tokenLeeway' => 0,
+    ]);
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUTH_TIME_CLAIM, time(), $now - $drift + $maxAge));
+
+    $auth0->decode($token, null, null, null, null, null, $now);
+});
+
+test('decode() compares `org_id` against `organization` configuration', function(): void {
+    $orgId = 'org8675309';
+
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256([
+        'org_id' => $orgId,
+    ]);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'organization' => [$orgId],
+    ]);
+
+    $decoded = $auth0->decode($token);
+
+    $this->assertEquals($orgId, $decoded->getOrganization());
+});
+
+test('decode() throws an exception when `org_id` claim does not exist, but an `organization` is configured', function(): void {
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'organization' => ['org8675309'],
+    ]);
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_ORG_ID_CLAIM);
+
+    $auth0->decode($token);
+});
+
+test('decode() throws an exception when `org_id` does not match `organization` configuration', function(): void {
+    $expectedOrgId = uniqid();
+    $tokenOrgId = uniqid();
+
+    $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256([
+        'org_id' => $tokenOrgId,
+    ]);
+
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'organization' => [$expectedOrgId],
+    ]);
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_ORG_ID_CLAIM, $expectedOrgId, $tokenOrgId));
+
+    $auth0->decode($token);
+});

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -305,7 +305,7 @@ test('decode() uses the configured cache handler', function(): void {
     $cachedJwks = $pool->getItem($cacheKey)->get();
     $this->assertNotEmpty($cachedJwks);
     $this->assertArrayHasKey('__test_kid__', $cachedJwks);
-    $this->assertEquals($mockJwks, $cachedJwks);
+    expect($cachedJwks)->toEqual($mockJwks);
 
     // Ignore that we can't verify using this mock cert, just that it was attempted.
     $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
@@ -372,7 +372,7 @@ test('decode() compares `org_id` against `organization` configuration', function
 
     $decoded = $auth0->decode($token);
 
-    $this->assertEquals($orgId, $decoded->getOrganization());
+    expect($decoded->getOrganization())->toEqual($orgId);
 });
 
 test('decode() throws an exception when `org_id` claim does not exist, but an `organization` is configured', function(): void {
@@ -410,7 +410,7 @@ test('decode() throws an exception when `org_id` does not match `organization` c
 
 test('exchange() returns false if no code is present', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-    $this->assertFalse($auth0->exchange());
+    expect($auth0->exchange())->toBeFalse();
 });
 
 test('exchange() returns false if no nonce is stored', function(): void {
@@ -484,14 +484,14 @@ test('exchange() succeeds with a valid id token', function(): void {
     $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
     $this->assertArrayHasKey('sub', $auth0->getUser());
-    $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
-    $this->assertEquals($token, $auth0->getIdToken());
-    $this->assertEquals('1.2.3', $auth0->getAccessToken());
-    $this->assertEquals(['test:part1','test:part2','test:part3'], $auth0->getAccessTokenScope());
-    $this->assertGreaterThan(time(), $auth0->getAccessTokenExpiration());
-    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+    expect($auth0->getUser()['sub'])->toEqual('__test_sub__');
+    expect($auth0->getIdToken())->toEqual($token);
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+    expect($auth0->getAccessTokenScope())->toEqual(['test:part1','test:part2','test:part3']);
+    expect($auth0->getAccessTokenExpiration())->toBeGreaterThan(time());
+    expect($auth0->getRefreshToken())->toEqual('4.5.6');
 });
 
 test('exchange() succeeds with no id token', function(): void {
@@ -510,11 +510,11 @@ test('exchange() succeeds with no id token', function(): void {
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
     $this->assertArrayHasKey('sub', $auth0->getUser());
-    $this->assertEquals('123', $auth0->getUser()['sub']);
-    $this->assertEquals('1.2.3', $auth0->getAccessToken());
-    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+    expect($auth0->getUser()['sub'])->toEqual('123');
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+    expect($auth0->getRefreshToken())->toEqual('4.5.6');
 });
 
 test('exchange() succeeds with PKCE disabled', function(): void {
@@ -535,10 +535,10 @@ test('exchange() succeeds with PKCE disabled', function(): void {
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
 
-    $this->assertTrue($auth0->exchange());
-    $this->assertEquals(['sub' => '__test_sub__'], $auth0->getUser());
-    $this->assertEquals('1.2.3', $auth0->getAccessToken());
-    $this->assertEquals('4.5.6', $auth0->getRefreshToken());
+    expect($auth0->exchange())->toBeTrue();
+    expect($auth0->getUser())->toEqual(['sub' => '__test_sub__']);
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+    expect($auth0->getRefreshToken())->toEqual('4.5.6');
 });
 
 test('exchange() skips hitting userinfo endpoint', function(): void {
@@ -562,10 +562,10 @@ test('exchange() skips hitting userinfo endpoint', function(): void {
     $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
-    $this->assertEquals('__test_sub__', $auth0->getUser()['sub']);
-    $this->assertEquals($token, $auth0->getIdToken());
-    $this->assertEquals('1.2.3', $auth0->getAccessToken());
+    expect($auth0->exchange())->toBeTrue();
+    expect($auth0->getUser()['sub'])->toEqual('__test_sub__');
+    expect($auth0->getIdToken())->toEqual($token);
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
 });
 
 test('exchange() throws an exception when code exchange fails', function(): void {
@@ -628,7 +628,7 @@ test('renew() throws an exception if there is no refresh token available', funct
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
 
     $this->expectException(\Auth0\SDK\Exception\StateException::class);
     $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN);
@@ -653,7 +653,7 @@ test('renew() throws an exception if no access token is returned', function(): v
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
 
     $this->expectException(\Auth0\SDK\Exception\StateException::class);
     $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_ACCESS_TOKEN);
@@ -682,25 +682,25 @@ test('renew() succeeds under expected and valid conditions', function(): void {
     $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
 
     $auth0->renew(['scope' => 'openid']);
     $request = $httpClient->getLastRequest()->getLastRequest();
     parse_str($request->getBody()->__toString(), $requestBody);
 
-    $this->assertEquals('__test_access_token__', $auth0->getAccessToken());
-    $this->assertEquals($token, $auth0->getIdToken());
+    expect($auth0->getAccessToken())->toEqual('__test_access_token__');
+    expect($auth0->getIdToken())->toEqual($token);
 
-    $this->assertEquals('openid', $requestBody['scope']);
-    $this->assertEquals('__test_client_secret__', $requestBody['client_secret']);
-    $this->assertEquals('__test_client_id__', $requestBody['client_id']);
-    $this->assertEquals('2.3.4', $requestBody['refresh_token']);
-    $this->assertEquals('https://__test_domain__/oauth/token', $request->getUri()->__toString());
+    expect($requestBody['scope'])->toEqual('openid');
+    expect($requestBody['client_secret'])->toEqual('__test_client_secret__');
+    expect($requestBody['client_id'])->toEqual('__test_client_id__');
+    expect($requestBody['refresh_token'])->toEqual('2.3.4');
+    expect($request->getUri()->__toString())->toEqual('https://__test_domain__/oauth/token');
 });
 
 test('getCredentials() returns null when a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-    $this->assertNull($auth0->getCredentials());
+    expect($auth0->getCredentials())->toBeNull();
 });
 
 test('getCredentials() returns the expected object structure when a session is available', function(): void {
@@ -724,11 +724,11 @@ test('getCredentials() returns the expected object structure when a session is a
     $auth0->configuration()->getTransientStorage()->set('nonce',  '__test_nonce__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  '__test_code_verifier__');
 
-    $this->assertTrue($auth0->exchange());
+    expect($auth0->exchange())->toBeTrue();
 
     $credentials = $auth0->getCredentials();
 
-    $this->assertIsObject($credentials);
+    expect($credentials)->toBeObject();
 
     $this->assertObjectHasAttribute('user', $credentials);
     $this->assertObjectHasAttribute('idToken', $credentials);
@@ -738,7 +738,7 @@ test('getCredentials() returns the expected object structure when a session is a
     $this->assertObjectHasAttribute('accessTokenExpired', $credentials);
     $this->assertObjectHasAttribute('refreshToken', $credentials);
 
-    $this->assertIsArray($credentials->user);
+    expect($credentials->user)->toBeArray();
 });
 
 test('getIdToken() performs an exchange if a session is not available', function(): void {
@@ -817,8 +817,8 @@ test('setIdToken() properly stores data', function(): void {
 
     $auth0->setIdToken($token);
 
-    $this->assertEquals($token, $auth0->getIdToken());
-    $this->assertEquals($token, $auth0->configuration()->getSessionStorage()->get('idToken'));
+    expect($auth0->getIdToken())->toEqual($token);
+    expect($auth0->configuration()->getSessionStorage()->get('idToken'))->toEqual($token);
 });
 
 test('setIdToken() uses `tokenLeeway` configuration', function(): void {
@@ -832,7 +832,7 @@ test('setIdToken() uses `tokenLeeway` configuration', function(): void {
     ]);
 
     $auth0->setIdToken($token);
-    $this->assertEquals($token, $auth0->getIdToken());
+    expect($auth0->getIdToken())->toEqual($token);
 });
 
 test('getRequestParameter() retrieves from $_POST when `responseMode` is configured to `form_post`', function(): void {
@@ -843,7 +843,7 @@ test('getRequestParameter() retrieves from $_POST when `responseMode` is configu
 
     $extracted = $auth0->getRequestParameter('test');
 
-    $this->assertEquals($_POST['test'], $extracted);
+    expect($extracted)->toEqual($_POST['test']);
     $this->assertNotEquals($_GET['test'], $extracted);
 });
 
@@ -862,9 +862,9 @@ test('getInvitationParameters() returns request parameters when valid', function
     $this->assertObjectHasAttribute('organization', $extracted);
     $this->assertObjectHasAttribute('organizationName', $extracted);
 
-    $this->assertEquals($extracted->invitation, '__test_invitation__');
-    $this->assertEquals($extracted->organization, '__test_organization__');
-    $this->assertEquals($extracted->organizationName, '__test_organization_name__');
+    expect('__test_invitation__')->toEqual($extracted->invitation);
+    expect('__test_organization__')->toEqual($extracted->organization);
+    expect('__test_organization_name__')->toEqual($extracted->organizationName);
 });
 
 test('getInvitationParameters() does not return invalid request parameters', function(): void {

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Store\InMemoryStorage;
+use Auth0\SDK\Store\MemoryStore;
 
 uses()->group('auth0');
 

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -306,12 +306,8 @@ test('decode() uses the configured cache handler', function(): void {
     $this->assertArrayHasKey('__test_kid__', $cachedJwks);
     expect($cachedJwks)->toEqual($mockJwks);
 
-    // Ignore that we can't verify using this mock cert, just that it was attempted.
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage('Cannot verify signature');
-
     $auth0->decode((new \Auth0\Tests\Utilities\TokenGenerator())->withRs256([], null, ['kid' => '__test_kid__']));
-});
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_BAD_SIGNATURE);
 
 test('decode() compares `auth_time` against `tokenMaxAge` configuration', function(): void {
     $now = time();
@@ -328,11 +324,8 @@ test('decode() compares `auth_time` against `tokenMaxAge` configuration', functi
         'tokenLeeway' => 0,
     ]);
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUTH_TIME_CLAIM, time(), $now - $drift + $maxAge));
-
     $auth0->decode($token, null, null, null, null, null, $now);
-});
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
 test('decode() converts a string `max_age` value from transient storage into an int', function(): void {
     $now = time();
@@ -351,11 +344,8 @@ test('decode() converts a string `max_age` value from transient storage into an 
     $storage = $auth0->configuration()->getTransientStorage();
     $storage->set('max_age', '10');
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUTH_TIME_CLAIM, time(), $now - $drift + $maxAge));
-
     $auth0->decode($token, null, null, null, null, null, $now);
-});
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
 test('decode() compares `org_id` against `organization` configuration', function(): void {
     $orgId = 'org8675309';
@@ -382,11 +372,8 @@ test('decode() throws an exception when `org_id` claim does not exist, but an `o
         'organization' => ['org8675309'],
     ]);
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_ORG_ID_CLAIM);
-
     $auth0->decode($token);
-});
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_ORG_ID_CLAIM);
 
 test('decode() throws an exception when `org_id` does not match `organization` configuration', function(): void {
     $expectedOrgId = uniqid();
@@ -401,11 +388,8 @@ test('decode() throws an exception when `org_id` does not match `organization` c
         'organization' => [$expectedOrgId],
     ]);
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_ORG_ID_CLAIM, $expectedOrgId, $tokenOrgId));
-
     $auth0->decode($token);
-});
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
 test('exchange() returns false if no code is present', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -428,11 +412,8 @@ test('exchange() returns false if no nonce is stored', function(): void {
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier', '__test_code_verifier__');
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_NONCE);
-
     $auth0->exchange();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_MISSING_NONCE);
 
 test('exchange() throws an exception if no code verified was found', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -443,11 +424,8 @@ test('exchange() throws an exception if no code verified was found', function():
     $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  null);
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_MISSING_CODE_VERIFIER);
-
     $auth0->exchange();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_MISSING_CODE_VERIFIER);
 
 test('exchange() throws an exception if no state was found', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -456,11 +434,8 @@ test('exchange() throws an exception if no state was found', function(): void {
 
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  null);
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->exchange();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('exchange() succeeds with a valid id token', function(): void {
     $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
@@ -583,11 +558,8 @@ test('exchange() throws an exception when code exchange fails', function(): void
     $auth0->configuration()->getTransientStorage()->set('nonce',  uniqid());
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  uniqid());
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_CODE_EXCHANGE);
-
     $auth0->exchange();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_FAILED_CODE_EXCHANGE);
 
 test('exchange() throws an exception when an access token is not returned from code exchange', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -605,11 +577,8 @@ test('exchange() throws an exception when an access token is not returned from c
     $auth0->configuration()->getTransientStorage()->set('nonce',  uniqid());
     $auth0->configuration()->getTransientStorage()->set('code_verifier',  uniqid());
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_BAD_ACCESS_TOKEN);
-
     $auth0->exchange();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_BAD_ACCESS_TOKEN);
 
 test('renew() throws an exception if there is no refresh token available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -629,11 +598,8 @@ test('renew() throws an exception if there is no refresh token available', funct
 
     expect($auth0->exchange())->toBeTrue();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN);
-
     $auth0->renew();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN);
 
 test('renew() throws an exception if no access token is returned', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
@@ -654,11 +620,8 @@ test('renew() throws an exception if no access token is returned', function(): v
 
     expect($auth0->exchange())->toBeTrue();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_ACCESS_TOKEN);
-
     $auth0->renew();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_FAILED_RENEW_TOKEN_MISSING_ACCESS_TOKEN);
 
 test('renew() succeeds under expected and valid conditions', function(): void {
     $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
@@ -745,66 +708,48 @@ test('getIdToken() performs an exchange if a session is not available', function
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getIdToken();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('getUser() performs an exchange if a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getUser();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('getRefreshToken() performs an exchange if a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getRefreshToken();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('getAccessToken() performs an exchange if a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getAccessToken();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('getAccessTokenScope() performs an exchange if a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getAccessTokenScope();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('getAccessTokenExpiration() performs an exchange if a session is not available', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
 
     $_GET['code'] = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\StateException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
     $auth0->getAccessTokenExpiration();
-});
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('setIdToken() properly stores data', function(): void {
     $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -34,14 +34,14 @@ it('uses the configured session storage handler', function(): void {
         /**
          * Example of an empty store.
          *
-         * @param string      $key     An example key.
-         * @param string|null $default An example default value.
+         * @param string $key     An example key.
+         * @param mixed  $default An example default value.
          *
          * @return mixed
          */
         public function get(
             string $key,
-            ?string $default = null
+            $default = null
         ) {
             $response = '__test_custom_store__' . $key . '__';
 
@@ -63,7 +63,13 @@ it('uses the configured session storage handler', function(): void {
         ): void {
         }
 
-        public function deleteAll(): void
+        public function purge(): void
+        {
+        }
+
+        public function defer(
+            bool $deferring = false
+        ): void
         {
         }
     };

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Store\MemoryStore;
 
 uses()->group('auth0');
 

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -46,13 +46,10 @@ test('__construct() does not accept invalid types from configuration array', fun
 {
     $randomNumber = mt_rand();
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE_NULLABLE, 'domain', 'string', 'int'));
-
     new SdkConfiguration([
         'domain' => $randomNumber,
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE_NULLABLE, 'domain', 'string', 'int'));
 
 test('__construct() successfully only stores the host when passed a full uri as `domain`', function(): void
 {
@@ -71,25 +68,19 @@ test('__construct() throws an exception if domain is an empty string', function(
     $clientId = uniqid();
     $redirectUri = uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'domain'));
-
     $sdk = new SdkConfiguration([
         'domain' => '',
         'cookieSecret' => $cookieSecret,
         'clientId' => $clientId,
         'redirectUri' => $redirectUri,
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'domain'));
 
 test('__construct() throws an exception if an invalid token algorithm is specified', function(): void {
     $domain = uniqid();
     $cookieSecret = uniqid();
     $clientId = uniqid();
     $redirectUri = uniqid();
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_INVALID_TOKEN_ALGORITHM);
 
     $sdk = new SdkConfiguration([
         'domain' => $domain,
@@ -98,16 +89,13 @@ test('__construct() throws an exception if an invalid token algorithm is specifi
         'redirectUri' => $redirectUri,
         'tokenAlgorithm' => 'X8675309'
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_INVALID_TOKEN_ALGORITHM);
 
 test('__construct() throws an exception if an invalid token leeway is specified', function(): void {
     $domain = uniqid();
     $cookieSecret = uniqid();
     $clientId = uniqid();
     $redirectUri = uniqid();
-
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE, 'tokenLeeway', 'int', 'string'));
 
     $sdk = new SdkConfiguration([
         'domain' => $domain,
@@ -116,7 +104,7 @@ test('__construct() throws an exception if an invalid token leeway is specified'
         'redirectUri' => $redirectUri,
         'tokenLeeway' => 'TEST'
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE, 'tokenLeeway', 'int', 'string'));
 
 test('successfully updates values', function(): void
 {
@@ -176,15 +164,12 @@ test('successfully resets values', function(): void
 
 test('an invalid strategy throws an exception', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'strategy'));
-
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
         'clientId' => uniqid(),
         'strategy' => uniqid(),
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'strategy'));
 
 test('a non-existent array value is ignored', function(): void
 {
@@ -209,79 +194,58 @@ test('a `webapp` strategy is used by default', function(): void
 
 test('a `webapp` strategy requires a domain', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'webapp',
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
 
 test('a `webapp` strategy requires a client id', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'webapp',
         'domain' => uniqid()
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
 
 test('a `webapp` strategy requires a client secret when HS256 is used', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'webapp',
         'domain' => uniqid(),
         'clientId' => uniqid(),
         'tokenAlgorithm' => 'HS256'
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
 
 test('a `api` strategy requires a domain', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'api',
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
 
 test('a `api` strategy requires an audience', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_AUDIENCE);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'api',
         'domain' => uniqid()
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_AUDIENCE);
 
 test('a `management` strategy requires a client id if a management token is not provided', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'management'
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
 
 test('a `management` strategy requires a client secret if a management token is not provided', function(): void
 {
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
-
     $sdk = new SdkConfiguration([
         'strategy' => 'management',
         'clientId' => uniqid()
     ]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
 
 test('a `management` strategy does not require a client id or secret if a management token is provided', function(): void
 {

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -47,7 +47,7 @@ test('__construct() does not accept invalid types from configuration array', fun
     $randomNumber = mt_rand();
 
     $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE_NULLABLE, 'domain', 'string', 'integer'));
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE_NULLABLE, 'domain', 'string', 'int'));
 
     new SdkConfiguration([
         'domain' => $randomNumber,
@@ -107,7 +107,7 @@ test('__construct() throws an exception if an invalid token leeway is specified'
     $redirectUri = uniqid();
 
     $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'tokenLeeway'));
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_INCOMPATIBLE, 'tokenLeeway', 'int', 'string'));
 
     $sdk = new SdkConfiguration([
         'domain' => $domain,
@@ -116,23 +116,6 @@ test('__construct() throws an exception if an invalid token leeway is specified'
         'redirectUri' => $redirectUri,
         'tokenLeeway' => 'TEST'
     ]);
-});
-
-test('__construct() converts token leeway passed as a string into an int silently', function(): void {
-    $domain = uniqid();
-    $cookieSecret = uniqid();
-    $clientId = uniqid();
-    $redirectUri = uniqid();
-
-    $sdk = new SdkConfiguration([
-        'domain' => $domain,
-        'cookieSecret' => $cookieSecret,
-        'clientId' => $clientId,
-        'redirectUri' => $redirectUri,
-        'tokenLeeway' => '300'
-    ]);
-
-    $this->assertEquals(300, $sdk->getTokenLeeway());
 });
 
 test('successfully updates values', function(): void
@@ -189,6 +172,29 @@ test('successfully resets values', function(): void
 
     $this->assertEquals(null, $sdk->getDomain());
     $this->assertTrue($sdk->getUsePkce());
+});
+
+test('an invalid strategy throws an exception', function(): void
+{
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'strategy'));
+
+    $sdk = new SdkConfiguration([
+        'domain' => uniqid(),
+        'clientId' => uniqid(),
+        'strategy' => uniqid(),
+    ]);
+});
+
+test('a non-existent array value is ignored', function(): void
+{
+    $sdk = new SdkConfiguration([
+        'domain' => uniqid(),
+        'clientId' => uniqid(),
+        'organization' => [],
+    ]);
+
+    $this->assertNull($sdk->getOrganization());
 });
 
 test('a `webapp` strategy is used by default', function(): void

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -19,9 +19,9 @@ test('__construct() accepts a configuration array', function(): void {
         'redirectUri' => $redirectUri,
     ]);
 
-    $this->assertEquals($domain, $sdk->getDomain());
-    $this->assertEquals($clientId, $sdk->getClientId());
-    $this->assertEquals($redirectUri, $sdk->getRedirectUri());
+    expect($sdk->getDomain())->toEqual($domain);
+    expect($sdk->getClientId())->toEqual($clientId);
+    expect($sdk->getRedirectUri())->toEqual($redirectUri);
 });
 
 test('__construct() overrides arguments with configuration array', function(): void
@@ -39,7 +39,7 @@ test('__construct() overrides arguments with configuration array', function(): v
         'redirectUri' => $redirectUri,
     ], $domain2);
 
-    $this->assertEquals($domain, $sdk->getDomain());
+    expect($sdk->getDomain())->toEqual($domain);
 });
 
 test('__construct() does not accept invalid types from configuration array', function(): void
@@ -63,7 +63,7 @@ test('__construct() successfully only stores the host when passed a full uri as 
         'redirectUri' => uniqid(),
     ]);
 
-    $this->assertEquals('test.auth0.com', $sdk->getDomain());
+    expect($sdk->getDomain())->toEqual('test.auth0.com');
 });
 
 test('__construct() throws an exception if domain is an empty string', function(): void {
@@ -137,20 +137,20 @@ test('successfully updates values', function(): void
         'redirectUri' => $redirectUri1,
     ]);
 
-    $this->assertEquals($domain1, $sdk->getDomain());
-    $this->assertEquals($cookieSecret1, $sdk->getCookieSecret());
-    $this->assertEquals($clientId1, $sdk->getClientId());
-    $this->assertEquals($redirectUri1, $sdk->getRedirectUri());
+    expect($sdk->getDomain())->toEqual($domain1);
+    expect($sdk->getCookieSecret())->toEqual($cookieSecret1);
+    expect($sdk->getClientId())->toEqual($clientId1);
+    expect($sdk->getRedirectUri())->toEqual($redirectUri1);
 
     $sdk->setDomain($domain2);
     $sdk->setCookieSecret($cookieSecret2);
     $sdk->setClientId($clientId2);
     $sdk->setRedirectUri($redirectUri2);
 
-    $this->assertEquals($domain2, $sdk->getDomain());
-    $this->assertEquals($cookieSecret2, $sdk->getCookieSecret());
-    $this->assertEquals($clientId2, $sdk->getClientId());
-    $this->assertEquals($redirectUri2, $sdk->getRedirectUri());
+    expect($sdk->getDomain())->toEqual($domain2);
+    expect($sdk->getCookieSecret())->toEqual($cookieSecret2);
+    expect($sdk->getClientId())->toEqual($clientId2);
+    expect($sdk->getRedirectUri())->toEqual($redirectUri2);
 });
 
 test('successfully resets values', function(): void
@@ -165,13 +165,13 @@ test('successfully resets values', function(): void
         'usePkce' => false,
     ]);
 
-    $this->assertEquals($domain, $sdk->getDomain());
-    $this->assertFalse($sdk->getUsePkce());
+    expect($sdk->getDomain())->toEqual($domain);
+    expect($sdk->getUsePkce())->toBeFalse();
 
     $sdk->reset();
 
-    $this->assertEquals(null, $sdk->getDomain());
-    $this->assertTrue($sdk->getUsePkce());
+    expect($sdk->getDomain())->toEqual(null);
+    expect($sdk->getUsePkce())->toBeTrue();
 });
 
 test('an invalid strategy throws an exception', function(): void
@@ -194,7 +194,7 @@ test('a non-existent array value is ignored', function(): void
         'organization' => [],
     ]);
 
-    $this->assertNull($sdk->getOrganization());
+    expect($sdk->getOrganization())->toBeNull();
 });
 
 test('a `webapp` strategy is used by default', function(): void
@@ -204,7 +204,7 @@ test('a `webapp` strategy is used by default', function(): void
         'clientId' => uniqid(),
     ]);
 
-    $this->assertEquals('webapp', $sdk->getStrategy());
+    expect($sdk->getStrategy())->toEqual('webapp');
 });
 
 test('a `webapp` strategy requires a domain', function(): void
@@ -290,7 +290,7 @@ test('a `management` strategy does not require a client id or secret if a manage
         'managementToken' => uniqid()
     ]);
 
-    $this->assertInstanceOf(SdkConfiguration::class, $sdk);
+    expect($sdk)->toBeInstanceOf(SdkConfiguration::class);
 });
 
 test('formatDomain() returns a properly formatted uri', function(): void
@@ -304,7 +304,7 @@ test('formatDomain() returns a properly formatted uri', function(): void
         'redirectUri' => uniqid(),
     ]);
 
-    $this->assertEquals('https://' . $domain, $sdk->formatDomain());
+    expect($sdk->formatDomain())->toEqual('https://' . $domain);
 });
 
 test('formatScope() returns an empty string when there are no scopes defined', function(): void
@@ -317,7 +317,7 @@ test('formatScope() returns an empty string when there are no scopes defined', f
         'scope' => [],
     ]);
 
-    $this->assertEquals('', $sdk->formatScope());
+    expect($sdk->formatScope())->toEqual('');
 });
 
 test('scope() successfully converts the array to a string', function(): void
@@ -330,7 +330,7 @@ test('scope() successfully converts the array to a string', function(): void
         'scope' => ['one', 'two', 'three'],
     ]);
 
-    $this->assertEquals('one two three', $sdk->formatScope());
+    expect($sdk->formatScope())->toEqual('one two three');
 });
 
 test('defaultOrganization() successfully returns the first organization', function(): void
@@ -343,7 +343,7 @@ test('defaultOrganization() successfully returns the first organization', functi
         'organization' => ['org1', 'org2', 'org3'],
     ]);
 
-    $this->assertEquals('org1', $sdk->defaultOrganization());
+    expect($sdk->defaultOrganization())->toEqual('org1');
 });
 
 test('defaultAudience() successfully returns the first audience', function(): void
@@ -356,5 +356,5 @@ test('defaultAudience() successfully returns the first audience', function(): vo
         'audience' => ['aud1', 'aud2', 'aud3'],
     ]);
 
-    $this->assertEquals('aud1', $sdk->defaultAudience());
+    expect($sdk->defaultAudience())->toEqual('aud1');
 });

--- a/tests/Unit/Event/HttpRequestBuiltTest.php
+++ b/tests/Unit/Event/HttpRequestBuiltTest.php
@@ -35,8 +35,8 @@ it('handles RequestInterface properly', function(): void {
     $request2->test = true;
 
     $event = new HttpRequestBuilt($request1);
-    $this->assertEquals($request1, $event->get());
+    expect($event->get())->toEqual($request1);
 
     $event->set($request2);
-    $this->assertEquals($request2, $event->get());
+    expect($event->get())->toEqual($request2);
 });

--- a/tests/Unit/Event/HttpRequestBuiltTest.php
+++ b/tests/Unit/Event/HttpRequestBuiltTest.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-uses()->group('utility', 'psr14', 'events');
+uses()->group('event', 'event.http_request_built');
 
 it('handles RequestInterface properly', function(): void {
     $request1 = new class() implements RequestInterface {

--- a/tests/Unit/Event/HttpRequestBuiltTest.php
+++ b/tests/Unit/Event/HttpRequestBuiltTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Event\HttpRequestBuilt;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+uses()->group('utility', 'psr14', 'events');
+
+it('handles RequestInterface properly', function(): void {
+    $request1 = new class() implements RequestInterface {
+        public bool $test = false;
+        public function getProtocolVersion() {}
+        public function withProtocolVersion($version) {}
+        public function getHeaders() {}
+        public function hasHeader($name) {}
+        public function getHeader($name) {}
+        public function getHeaderLine($name) {}
+        public function withHeader($name, $value) {}
+        public function withAddedHeader($name, $value) {}
+        public function withoutHeader($name) {}
+        public function getBody() {}
+        public function withBody(StreamInterface $body) {}
+        public function getRequestTarget() {}
+        public function withRequestTarget($requestTarget) {}
+        public function getMethod() {}
+        public function withMethod($method) {}
+        public function getUri() {}
+        public function withUri(UriInterface $uri, $preserveHost = false) {}
+    };
+
+    $request2 = clone $request1;
+    $request2->test = true;
+
+    $event = new HttpRequestBuilt($request1);
+    $this->assertEquals($request1, $event->get());
+
+    $event->set($request2);
+    $this->assertEquals($request2, $event->get());
+});

--- a/tests/Unit/Event/HttpResponseReceivedTest.php
+++ b/tests/Unit/Event/HttpResponseReceivedTest.php
@@ -57,12 +57,12 @@ it('handles RequestInterface properly', function(): void {
     $response2->test = true;
 
     $event = new HttpResponseReceived($response1, $request1);
-    $this->assertEquals($response1, $event->get());
+    expect($event->get())->toEqual($response1);
 
-    $this->assertEquals($request1, $event->getRequest());
+    expect($event->getRequest())->toEqual($request1);
     $this->assertNotEquals($request2, $event->getRequest());
 
     $event->set($response2);
-    $this->assertEquals($response2, $event->get());
+    expect($event->get())->toEqual($response2);
     $this->assertNotEquals($response1, $event->get());
 });

--- a/tests/Unit/Event/HttpResponseReceivedTest.php
+++ b/tests/Unit/Event/HttpResponseReceivedTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Event\HttpResponseReceived;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+uses()->group('utility', 'psr14', 'events');
+
+it('handles RequestInterface properly', function(): void {
+    $request1 = new class() implements RequestInterface {
+        public bool $test = false;
+        public function getProtocolVersion() {}
+        public function withProtocolVersion($version) {}
+        public function getHeaders() {}
+        public function hasHeader($name) {}
+        public function getHeader($name) {}
+        public function getHeaderLine($name) {}
+        public function withHeader($name, $value) {}
+        public function withAddedHeader($name, $value) {}
+        public function withoutHeader($name) {}
+        public function getBody() {}
+        public function withBody(StreamInterface $body) {}
+        public function getRequestTarget() {}
+        public function withRequestTarget($requestTarget) {}
+        public function getMethod() {}
+        public function withMethod($method) {}
+        public function getUri() {}
+        public function withUri(UriInterface $uri, $preserveHost = false) {}
+    };
+
+    $request2 = clone $request1;
+    $request2->test = true;
+
+    $response1 = new class() implements ResponseInterface {
+        public bool $test = false;
+        public function getProtocolVersion() {}
+        public function withProtocolVersion($version) {}
+        public function getHeaders() {}
+        public function hasHeader($name) {}
+        public function getHeader($name) {}
+        public function getHeaderLine($name) {}
+        public function withHeader($name, $value) {}
+        public function withAddedHeader($name, $value) {}
+        public function withoutHeader($name) {}
+        public function getBody() {}
+        public function withBody(StreamInterface $body) {}
+        public function getStatusCode() {}
+        public function withStatus($code, $reasonPhrase = '') {}
+        public function getReasonPhrase() {}
+    };
+
+    $response2 = clone($response1);
+    $response2->test = true;
+
+    $event = new HttpResponseReceived($response1, $request1);
+    $this->assertEquals($response1, $event->get());
+
+    $this->assertEquals($request1, $event->getRequest());
+    $this->assertNotEquals($request2, $event->getRequest());
+
+    $event->set($response2);
+    $this->assertEquals($response2, $event->get());
+    $this->assertNotEquals($response1, $event->get());
+});

--- a/tests/Unit/Event/HttpResponseReceivedTest.php
+++ b/tests/Unit/Event/HttpResponseReceivedTest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-uses()->group('utility', 'psr14', 'events');
+uses()->group('event', 'event.http_response_received');
 
 it('handles RequestInterface properly', function(): void {
     $request1 = new class() implements RequestInterface {

--- a/tests/Unit/Mixin/ConfigurableMixinTest.php
+++ b/tests/Unit/Mixin/ConfigurableMixinTest.php
@@ -36,7 +36,7 @@ test('get() throws an exception when a value is missing', function(): void {
 
     $exception = new class() extends \Exception implements \Throwable {};
 
-    $this->expectException($exception::class);
+    $this->expectException(get_class($exception));
 
     $configurable->getExample($exception);
 });

--- a/tests/Unit/Mixin/ConfigurableMixinTest.php
+++ b/tests/Unit/Mixin/ConfigurableMixinTest.php
@@ -72,7 +72,7 @@ test('get() returns a default value', function(): void {
         }
     };
 
-    $this->assertEquals(123, $configurable->getExample());
+    expect($configurable->getExample())->toEqual(123);
 });
 
 test('set() assigns a value', function(): void {
@@ -88,7 +88,7 @@ test('set() assigns a value', function(): void {
     };
 
     $configurable->setExample(456);
-    $this->assertEquals(456, $configurable->getExample());
+    expect($configurable->getExample())->toEqual(456);
 });
 
 test('set() throws an exception when a property does not exist', function(): void {
@@ -183,7 +183,7 @@ test('set() calls an onStateChange callback method on the parent class', functio
 
     $configurable->setExample(123);
 
-    $this->assertEquals('success', $this->getExample());
+    expect($this->getExample())->toEqual('success');
 });
 
 test('push() adds to an array property value that has a nullable default value', function(): void {
@@ -198,10 +198,10 @@ test('push() adds to an array property value that has a nullable default value',
         }
     };
 
-    $this->assertNull($configurable->getExample());
+    expect($configurable->getExample())->toBeNull();
 
     $configurable->pushExample('c');
-    $this->assertEquals(['c'], $configurable->getExample());
+    expect($configurable->getExample())->toEqual(['c']);
 });
 
 test('push() adds to an array property value that has a default array value', function(): void {
@@ -217,7 +217,7 @@ test('push() adds to an array property value that has a default array value', fu
     };
 
     $configurable->pushExample('c');
-    $this->assertEquals(['a','b','c'], $configurable->getExample());
+    expect($configurable->getExample())->toEqual(['a','b','c']);
 });
 
 test('push() without a value does not change the target property', function(): void {
@@ -232,8 +232,8 @@ test('push() without a value does not change the target property', function(): v
         }
     };
 
-    $this->assertEquals($configurable, $configurable->pushExample([null]));
-    $this->assertEquals(['a','b'], $configurable->getExample());
+    expect($configurable->pushExample([null]))->toEqual($configurable);
+    expect($configurable->getExample())->toEqual(['a','b']);
 });
 
 test('push() throws a ConfigurationException exception when a property is not defined', function(): void {
@@ -266,7 +266,7 @@ test('has() returns false if a value was not defined', function(): void {
         }
     };
 
-    $this->assertFalse($configurable->hasExample());
+    expect($configurable->hasExample())->toBeFalse();
 });
 
 test('has() throws a ConfigurationException exception when a property is not defined', function(): void {
@@ -338,9 +338,9 @@ test('reset() resets property values as expected', function(): void {
     };
 
     $configurable->setExample(123);
-    $this->assertEquals(123, $configurable->getExample());
+    expect($configurable->getExample())->toEqual(123);
     $configurable->reset();
-    $this->assertNull($configurable->getExample());
+    expect($configurable->getExample())->toBeNull();
 });
 
 test('reset() is not possible once lock() is used', function(): void {
@@ -382,9 +382,9 @@ test('setState() will use a supplied configuration array, and values supplied th
         'example2' => 'test2'
     ], 456, 'xyz', true);
 
-    $this->assertEquals(123, $configurable->getExample());
-    $this->assertEquals('test2', $configurable->getExample2());
-    $this->assertNull($configurable->getExample3());
+    expect($configurable->getExample())->toEqual(123);
+    expect($configurable->getExample2())->toEqual('test2');
+    expect($configurable->getExample3())->toBeNull();
 });
 
 test('setState() applies constructor values correctly', function(): void {
@@ -403,7 +403,7 @@ test('setState() applies constructor values correctly', function(): void {
 
     $configurable = new $class(null, 456, 'xyz', true);
 
-    $this->assertEquals(456, $configurable->getExample());
-    $this->assertEquals('xyz', $configurable->getExample2());
-    $this->assertTrue($configurable->getExample3());
+    expect($configurable->getExample())->toEqual(456);
+    expect($configurable->getExample2())->toEqual('xyz');
+    expect($configurable->getExample3())->toBeTrue();
 });

--- a/tests/Unit/Mixin/ConfigurableMixinTest.php
+++ b/tests/Unit/Mixin/ConfigurableMixinTest.php
@@ -16,11 +16,8 @@ test('get() throws a ConfigurationException exception when a value is missing', 
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALUE_REQUIRED, 'example'));
-
     $configurable->getExample('123');
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALUE_REQUIRED, 'example'));
 
 test('get() throws an exception when a value is missing', function(): void {
     $configurable = new class() {
@@ -54,11 +51,8 @@ test('get() throws a ConfigurationException exception when a property is not def
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
-
     $configurable->getMissing();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
 
 test('get() returns a default value', function(): void {
     $configurable = new class() {
@@ -103,11 +97,8 @@ test('set() throws an exception when a property does not exist', function(): voi
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_MISSING, 'missing'));
-
     $configurable->setMissing(456);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_MISSING, 'missing'));
 
 test('set() throws an exception when a non-nullable property is assigned a null value', function(): void {
     $configurable = new class() {
@@ -121,10 +112,8 @@ test('set() throws an exception when a non-nullable property is assigned a null 
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-
     $configurable->setExample(null);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class);
 
 test('set() throws an exception when a property is assigned an invalid value type', function(): void {
     $configurable = new class() {
@@ -138,10 +127,8 @@ test('set() throws an exception when a property is assigned an invalid value typ
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-
     $configurable->setExample(123);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class);
 
 test('set() throws an exception when a nullable property is assigned an invalid value type', function(): void {
     $configurable = new class() {
@@ -155,10 +142,8 @@ test('set() throws an exception when a nullable property is assigned an invalid 
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-
     $configurable->setExample(123);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class);
 
 test('set() calls an onStateChange callback method on the parent class', function(): void {
     $configurable = new class() {
@@ -179,12 +164,10 @@ test('set() calls an onStateChange callback method on the parent class', functio
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-
     $configurable->setExample(123);
 
     expect($this->getExample())->toEqual('success');
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class);
 
 test('push() adds to an array property value that has a nullable default value', function(): void {
     $configurable = new class() {
@@ -248,11 +231,8 @@ test('push() throws a ConfigurationException exception when a property is not de
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
-
     $configurable->pushMissing([123]);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
 
 test('has() returns false if a value was not defined', function(): void {
     $configurable = new class() {
@@ -281,11 +261,8 @@ test('has() throws a ConfigurationException exception when a property is not def
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
-
     $configurable->hasMissing();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
 
 test('calling a non-existent method throws an ArgumentException', function(): void {
     $configurable = new class() {
@@ -299,11 +276,8 @@ test('calling a non-existent method throws an ArgumentException', function(): vo
         }
     };
 
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_UNKNOWN_METHOD, 'somethingSomething'));
-
     $configurable->somethingSomething();
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_UNKNOWN_METHOD, 'somethingSomething'));
 
 test('lock() causes a configuration to become immutable', function(): void {
     $configurable = new class() {
@@ -319,11 +293,8 @@ test('lock() causes a configuration to become immutable', function(): void {
 
     $configurable->lock();
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
-
     $configurable->setExample(true);
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
 
 test('reset() resets property values as expected', function(): void {
     $configurable = new class() {
@@ -357,11 +328,8 @@ test('reset() is not possible once lock() is used', function(): void {
 
     $configurable->lock();
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
-
     $configurable->reset();
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
 
 test('setState() will use a supplied configuration array, and values supplied this way overwrite passed arguments', function(): void {
     $class = new class() {

--- a/tests/Unit/Mixin/ConfigurableMixinTest.php
+++ b/tests/Unit/Mixin/ConfigurableMixinTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses()->group('configuration', 'traits', 'mixins');
+uses()->group('mixin', 'mixin.configurable');
 
 test('get() throws a ConfigurationException exception when a value is missing', function(): void {
     $configurable = new class() {

--- a/tests/Unit/Mixin/ConfigurableMixinTest.php
+++ b/tests/Unit/Mixin/ConfigurableMixinTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('configuration', 'traits', 'mixins');
+
+test('get() throws a ConfigurationException exception when a value is missing', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALUE_REQUIRED, 'example'));
+
+    $configurable->getExample('123');
+});
+
+test('get() throws an exception when a value is missing', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $exception = new class() extends \Exception implements \Throwable {};
+
+    $this->expectException($exception::class);
+
+    $configurable->getExample($exception);
+});
+
+
+test('get() throws a ConfigurationException exception when a property is not defined', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
+
+    $configurable->getMissing();
+});
+
+test('get() returns a default value', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = 123
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->assertEquals(123, $configurable->getExample());
+});
+
+test('set() assigns a value', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = 123
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable->setExample(456);
+    $this->assertEquals(456, $configurable->getExample());
+});
+
+test('set() throws an exception when a property does not exist', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = 123
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_MISSING, 'missing'));
+
+    $configurable->setMissing(456);
+});
+
+test('set() throws an exception when a non-nullable property is assigned a null value', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            int $example = 123
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+
+    $configurable->setExample(null);
+});
+
+test('set() throws an exception when a property is assigned an invalid value type', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            string $example = 'hello world'
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+
+    $configurable->setExample(123);
+});
+
+test('set() throws an exception when a nullable property is assigned an invalid value type', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?string $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+
+    $configurable->setExample(123);
+});
+
+test('set() calls an onStateChange callback method on the parent class', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?string $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+
+        public function onStateChange(
+            $propertyName,
+            $propertyValue
+        ) {
+            return 'success';
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+
+    $configurable->setExample(123);
+
+    $this->assertEquals('success', $this->getExample());
+});
+
+test('push() adds to an array property value that has a nullable default value', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?array $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->assertNull($configurable->getExample());
+
+    $configurable->pushExample('c');
+    $this->assertEquals(['c'], $configurable->getExample());
+});
+
+test('push() adds to an array property value that has a default array value', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?array $example = ['a','b']
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable->pushExample('c');
+    $this->assertEquals(['a','b','c'], $configurable->getExample());
+});
+
+test('push() without a value does not change the target property', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?array $example = ['a','b']
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->assertEquals($configurable, $configurable->pushExample([null]));
+    $this->assertEquals(['a','b'], $configurable->getExample());
+});
+
+test('push() throws a ConfigurationException exception when a property is not defined', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
+
+    $configurable->pushMissing([123]);
+});
+
+test('has() returns false if a value was not defined', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->assertFalse($configurable->hasExample());
+});
+
+test('has() throws a ConfigurationException exception when a property is not defined', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_GET_MISSING, 'missing'));
+
+    $configurable->hasMissing();
+});
+
+test('calling a non-existent method throws an ArgumentException', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_UNKNOWN_METHOD, 'somethingSomething'));
+
+    $configurable->somethingSomething();
+});
+
+test('lock() causes a configuration to become immutable', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable->lock();
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
+
+    $configurable->setExample(true);
+});
+
+test('reset() resets property values as expected', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable->setExample(123);
+    $this->assertEquals(123, $configurable->getExample());
+    $configurable->reset();
+    $this->assertNull($configurable->getExample());
+});
+
+test('reset() is not possible once lock() is used', function(): void {
+    $configurable = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable->lock();
+
+    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_SET_IMMUTABLE);
+
+    $configurable->reset();
+});
+
+test('setState() will use a supplied configuration array, and values supplied this way overwrite passed arguments', function(): void {
+    $class = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null,
+            ?string $example2 = 'test',
+            ?bool $example3 = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable = new $class([
+        'example' => 123,
+        'example2' => 'test2'
+    ], 456, 'xyz', true);
+
+    $this->assertEquals(123, $configurable->getExample());
+    $this->assertEquals('test2', $configurable->getExample2());
+    $this->assertNull($configurable->getExample3());
+});
+
+test('setState() applies constructor values correctly', function(): void {
+    $class = new class() {
+        use \Auth0\SDK\Mixins\ConfigurableMixin;
+
+        public function __construct(
+            ?array $configuration = null,
+            ?int $example = null,
+            ?string $example2 = 'test',
+            ?bool $example3 = null
+        ) {
+            $this->setState(func_get_args());
+        }
+    };
+
+    $configurable = new $class(null, 456, 'xyz', true);
+
+    $this->assertEquals(456, $configurable->getExample());
+    $this->assertEquals('xyz', $configurable->getExample2());
+    $this->assertTrue($configurable->getExample3());
+});

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -7,7 +7,7 @@ use Auth0\SDK\Store\CookieStore;
 use Auth0\Tests\Utilities\MockCrypto;
 use Auth0\Tests\Utilities\MockDataset;
 
-uses()->group('session', 'cookies');
+uses()->group('storage', 'storage.cookies');
 
 beforeEach(function(): void {
     $this->namespace = uniqid();

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -165,11 +165,8 @@ test('encrypt() throws an exception if a cookie secret is not configured', funct
 
     $this->store = new CookieStore($this->configuration, $this->namespace);
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
-
     $this->store->set('testing', 'this should throw an error');
-});
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
 
 test('decrypt() throws an exception if a cookie secret is not configured', function(array $state): void {
     $this->configuration = new SdkConfiguration([
@@ -182,13 +179,10 @@ test('decrypt() throws an exception if a cookie secret is not configured', funct
     $encrypted = MockCrypto::cookieCompatibleEncrypt($this->cookieSecret, serialize([$this->exampleKey => $state]));
     $_COOKIE[$cookieNamespace] = $encrypted;
 
-    $this->expectException(\Auth0\SDK\Exception\ConfigurationException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
-
     $this->store->getState();
 })->with(['mocked state' => [
     fn() => MockDataset::state()
-]]);
+]])->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
 
 test('decrypt() returns null if malformed JSON is encoded', function(): void {
     $cookieNamespace = $this->store->getNamespace() . '_0';

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -32,13 +32,13 @@ it('hashes the namespace', function(): void {
 });
 
 it('calculates a chunking threshold', function(): void {
-    $this->assertGreaterThan(0, $this->store->getThreshold());
+    expect($this->store->getThreshold())->toBeGreaterThan(0);
 });
 
 it('populates state from getState() override', function(array $state): void {
     $this->store->getState([$this->exampleKey => $state]);
 
-    $this->assertEquals($state, $this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toEqual($state);
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -51,7 +51,7 @@ it('populates state from $_COOKIE correctly', function(array $state): void {
 
     $this->store->getState();
 
-    $this->assertEquals($state, $this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toEqual($state);
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -66,7 +66,7 @@ it('populates state from a chunked $_COOKIE correctly', function(array $state): 
 
     $this->store->getState();
 
-    $this->assertEquals($state, $this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toEqual($state);
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -78,7 +78,7 @@ it('does not populate state from a malformed $_COOKIE', function(array $state): 
 
     $this->store->getState();
 
-    $this->assertNull($this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toBeNull();
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -90,7 +90,7 @@ it('does not populate state from an unencrypted $_COOKIE', function(array $state
 
     $this->store->getState();
 
-    $this->assertNull($this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toBeNull();
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -109,7 +109,7 @@ test('set() updates state and $_COOKIE', function(array $states): void {
 
     $this->store->set($this->exampleKey, $states[1]);
 
-    $this->assertEquals($states[1], $this->store->get($this->exampleKey));
+    expect($this->store->get($this->exampleKey))->toEqual($states[1]);
     $this->assertNotEquals($_COOKIE[$cookieNamespace], $previousCookieState);
 })->with(['mocked states' => [
     fn() => [ MockDataset::state(), MockDataset::state() ]
@@ -131,8 +131,8 @@ test('delete() updates state and $_COOKIE', function(array $state): void {
 
     $this->store->delete($this->exampleKey);
 
-    $this->assertNull($_COOKIE[$cookieNamespace] ?? null);
-    $this->assertNull($this->store->get($this->exampleKey));
+    expect($_COOKIE[$cookieNamespace] ?? null)->toBeNull();
+    expect($this->store->get($this->exampleKey))->toBeNull();
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -151,9 +151,9 @@ test('purge() clears state and $_COOKIE', function(array $state): void {
 
     $this->store->purge();
 
-    $this->assertNull($_COOKIE[$cookieNamespace] ?? null);
-    $this->assertEmpty($_COOKIE);
-    $this->assertEmpty($this->store->getState());
+    expect($_COOKIE[$cookieNamespace] ?? null)->toBeNull();
+    expect($_COOKIE)->toBeEmpty();
+    expect($this->store->getState())->toBeEmpty();
 })->with(['mocked state' => [
     fn() => MockDataset::state()
 ]]);
@@ -194,7 +194,7 @@ test('decrypt() returns null if malformed JSON is encoded', function(): void {
     $cookieNamespace = $this->store->getNamespace() . '_0';
     $_COOKIE[$cookieNamespace] = 'nonsense';
 
-    $this->assertEmpty($this->store->getState());
+    expect($this->store->getState())->toBeEmpty();
 });
 
 test('decrypt() returns null if a malformed cryptographic manifest is encoded', function(): void {
@@ -203,14 +203,14 @@ test('decrypt() returns null if a malformed cryptographic manifest is encoded', 
         'tag' => uniqid()
     ]));
 
-    $this->assertEmpty($this->store->getState());
+    expect($this->store->getState())->toBeEmpty();
 
     $_COOKIE[$cookieNamespace] = json_encode(serialize([
         'iv' => 'hi 👋 malformed cryptographic manifest here',
         'tag' => (string) uniqid()
     ]));
 
-    $this->assertEmpty($this->store->getState());
+    expect($this->store->getState())->toBeEmpty();
 });
 
 test('decrypt() returns null if a malformed data payload is encoded', function(): void {
@@ -226,5 +226,5 @@ test('decrypt() returns null if a malformed data payload is encoded', function()
 
     $_COOKIE[$cookieNamespace] = $payload;
 
-    $this->assertEmpty($this->store->getState());
+    expect($this->store->getState())->toBeEmpty();
 });

--- a/tests/Unit/Store/InMemoryTest.php
+++ b/tests/Unit/Store/InMemoryTest.php
@@ -42,10 +42,10 @@ test('delete() clears values as expected', function(string $key, string $value):
     fn() => uniqid(),
 ]]);
 
-test('deleteAll() clears values as expected', function(string $key, string $value): void {
+test('purge() clears values as expected', function(string $key, string $value): void {
     $this->store->set($key, $value);
 
-    $this->store->deleteAll();
+    $this->store->purge();
     $this->assertNull($this->store->get($key));
 })->with(['mocked data' => [
     fn() => uniqid(),

--- a/tests/Unit/Store/InMemoryTest.php
+++ b/tests/Unit/Store/InMemoryTest.php
@@ -2,48 +2,52 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\Store;
-
 use Auth0\SDK\Store\InMemoryStorage;
-use PHPUnit\Framework\TestCase;
 
-/**
- * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- */
-class InMemoryTest extends TestCase
-{
-    public function testSetGet(): void
-    {
-        $store = new InMemoryStorage();
-        $store->set('test_set_key', '__test_set_value__');
-        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
-        $this->assertSame(null, $store->get('missing_key'));
-    }
+uses()->group('storage', 'storage.in_memory');
 
-    public function testGetDefault(): void
-    {
-        $store = new InMemoryStorage();
-        $store->set('test_set_key', null);
-        $this->assertSame(null, $store->get('test_set_key', 'foobar'));
-        $this->assertSame('foobar', $store->get('missing_key', 'foobar'));
-        $this->assertSame(null, $store->get('missing_key'));
-    }
+beforeEach(function(): void {
+    $this->store = new InMemoryStorage();
+});
 
-    public function testDelete(): void
-    {
-        $store = new InMemoryStorage();
-        $store->set('test_set_key', '__test_set_value__');
+test('set() assigns values as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+    $this->assertEquals($value, $this->store->get($key));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
 
-        $store->delete('test_set_key');
-        $this->assertNull($store->get('test_set_key'));
-    }
+test('get() retrieves values as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+    $this->assertEquals($value, $this->store->get($key, 'foobar'));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
 
-    public function testDeleteAll(): void
-    {
-        $store = new InMemoryStorage();
-        $store->set('test_set_key', '__test_set_value__');
+test('get() retrieves default values as expected', function(string $key): void {
+    $this->assertEquals('foobar', $this->store->get($key, 'foobar'));
+})->with(['mocked key' => [
+    fn() => uniqid(),
+]]);
 
-        $store->deleteAll();
-        $this->assertNull($store->get('test_set_key'));
-    }
-}
+test('delete() clears values as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+
+    $this->store->delete($key);
+    $this->assertNull($this->store->get($key));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
+
+test('deleteAll() clears values as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+
+    $this->store->deleteAll();
+    $this->assertNull($this->store->get($key));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);

--- a/tests/Unit/Store/MemoryStoreTest.php
+++ b/tests/Unit/Store/MemoryStoreTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Store\InMemoryStorage;
+use Auth0\SDK\Store\MemoryStore;
 
-uses()->group('storage', 'storage.in_memory');
+uses()->group('storage', 'storage.memory');
 
 beforeEach(function(): void {
-    $this->store = new InMemoryStorage();
+    $this->store = new MemoryStore();
 });
 
 test('set() assigns values as expected', function(string $key, string $value): void {

--- a/tests/Unit/Store/MemoryStoreTest.php
+++ b/tests/Unit/Store/MemoryStoreTest.php
@@ -12,7 +12,7 @@ beforeEach(function(): void {
 
 test('set() assigns values as expected', function(string $key, string $value): void {
     $this->store->set($key, $value);
-    $this->assertEquals($value, $this->store->get($key));
+    expect($this->store->get($key))->toEqual($value);
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -20,14 +20,14 @@ test('set() assigns values as expected', function(string $key, string $value): v
 
 test('get() retrieves values as expected', function(string $key, string $value): void {
     $this->store->set($key, $value);
-    $this->assertEquals($value, $this->store->get($key, 'foobar'));
+    expect($this->store->get($key, 'foobar'))->toEqual($value);
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
 ]]);
 
 test('get() retrieves default values as expected', function(string $key): void {
-    $this->assertEquals('foobar', $this->store->get($key, 'foobar'));
+    expect($this->store->get($key, 'foobar'))->toEqual('foobar');
 })->with(['mocked key' => [
     fn() => uniqid(),
 ]]);
@@ -36,7 +36,7 @@ test('delete() clears values as expected', function(string $key, string $value):
     $this->store->set($key, $value);
 
     $this->store->delete($key);
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toBeNull();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -46,7 +46,7 @@ test('purge() clears values as expected', function(string $key, string $value): 
     $this->store->set($key, $value);
 
     $this->store->purge();
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toBeNull();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),

--- a/tests/Unit/Store/Psr6StoreTest.php
+++ b/tests/Unit/Store/Psr6StoreTest.php
@@ -20,12 +20,12 @@ beforeEach(function(): void {
 
 test('set() and get() behave as expected', function(string $key, string $value): void {
     $this->store->set($key, $value);
-    $this->assertSame($value, $this->store->get($key));
-    $this->assertSame(null, $this->store->get('missing_key'));
+    expect($this->store->get($key))->toBe($value);
+    expect($this->store->get('missing_key'))->toBe(null);
 
     $this->assertNotNull($randomKey = $this->public->get($this->storageKey));
     $this->public->delete($this->storageKey);
-    $this->assertSame(null, $this->store->get($key));
+    expect($this->store->get($key))->toBe(null);
 
     // Make sure we have a new key
     $this->assertNotSame($randomKey, $this->store->get($key));
@@ -67,8 +67,8 @@ it('stores data in private', function(string $key, string $value): void {
 
     $store = new Psr6Store($public, $private, $this->storageKey);
     $store->set($key, $value);
-    $this->assertSame($value, $store->get($key));
-    $this->assertSame(null, $store->get('missing_key'));
+    expect($store->get($key))->toBe($value);
+    expect($store->get('missing_key'))->toBe(null);
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -77,20 +77,20 @@ it('stores data in private', function(string $key, string $value): void {
 test('get() retrieves a default value as expected', function(string $key): void {
     $this->store->set($key, null);
 
-    $this->assertSame(null, $this->store->get($key, 'foobar'));
-    $this->assertSame('foobar', $this->store->get('missing_key', 'foobar'));
-    $this->assertSame(null, $this->store->get('missing_key'));
+    expect($this->store->get($key, 'foobar'))->toBe(null);
+    expect($this->store->get('missing_key', 'foobar'))->toBe('foobar');
+    expect($this->store->get('missing_key'))->toBe(null);
 })->with(['mocked key' => [
     fn() => uniqid(),
 ]]);
 
 test('delete() clears values as expected', function(string $key, string $value): void {
     $this->store->delete($key);
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toBeNull();
 
     $this->store->set($key, $value);
     $this->store->delete($key);
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toBeNull();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -100,7 +100,7 @@ test('purge() clears values as expected', function(string $key, string $value): 
     $this->store->set($key, $value);
 
     $this->store->purge();
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toBeNull();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),

--- a/tests/Unit/Store/Psr6StoreTest.php
+++ b/tests/Unit/Store/Psr6StoreTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Auth0\Tests\Unit\Store;
 
 use Auth0\SDK\Contract\StoreInterface;
-use Auth0\SDK\Store\InMemoryStorage;
+use Auth0\SDK\Store\MemoryStore;
 use Auth0\SDK\Store\Psr6Store;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -21,7 +21,7 @@ class Psr6StoreTest extends TestCase
 
     public function testSetGet(): void
     {
-        $public = new InMemoryStorage();
+        $public = new MemoryStore();
         $private = new ArrayAdapter();
         $store = new Psr6Store($public, $private);
         $store->set('test_set_key', '__test_set_value__');
@@ -73,7 +73,7 @@ class Psr6StoreTest extends TestCase
 
     public function testGetDefault(): void
     {
-        $public = new InMemoryStorage();
+        $public = new MemoryStore();
         $private = new ArrayAdapter();
         $store = new Psr6Store($public, $private);
         $store->set('test_set_key', null);
@@ -84,7 +84,7 @@ class Psr6StoreTest extends TestCase
 
     public function testDelete(): void
     {
-        $public = new InMemoryStorage();
+        $public = new MemoryStore();
         $private = new ArrayAdapter();
         $store = new Psr6Store($public, $private);
         $store->set('test_set_key', '__test_set_value__');
@@ -95,7 +95,7 @@ class Psr6StoreTest extends TestCase
 
     public function testPurge(): void
     {
-        $public = new InMemoryStorage();
+        $public = new MemoryStore();
         $private = new ArrayAdapter();
         $store = new Psr6Store($public, $private);
         $store->set('test_set_key', '__test_set_value__');

--- a/tests/Unit/Store/Psr6StoreTest.php
+++ b/tests/Unit/Store/Psr6StoreTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-declare(strict_types=1);
-
 use Auth0\SDK\Contract\StoreInterface;
 use Auth0\SDK\Store\MemoryStore;
 use Auth0\SDK\Store\Psr6Store;

--- a/tests/Unit/Store/Psr6StoreTest.php
+++ b/tests/Unit/Store/Psr6StoreTest.php
@@ -2,105 +2,108 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\Store;
+declare(strict_types=1);
 
 use Auth0\SDK\Contract\StoreInterface;
 use Auth0\SDK\Store\MemoryStore;
 use Auth0\SDK\Store\Psr6Store;
-use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-/**
- * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- */
-class Psr6StoreTest extends TestCase
-{
-    private const PUBLIC_STORAGE_KEY = 'storage_key';
+uses()->group('storage', 'storage.psr6');
 
-    public function testSetGet(): void
-    {
-        $public = new MemoryStore();
-        $private = new ArrayAdapter();
-        $store = new Psr6Store($public, $private);
-        $store->set('test_set_key', '__test_set_value__');
-        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
-        $this->assertSame(null, $store->get('missing_key'));
+beforeEach(function(): void {
+    $this->public = new MemoryStore();
+    $this->private = new ArrayAdapter();
+    $this->storageKey = uniqid();
+    $this->store = new Psr6Store($this->public, $this->private, $this->storageKey);
+});
 
-        $this->assertNotNull($randomKey = $public->get(self::PUBLIC_STORAGE_KEY));
-        $public->delete(self::PUBLIC_STORAGE_KEY);
-        $this->assertSame(null, $store->get('test_set_key'));
+test('set() and get() behave as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+    $this->assertSame($value, $this->store->get($key));
+    $this->assertSame(null, $this->store->get('missing_key'));
 
-        // Make sure we have a new key
-        $this->assertNotSame($randomKey, $store->get('test_set_key'));
-        $this->assertNotNull($public->get(self::PUBLIC_STORAGE_KEY));
-    }
+    $this->assertNotNull($randomKey = $this->public->get($this->storageKey));
+    $this->public->delete($this->storageKey);
+    $this->assertSame(null, $this->store->get($key));
 
-    public function testDataIsStoredInPrivate(): void
-    {
-        $public = $this->getMockBuilder(StoreInterface::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['set', 'get', 'delete', 'purge', 'defer'])
-            ->getMock();
-        $public->expects($this->atLeastOnce())->method('get')->with(self::PUBLIC_STORAGE_KEY)->willReturn('foobar');
-        // Make sure we don't create a new key
-        $public->expects($this->never())->method('set');
+    // Make sure we have a new key
+    $this->assertNotSame($randomKey, $this->store->get($key));
+    $this->assertNotNull($this->public->get($this->storageKey));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
 
-        $private = $this->getMockBuilder(CacheItemPoolInterface::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([
-                'getItem', 'saveDeferred', 'getItems', 'hasItem', 'clear',
-                'save', 'deleteItems', 'deleteItem', 'commit'
-            ])
-            ->getMock();
+it('stores data in private', function(string $key, string $value): void {
+    $public = $this->getMockBuilder(StoreInterface::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['set', 'get', 'delete', 'purge', 'defer'])
+        ->getMock();
 
-        $item = $this->getMockBuilder(CacheItemInterface::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['get', 'set', 'getKey', 'isHit', 'expiresAt', 'expiresAfter'])
-            ->getMock();
-        $item->expects($this->once())->method('set')->with(['test_set_key'=>'__test_set_value__']);
-        $item->method('get')->willReturnOnConsecutiveCalls(null, ['test_set_key'=>'__test_set_value__']);
+    $private = $this->getMockBuilder(CacheItemPoolInterface::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods([
+            'getItem', 'saveDeferred', 'getItems', 'hasItem', 'clear',
+            'save', 'deleteItems', 'deleteItem', 'commit'
+        ])
+        ->getMock();
 
-        $private->method('getItem')->with('auth0_foobar')->willReturn($item);
-        $private->method('saveDeferred')->willReturn(true);
+    $public->expects($this->atLeastOnce())->method('get')->with($this->storageKey)->willReturn('foobar');
 
-        $store = new Psr6Store($public, $private);
-        $store->set('test_set_key', '__test_set_value__');
-        $this->assertSame('__test_set_value__', $store->get('test_set_key'));
-        $this->assertSame(null, $store->get('missing_key'));
-    }
+    // Make sure we don't create a new key
+    $public->expects($this->never())->method('set');
 
-    public function testGetDefault(): void
-    {
-        $public = new MemoryStore();
-        $private = new ArrayAdapter();
-        $store = new Psr6Store($public, $private);
-        $store->set('test_set_key', null);
-        $this->assertSame(null, $store->get('test_set_key', 'foobar'));
-        $this->assertSame('foobar', $store->get('missing_key', 'foobar'));
-        $this->assertSame(null, $store->get('missing_key'));
-    }
+    $item = $this->getMockBuilder(CacheItemInterface::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['get', 'set', 'getKey', 'isHit', 'expiresAt', 'expiresAfter'])
+        ->getMock();
 
-    public function testDelete(): void
-    {
-        $public = new MemoryStore();
-        $private = new ArrayAdapter();
-        $store = new Psr6Store($public, $private);
-        $store->set('test_set_key', '__test_set_value__');
+    $item->expects($this->once())->method('set')->with([$key=>$value]);
+    $item->method('get')->willReturnOnConsecutiveCalls(null, [$key=>$value]);
 
-        $store->delete('test_set_key');
-        $this->assertNull($store->get('test_set_key'));
-    }
+    $private->method('getItem')->with('auth0_foobar')->willReturn($item);
+    $private->method('saveDeferred')->willReturn(true);
 
-    public function testPurge(): void
-    {
-        $public = new MemoryStore();
-        $private = new ArrayAdapter();
-        $store = new Psr6Store($public, $private);
-        $store->set('test_set_key', '__test_set_value__');
+    $store = new Psr6Store($public, $private, $this->storageKey);
+    $store->set($key, $value);
+    $this->assertSame($value, $store->get($key));
+    $this->assertSame(null, $store->get('missing_key'));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
 
-        $store->purge();
-        $this->assertNull($store->get('test_set_key'));
-    }
-}
+test('get() retrieves a default value as expected', function(string $key): void {
+    $this->store->set($key, null);
+
+    $this->assertSame(null, $this->store->get($key, 'foobar'));
+    $this->assertSame('foobar', $this->store->get('missing_key', 'foobar'));
+    $this->assertSame(null, $this->store->get('missing_key'));
+})->with(['mocked key' => [
+    fn() => uniqid(),
+]]);
+
+test('delete() clears values as expected', function(string $key, string $value): void {
+    $this->store->delete($key);
+    $this->assertNull($this->store->get($key));
+
+    $this->store->set($key, $value);
+    $this->store->delete($key);
+    $this->assertNull($this->store->get($key));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);
+
+test('purge() clears values as expected', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+
+    $this->store->purge();
+    $this->assertNull($this->store->get($key));
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);

--- a/tests/Unit/Store/SessionStoreTest.php
+++ b/tests/Unit/Store/SessionStoreTest.php
@@ -25,7 +25,7 @@ beforeEach(function(): void {
 
 test('set() assigns values as expected', function(string $key, string $value): void {
     $this->store->set($key, $value);
-    $this->assertEquals($value, $_SESSION[$this->namespace . '_' . $key]);
+    expect($_SESSION[$this->namespace . '_' . $key])->toEqual($value);
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -33,26 +33,26 @@ test('set() assigns values as expected', function(string $key, string $value): v
 
 test('get() retrieves values as expected', function(string $key, string $value): void {
     $_SESSION[$this->namespace . '_' . $key] = $value;
-    $this->assertEquals($value, $this->store->get($key, 'foobar'));
+    expect($this->store->get($key, 'foobar'))->toEqual($value);
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
 ]]);
 
 test('get() retrieves a default value as expected', function(string $key): void {
-    $this->assertEquals('foobar', $this->store->get($key, 'foobar'));
+    expect($this->store->get($key, 'foobar'))->toEqual('foobar');
 })->with(['mocked key' => [
     fn() => uniqid(),
 ]]);
 
 test('delete() clears values as expected', function(string $key, string $value): void {
     $_SESSION[$this->namespace . '_' . $key] = $value;
-    $this->assertTrue(isset($_SESSION[$this->namespace . '_' . $key]));
+    expect(isset($_SESSION[$this->namespace . '_' . $key]))->toBeTrue();
 
     $this->store->delete($key);
 
-    $this->assertNull($this->store->get($key));
-    $this->assertFalse(isset($_SESSION[$this->namespace . '_' . $key]));
+    expect($this->store->get($key))->toBeNull();
+    expect(isset($_SESSION[$this->namespace . '_' . $key]))->toBeFalse();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -60,12 +60,12 @@ test('delete() clears values as expected', function(string $key, string $value):
 
 test('purge() clears values as expected', function(string $key, string $value): void {
     $_SESSION[$this->namespace . '_' . $key] = $value;
-    $this->assertTrue(isset($_SESSION[$this->namespace . '_' . $key]));
+    expect(isset($_SESSION[$this->namespace . '_' . $key]))->toBeTrue();
 
     $this->store->purge();
 
-    $this->assertNull($this->store->get($key));
-    $this->assertFalse(isset($_SESSION[$this->namespace . '_' . $key]));
+    expect($this->store->get($key))->toBeNull();
+    expect(isset($_SESSION[$this->namespace . '_' . $key]))->toBeFalse();
 })->with(['mocked data' => [
     fn() => uniqid(),
     fn() => uniqid(),

--- a/tests/Unit/Store/SessionStoreTest.php
+++ b/tests/Unit/Store/SessionStoreTest.php
@@ -58,11 +58,11 @@ test('delete() clears values as expected', function(string $key, string $value):
     fn() => uniqid(),
 ]]);
 
-test('deleteAll() clears values as expected', function(string $key, string $value): void {
+test('purge() clears values as expected', function(string $key, string $value): void {
     $_SESSION[$this->namespace . '_' . $key] = $value;
     $this->assertTrue(isset($_SESSION[$this->namespace . '_' . $key]));
 
-    $this->store->deleteAll();
+    $this->store->purge();
 
     $this->assertNull($this->store->get($key));
     $this->assertFalse(isset($_SESSION[$this->namespace . '_' . $key]));

--- a/tests/Unit/Token/ParserTest.php
+++ b/tests/Unit/Token/ParserTest.php
@@ -24,13 +24,10 @@ it('throws an exception with malformed token separators', function(
 ): void {
     $jwt = uniqid() . uniqid();
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\InvalidTokenException::MSG_BAD_SEPARATORS);
-
     $token = new Parser($jwt, $configuration);
 })->with(['mocked configured' => [
     fn() => $this->configuration
-]]);
+]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_BAD_SEPARATORS);
 
 it('accepts and successfully parses a valid RS256 ID Token', function(
     SdkConfiguration $configuration,

--- a/tests/Unit/Token/ParserTest.php
+++ b/tests/Unit/Token/ParserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Token\Parser;
+use Auth0\Tests\Utilities\TokenGenerator;
+use Auth0\Tests\Utilities\TokenGeneratorResponse;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+uses()->group('token', 'token.parser');
+
+beforeEach(function() {
+    $this->cache = new ArrayAdapter();
+
+    $this->configuration = new SdkConfiguration([
+        'strategy' => 'none',
+        'tokenCache' => $this->cache
+    ]);
+});
+
+it('throws an exception with malformed token separators', function(
+    SdkConfiguration $configuration
+): void {
+    $jwt = uniqid() . uniqid();
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\InvalidTokenException::MSG_BAD_SEPARATORS);
+
+    $token = new Parser($jwt, $configuration);
+})->with(['mocked configured' => [
+    fn() => $this->configuration
+]]);
+
+it('accepts and successfully parses a valid RS256 ID Token', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Parser($jwt->token, $configuration);
+
+    $this->assertIsObject($token);
+    $this->assertIsArray($token->getClaims());
+    // $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
+    // $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
+    // $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
+    // $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
+    // $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
+    // $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
+    // $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
+    // $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
+    // $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+})->with(['mocked rs256 id token' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_RS256)
+]]);

--- a/tests/Unit/Token/ParserTest.php
+++ b/tests/Unit/Token/ParserTest.php
@@ -38,8 +38,8 @@ it('accepts and successfully parses a valid RS256 ID Token', function(
 ): void {
     $token = new Parser($jwt->token, $configuration);
 
-    $this->assertIsObject($token);
-    $this->assertIsArray($token->getClaims());
+    expect($token)->toBeObject();
+    expect($token->getClaims())->toBeArray();
     // $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
     // $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
     // $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());

--- a/tests/Unit/Token/ValidatorTest.php
+++ b/tests/Unit/Token/ValidatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Token\Validator;
+use Auth0\Tests\Utilities\TokenGenerator;
+use Auth0\Tests\Utilities\TokenGeneratorResponse;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+uses()->group('token', 'token.validator');
+
+beforeEach(function() {
+    $this->claims = [
+        'sub' => uniqid(),
+        'iss' => uniqid(),
+        'aud' => uniqid(),
+        'nonce' => uniqid(),
+        'auth_time' => time() - 100,
+        'exp' => time() + 1000,
+        'iat' => time() - 1000,
+        'azp' => uniqid()
+    ];
+});
+
+test('audience() throws an exception when `aud` claim is missing', function(): void {
+    unset($this->claims['aud']);
+    (new Validator($this->claims))->audience(['missing']);
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_AUDIENCE_CLAIM);
+
+test('authTime() throws an exception when `auth_time` claim is missing', function(): void {
+    unset($this->claims['auth_time']);
+    (new Validator($this->claims))->authTime(100);
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_AUTH_TIME_CLAIM);
+
+test('authorizedParty() throws an exception when `aud` claim is missing', function(): void {
+    unset($this->claims['aud']);
+    (new Validator($this->claims))->authorizedParty(['missing']);
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_AUDIENCE_CLAIM);
+
+test('authorizedParty() throws an exception when `azp` claim is missing', function(): void {
+    $this->claims['aud'] = [uniqid(), uniqid()];
+    unset($this->claims['azp']);
+    (new Validator($this->claims))->authorizedParty(['missing']);
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_AZP_CLAIM);
+
+test('authorizedParty() throws an exception when `azp` is not present in `aud` claims', function(): void {
+    $this->claims['aud'] = [uniqid(), uniqid()];
+    $this->claims['azp'] = 'mismatch';
+    (new Validator($this->claims))->authorizedParty(['missing']);
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AZP_CLAIM, 'missing', 'mismatch'));
+
+test('expiration() throws an exception when `exp` claim is missing', function(): void {
+    unset($this->claims['exp']);
+    (new Validator($this->claims))->expiration();
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_EXP_CLAIM);
+
+test('expiration() throws an exception when `exp` claim is less than present time', function(): void {
+    $this->claims['exp'] = time() - 1000;
+    (new Validator($this->claims))->expiration();
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
+
+test('issued() throws an exception when `iat` claim is missing', function(): void {
+    unset($this->claims['iat']);
+    (new Validator($this->claims))->issued();
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_IAT_CLAIM);
+
+test('issuer() throws an exception when `iss` claim is missing', function(): void {
+    unset($this->claims['iss']);
+    (new Validator($this->claims))->issuer(uniqid());
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_ISS_CLAIM);
+
+test('issuer() throws an exception when `iss` claim is mismatched', function(): void {
+    (new Validator($this->claims))->issuer(uniqid());
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
+
+test('nonce() throws an exception when `nonce` claim is missing', function(): void {
+    unset($this->claims['nonce']);
+    (new Validator($this->claims))->nonce(uniqid());
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_NONCE_CLAIM);
+
+test('nonce() throws an exception when `nonce` claim is mismatched', function(): void {
+    (new Validator($this->claims))->nonce(uniqid());
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
+
+test('subject() throws an exception when `sub` claim is missing', function(): void {
+    unset($this->claims['sub']);
+    (new Validator($this->claims))->subject();
+})->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_MISSING_SUB_CLAIM);

--- a/tests/Unit/Token/VerifierTest.php
+++ b/tests/Unit/Token/VerifierTest.php
@@ -123,7 +123,7 @@ test('[RS256] verify() succeeds when signing key is correct', function($keyPair,
     $item->set(['__test_kid__' => ['x5c' => [$keyPair['cert']]]]);
     $cache->save($item);
 
-    $this->assertIsObject(new Verifier($this->configuration, $payload, $signature, $headers, Token::ALGO_RS256, $jwksUri, null, null, $cache));
+    expect(new Verifier($this->configuration, $payload, $signature, $headers, Token::ALGO_RS256, $jwksUri, null, null, $cache))->toBeObject();
 })->with('tokenRs256');
 
 test('[RS256] verify() throws an error when signing key is wrong', function($keyPair, $token, $payload, $signature, $headers, $jwksUri, $jwksCacheKey): void {
@@ -162,5 +162,5 @@ test('[HS256] verify() throws an error when secret is wrong', function($token, $
 
 test('[HS256] verify() succeeds when secret is correct', function($token, $payload, $signature, $headers): void {
     $headers = TokenGenerator::decodePart($headers);
-    $this->assertIsObject(new Verifier($this->configuration, $payload, $signature, $headers, Token::ALGO_HS256, null, '__test_client_secret__'));
+    expect(new Verifier($this->configuration, $payload, $signature, $headers, Token::ALGO_HS256, null, '__test_client_secret__'))->toBeObject();
 })->with('tokenHs256');

--- a/tests/Unit/Token/VerifierTest.php
+++ b/tests/Unit/Token/VerifierTest.php
@@ -8,7 +8,7 @@ use Auth0\SDK\Token\Verifier;
 use Auth0\Tests\Utilities\TokenGenerator;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-// uses()->group('token', 'token.verifier');
+uses()->group('token', 'token.verifier');
 
 beforeEach(function() {
     $this->configuration = new SdkConfiguration([

--- a/tests/Unit/Token/VerifierTest.php
+++ b/tests/Unit/Token/VerifierTest.php
@@ -8,6 +8,8 @@ use Auth0\SDK\Token\Verifier;
 use Auth0\Tests\Utilities\TokenGenerator;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
+// uses()->group('token', 'token.verifier');
+
 beforeEach(function() {
     $this->configuration = new SdkConfiguration([
         'domain' => uniqid(),

--- a/tests/Unit/TokenTest.php
+++ b/tests/Unit/TokenTest.php
@@ -25,16 +25,16 @@ it('accepts and successfully parses a valid RS256 ID Token', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
 
-    $this->assertIsObject($token);
-    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
-    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
-    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
-    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
-    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
-    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
-    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
-    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
-    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+    expect($token)->toBeObject();
+    expect($token->getAudience()[0] ?? null)->toEqual($jwt->claims['aud'] ?? null);
+    expect($token->getAuthorizedParty())->toEqual($jwt->claims['azp'] ?? null);
+    expect($token->getAuthTime())->toEqual($jwt->claims['auth_time'] ?? null);
+    expect($token->getExpiration())->toEqual($jwt->claims['exp'] ?? null);
+    expect($token->getIssued())->toEqual($jwt->claims['iat'] ?? null);
+    expect($token->getIssuer())->toEqual($jwt->claims['iss'] ?? null);
+    expect($token->getNonce())->toEqual($jwt->claims['nonce'] ?? null);
+    expect($token->getOrganization())->toEqual($jwt->claims['org_id'] ?? null);
+    expect($token->getSubject())->toEqual($jwt->claims['sub'] ?? null);
 })->with(['mocked rs256 id token' => [
     fn() => $this->configuration,
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_RS256)
@@ -46,16 +46,16 @@ it('accepts and successfully parses a valid HS256 ID Token', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
 
-    $this->assertIsObject($token);
-    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
-    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
-    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
-    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
-    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
-    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
-    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
-    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
-    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+    expect($token)->toBeObject();
+    expect($token->getAudience()[0] ?? null)->toEqual($jwt->claims['aud'] ?? null);
+    expect($token->getAuthorizedParty())->toEqual($jwt->claims['azp'] ?? null);
+    expect($token->getAuthTime())->toEqual($jwt->claims['auth_time'] ?? null);
+    expect($token->getExpiration())->toEqual($jwt->claims['exp'] ?? null);
+    expect($token->getIssued())->toEqual($jwt->claims['iat'] ?? null);
+    expect($token->getIssuer())->toEqual($jwt->claims['iss'] ?? null);
+    expect($token->getNonce())->toEqual($jwt->claims['nonce'] ?? null);
+    expect($token->getOrganization())->toEqual($jwt->claims['org_id'] ?? null);
+    expect($token->getSubject())->toEqual($jwt->claims['sub'] ?? null);
 })->with(['mocked hs256 id token' => [
     fn() => $this->configuration,
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
@@ -67,16 +67,16 @@ it('accepts and successfully parses a valid RS256 Access Token', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_TOKEN);
 
-    $this->assertIsObject($token);
-    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
-    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
-    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
-    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
-    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
-    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
-    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
-    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
-    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+    expect($token)->toBeObject();
+    expect($token->getAudience()[0] ?? null)->toEqual($jwt->claims['aud'] ?? null);
+    expect($token->getAuthorizedParty())->toEqual($jwt->claims['azp'] ?? null);
+    expect($token->getAuthTime())->toEqual($jwt->claims['auth_time'] ?? null);
+    expect($token->getExpiration())->toEqual($jwt->claims['exp'] ?? null);
+    expect($token->getIssued())->toEqual($jwt->claims['iat'] ?? null);
+    expect($token->getIssuer())->toEqual($jwt->claims['iss'] ?? null);
+    expect($token->getNonce())->toEqual($jwt->claims['nonce'] ?? null);
+    expect($token->getOrganization())->toEqual($jwt->claims['org_id'] ?? null);
+    expect($token->getSubject())->toEqual($jwt->claims['sub'] ?? null);
 })->with(['mocked rs256 access token' => [
     fn() => $this->configuration,
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -88,16 +88,16 @@ it('accepts and successfully parses a valid HS256 Access Token', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_TOKEN);
 
-    $this->assertIsObject($token);
-    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
-    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
-    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
-    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
-    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
-    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
-    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
-    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
-    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+    expect($token)->toBeObject();
+    expect($token->getAudience()[0] ?? null)->toEqual($jwt->claims['aud'] ?? null);
+    expect($token->getAuthorizedParty())->toEqual($jwt->claims['azp'] ?? null);
+    expect($token->getAuthTime())->toEqual($jwt->claims['auth_time'] ?? null);
+    expect($token->getExpiration())->toEqual($jwt->claims['exp'] ?? null);
+    expect($token->getIssued())->toEqual($jwt->claims['iat'] ?? null);
+    expect($token->getIssuer())->toEqual($jwt->claims['iss'] ?? null);
+    expect($token->getNonce())->toEqual($jwt->claims['nonce'] ?? null);
+    expect($token->getOrganization())->toEqual($jwt->claims['org_id'] ?? null);
+    expect($token->getSubject())->toEqual($jwt->claims['sub'] ?? null);
 })->with(['mocked hs256 access token' => [
     fn() => $this->configuration,
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_HS256)
@@ -108,7 +108,7 @@ test('verify() returns a fluent interface', function(
     TokenGeneratorResponse $jwt
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
-    $this->assertEquals($token, $token->verify());
+    expect($token->verify())->toEqual($token);
 })->with(['mocked data' => [
     function(): SdkConfiguration {
         $this->configuration->setTokenAlgorithm('HS256');
@@ -142,7 +142,7 @@ test('validate() returns a fluent interface', function(
     array $claims
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
-    $this->assertEquals($token, $token->validate(null, null, ['__test_org__'], $claims['nonce'], 100));
+    expect($token->validate(null, null, ['__test_org__'], $claims['nonce'], 100))->toEqual($token);
 })->with(['mocked data' => [
     function(): SdkConfiguration {
         $this->configuration->setDomain('__test_domain__');
@@ -182,7 +182,7 @@ test('toArray() returns an array', function(
     TokenGeneratorResponse $jwt
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
-    $this->assertIsArray($token->toArray());
+    expect($token->toArray())->toBeArray();
 })->with(['mocked data' => [
     fn() => $this->configuration,
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
@@ -194,7 +194,7 @@ test('toJson() returns a valid JSON-encoded string', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
     $json = $token->toJson();
-    $this->assertIsString($json);
+    expect($json)->toBeString();
     $this->assertNotNull(json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 })->with(['mocked data' => [
     fn() => $this->configuration,

--- a/tests/Unit/TokenTest.php
+++ b/tests/Unit/TokenTest.php
@@ -8,7 +8,7 @@ use Auth0\Tests\Utilities\TokenGenerator;
 use Auth0\Tests\Utilities\TokenGeneratorResponse;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-// uses()->group('token');
+uses()->group('token');
 
 beforeEach(function() {
     $this->cache = new ArrayAdapter();

--- a/tests/Unit/TokenTest.php
+++ b/tests/Unit/TokenTest.php
@@ -124,9 +124,6 @@ test('verify() overrides globally configured algorithm', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_UNEXPECTED_SIGNING_ALGORITHM, 'RS256', 'HS256'));
-
     $token->verify('RS256');
 })->with(['mocked data' => [
     function(): SdkConfiguration {
@@ -134,7 +131,7 @@ test('verify() overrides globally configured algorithm', function(
         return $this->configuration;
     },
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
-]]);
+]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_UNEXPECTED_SIGNING_ALGORITHM, 'RS256', 'HS256'));
 
 test('validate() returns a fluent interface', function(
     SdkConfiguration $configuration,
@@ -162,9 +159,6 @@ test('validate() overrides globally configured algorithm', function(
 ): void {
     $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
 
-    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUD_CLAIM, $claims['aud'], '__test_client_id__'));
-
     $token->validate(null, [ $claims['aud'] ]);
 })->with(['mocked data' => [
     function(): SdkConfiguration {
@@ -175,7 +169,7 @@ test('validate() overrides globally configured algorithm', function(
     },
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256),
     fn() => ['aud' => uniqid()]
-]]);
+]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
 test('toArray() returns an array', function(
     SdkConfiguration $configuration,

--- a/tests/Unit/TokenTest.php
+++ b/tests/Unit/TokenTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Token;
+use Auth0\Tests\Utilities\TokenGenerator;
+use Auth0\Tests\Utilities\TokenGeneratorResponse;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+// uses()->group('token');
+
+beforeEach(function() {
+    $this->cache = new ArrayAdapter();
+
+    $this->configuration = new SdkConfiguration([
+        'strategy' => 'none',
+        'tokenCache' => $this->cache
+    ]);
+});
+
+it('accepts and successfully parses a valid RS256 ID Token', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+
+    $this->assertIsObject($token);
+    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
+    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
+    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
+    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
+    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
+    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
+    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
+    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
+    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+})->with(['mocked rs256 id token' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_RS256)
+]]);
+
+it('accepts and successfully parses a valid HS256 ID Token', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+
+    $this->assertIsObject($token);
+    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
+    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
+    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
+    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
+    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
+    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
+    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
+    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
+    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+})->with(['mocked hs256 id token' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
+]]);
+
+it('accepts and successfully parses a valid RS256 Access Token', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_TOKEN);
+
+    $this->assertIsObject($token);
+    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
+    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
+    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
+    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
+    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
+    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
+    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
+    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
+    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+})->with(['mocked rs256 access token' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
+]]);
+
+it('accepts and successfully parses a valid HS256 Access Token', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_TOKEN);
+
+    $this->assertIsObject($token);
+    $this->assertEquals($jwt->claims['aud'] ?? null, $token->getAudience()[0] ?? null);
+    $this->assertEquals($jwt->claims['azp'] ?? null, $token->getAuthorizedParty());
+    $this->assertEquals($jwt->claims['auth_time'] ?? null, $token->getAuthTime());
+    $this->assertEquals($jwt->claims['exp'] ?? null, $token->getExpiration());
+    $this->assertEquals($jwt->claims['iat'] ?? null, $token->getIssued());
+    $this->assertEquals($jwt->claims['iss'] ?? null, $token->getIssuer());
+    $this->assertEquals($jwt->claims['nonce'] ?? null, $token->getNonce());
+    $this->assertEquals($jwt->claims['org_id'] ?? null, $token->getOrganization());
+    $this->assertEquals($jwt->claims['sub'] ?? null, $token->getSubject());
+})->with(['mocked hs256 access token' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_HS256)
+]]);
+
+test('verify() returns a fluent interface', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+    $this->assertEquals($token, $token->verify());
+})->with(['mocked data' => [
+    function(): SdkConfiguration {
+        $this->configuration->setTokenAlgorithm('HS256');
+        $this->configuration->setClientSecret('__test_client_secret__');
+        return $this->configuration;
+    },
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
+]]);
+
+test('verify() overrides globally configured algorithm', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_UNEXPECTED_SIGNING_ALGORITHM, 'RS256', 'HS256'));
+
+    $token->verify('RS256');
+})->with(['mocked data' => [
+    function(): SdkConfiguration {
+        $this->configuration->setTokenAlgorithm('HS256');
+        return $this->configuration;
+    },
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
+]]);
+
+test('validate() returns a fluent interface', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt,
+    array $claims
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+    $this->assertEquals($token, $token->validate(null, null, ['__test_org__'], $claims['nonce'], 100));
+})->with(['mocked data' => [
+    function(): SdkConfiguration {
+        $this->configuration->setDomain('__test_domain__');
+        $this->configuration->setClientId('__test_client_id__');
+        $this->configuration->setTokenAlgorithm('HS256');
+        $this->configuration->setClientSecret('__test_client_secret__');
+        return $this->configuration;
+    },
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256, ['org_id' => '__test_org__']),
+    fn() => ['nonce' => '__test_nonce__']
+]]);
+
+test('validate() overrides globally configured algorithm', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt,
+    array $claims
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+
+    $this->expectException(\Auth0\SDK\Exception\InvalidTokenException::class);
+    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\InvalidTokenException::MSG_MISMATCHED_AUD_CLAIM, $claims['aud'], '__test_client_id__'));
+
+    $token->validate(null, [ $claims['aud'] ]);
+})->with(['mocked data' => [
+    function(): SdkConfiguration {
+        $this->configuration->setDomain('__test_domain__');
+        $this->configuration->setClientId('__test_client_id__');
+        $this->configuration->setTokenAlgorithm('HS256');
+        return $this->configuration;
+    },
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256),
+    fn() => ['aud' => uniqid()]
+]]);
+
+test('toArray() returns an array', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+    $this->assertIsArray($token->toArray());
+})->with(['mocked data' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
+]]);
+
+test('toJson() returns a valid JSON-encoded string', function(
+    SdkConfiguration $configuration,
+    TokenGeneratorResponse $jwt
+): void {
+    $token = new Token($configuration, $jwt->token, Token::TYPE_ID_TOKEN);
+    $json = $token->toJson();
+    $this->assertIsString($json);
+    $this->assertNotNull(json_decode($json, true, 512, JSON_THROW_ON_ERROR));
+})->with(['mocked data' => [
+    fn() => $this->configuration,
+    fn() => TokenGenerator::create(TokenGenerator::TOKEN_ID, TokenGenerator::ALG_HS256)
+]]);

--- a/tests/Unit/Utility/EventDispatcherTest.php
+++ b/tests/Unit/Utility/EventDispatcherTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Hyperf\Event\ListenerProvider;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+uses()->group('utility', 'utility.event_dispatcher');
+
+test('dispatch() functions as expected', function(): void {
+    $mockEvent = new class() implements StoppableEventInterface {
+        public int $id = 123;
+        public bool $hit = false;
+        public bool $stopped = false;
+
+        public function isPropagationStopped(): bool {
+            return $this->stopped;
+        }
+    };
+
+    $listener = new ListenerProvider();
+
+    $listener->on(get_class($mockEvent), function($test) {
+        $test->hit = true;
+        return $test;
+    });
+
+    $configuration = new SdkConfiguration([
+        'strategy' => 'none',
+        'eventListenerProvider' => $listener
+    ]);
+
+    expect($configuration->getEventListenerProvider())->toBeInstanceOf(ListenerProvider::class);
+
+    $mockEvent = $configuration->eventDispatcher()->dispatch($mockEvent);
+
+    expect($mockEvent)
+        ->hit->toBeTrue()
+        ->id->toEqual(123)
+        ->isPropagationStopped()->toBeFalse();
+
+    $mockEvent->stopped = true;
+
+    $mockEvent = $configuration->eventDispatcher()->dispatch($mockEvent);
+
+    expect($mockEvent)
+        ->hit->toBeTrue()
+        ->id->toEqual(123)
+        ->isPropagationStopped()->toBeTrue();
+});

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -35,11 +35,11 @@ test('a 429 response is not retried if httpMaxRetries is zero', function(): void
         ->addPath('client')
         ->call();
 
-    $this->assertEquals(429, HttpResponse::getStatusCode($response));
+    expect(HttpResponse::getStatusCode($response))->toEqual(429);
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
 
-    $this->assertEquals(1, $requestCount);
+    expect($requestCount)->toEqual(1);
 });
 
 test('a 429 response is not retried more than the hard cap', function(): void {
@@ -53,11 +53,11 @@ test('a 429 response is not retried more than the hard cap', function(): void {
         ->addPath('client')
         ->call();
 
-    $this->assertEquals(429, HttpResponse::getStatusCode($response));
+    expect(HttpResponse::getStatusCode($response))->toEqual(429);
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
 
-    $this->assertEquals(10, $requestCount);
+    expect($requestCount)->toEqual(10);
 });
 
 test('an exponential back-off and jitter are being applied', function(): void {
@@ -79,20 +79,20 @@ test('an exponential back-off and jitter are being applied', function(): void {
     $requestCount = $this->client->getLastRequest()->getRequestCount();
     $requestDelays = $this->client->getLastRequest()->getRequestDelays();
 
-    $this->assertEquals(429, HttpResponse::getStatusCode($response));
-    $this->assertEquals(10, $requestCount);
-    $this->assertEquals(10, count($requestDelays));
+    expect(HttpResponse::getStatusCode($response))->toEqual(429);
+    expect($requestCount)->toEqual(10);
+    expect(count($requestDelays))->toEqual(10);
 
     // Assert that exponential backoff is happening.
-    $this->assertGreaterThanOrEqual($requestDelays[0], $requestDelays[1]);
-    $this->assertGreaterThanOrEqual($requestDelays[1], $requestDelays[2]);
-    $this->assertGreaterThanOrEqual($requestDelays[2], $requestDelays[3]);
-    $this->assertGreaterThanOrEqual($requestDelays[3], $requestDelays[4]);
-    $this->assertGreaterThanOrEqual($requestDelays[4], $requestDelays[5]);
-    $this->assertGreaterThanOrEqual($requestDelays[5], $requestDelays[6]);
-    $this->assertGreaterThanOrEqual($requestDelays[6], $requestDelays[7]);
-    $this->assertGreaterThanOrEqual($requestDelays[7], $requestDelays[8]);
-    $this->assertGreaterThanOrEqual($requestDelays[8], $requestDelays[9]);
+    expect($requestDelays[1])->toBeGreaterThanOrEqual($requestDelays[0]);
+    expect($requestDelays[2])->toBeGreaterThanOrEqual($requestDelays[1]);
+    expect($requestDelays[3])->toBeGreaterThanOrEqual($requestDelays[2]);
+    expect($requestDelays[4])->toBeGreaterThanOrEqual($requestDelays[3]);
+    expect($requestDelays[5])->toBeGreaterThanOrEqual($requestDelays[4]);
+    expect($requestDelays[6])->toBeGreaterThanOrEqual($requestDelays[5]);
+    expect($requestDelays[7])->toBeGreaterThanOrEqual($requestDelays[6]);
+    expect($requestDelays[8])->toBeGreaterThanOrEqual($requestDelays[7]);
+    expect($requestDelays[9])->toBeGreaterThanOrEqual($requestDelays[8]);
 
     // Ensure jitter is being applied.
     $this->assertNotEquals($baseWaits[1], $requestDelays[1]);
@@ -106,30 +106,30 @@ test('an exponential back-off and jitter are being applied', function(): void {
     $this->assertNotEquals($baseWaits[9], $requestDelays[9]);
 
     // Ensure subsequent delay is never less than the minimum.
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[1]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[2]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[3]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[4]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[5]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[6]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[7]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[8]);
-    $this->assertGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY, $requestDelays[9]);
+    expect($requestDelays[1])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[2])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[3])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[4])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[5])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[6])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[7])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[8])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
+    expect($requestDelays[9])->toBeGreaterThanOrEqual(HttpRequest::MIN_REQUEST_RETRY_DELAY);
 
     // Ensure delay is never more than the maximum.
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[0]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[1]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[2]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[3]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[4]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[5]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[6]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[7]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[8]);
-    $this->assertLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY, $requestDelays[9]);
+    expect($requestDelays[0])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[1])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[2])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[3])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[4])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[5])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[6])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[7])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[8])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
+    expect($requestDelays[9])->toBeLessThanOrEqual(HttpRequest::MAX_REQUEST_RETRY_DELAY);
 
     // Ensure total delay sum is never more than 10s.
-    $this->assertLessThanOrEqual(10000, array_sum($requestDelays));
+    expect(array_sum($requestDelays))->toBeLessThanOrEqual(10000);
 });
 
 test('a request is tried 3 times before failing in the event of a 429', function(): void {
@@ -143,11 +143,11 @@ test('a request is tried 3 times before failing in the event of a 429', function
         ->addPath('client')
         ->call();
 
-    $this->assertEquals(429, HttpResponse::getStatusCode($response));
+    expect(HttpResponse::getStatusCode($response))->toEqual(429);
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
 
-    $this->assertEquals(3, $requestCount);
+    expect($requestCount)->toEqual(3);
 });
 
 test('a request recovers from a 429 response and returns the successful result', function(): void {
@@ -161,9 +161,9 @@ test('a request recovers from a 429 response and returns the successful result',
         ->addPath('client')
         ->call();
 
-    $this->assertEquals(200, HttpResponse::getStatusCode($response));
+    expect(HttpResponse::getStatusCode($response))->toEqual(200);
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
 
-    $this->assertEquals(2, $requestCount);
+    expect($requestCount)->toEqual(2);
 });

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -7,15 +7,10 @@ use Auth0\SDK\Utility\HttpClient;
 use Auth0\SDK\Utility\HttpRequest;
 use Auth0\SDK\Utility\HttpResponse;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
-use Http\Discovery\Psr18ClientDiscovery;
-use Http\Discovery\Strategy\MockClientStrategy;
 
 uses()->group('utility', 'networking');
 
 beforeEach(function(): void {
-    // Allow mock HttpClient to be auto-discovered for use in testing.
-    Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);
-
     $this->config = new SdkConfiguration([
         'domain' => 'api.local.test',
         'cookieSecret' => uniqid(),
@@ -65,7 +60,7 @@ test('a 429 response is not retried more than the hard cap', function(): void {
     $this->assertEquals(10, $requestCount);
 });
 
-test('an expontential backoff and jitter are being applied', function(): void {
+test('an exponential back-off and jitter are being applied', function(): void {
     $this->config->setHttpMaxRetries(10);
     $baseWaits = [0];
     $baseWaitSum = 0;

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -8,7 +8,7 @@ use Auth0\SDK\Utility\HttpRequest;
 use Auth0\SDK\Utility\HttpResponse;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 
-uses()->group('utility', 'networking');
+uses()->group('utility', 'utility.http_client', 'networking');
 
 beforeEach(function(): void {
     $this->config = new SdkConfiguration([

--- a/tests/Unit/Utility/HttpRequestTest.php
+++ b/tests/Unit/Utility/HttpRequestTest.php
@@ -8,7 +8,7 @@ use Auth0\SDK\Utility\HttpRequest;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Psr\Http\Client\ClientExceptionInterface;
 
-uses()->group('utility', 'networking', 'httpRequest');
+uses()->group('utility', 'utility.http_request', 'networking');
 
 beforeEach(function(): void {
     $this->configuration = new SdkConfiguration([

--- a/tests/Unit/Utility/HttpRequestTest.php
+++ b/tests/Unit/Utility/HttpRequestTest.php
@@ -169,8 +169,6 @@ test('withParams() adds multiple parameters to the URL', function(array $paramet
 ]]);
 
 it('throws a NetworkException when the underlying client raises a ClientExceptionInterface', function(HttpRequest $client): void {
-    $this->expectException(\Auth0\SDK\Exception\NetworkException::class);
-
     $client->call();
 })->with(['mocked client' => [
     function(): HttpRequest {
@@ -184,4 +182,4 @@ it('throws a NetworkException when the underlying client raises a ClientExceptio
 
         return new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'get', '/' . uniqid(), [], null, $responses);
     }
-]]);
+]])->throws(\Auth0\SDK\Exception\NetworkException::class);

--- a/tests/Unit/Utility/HttpRequestTest.php
+++ b/tests/Unit/Utility/HttpRequestTest.php
@@ -18,15 +18,15 @@ beforeEach(function(): void {
 });
 
 it('builds url pathes correctly', function(HttpRequest $client): void {
-    $this->assertEquals('', $client->getUrl());
-    $this->assertEquals('path1', $client->addPath('path1')->getUrl());
-    $this->assertEquals('path1/path2/3', $client->addPath('path2', '3')->getUrl());
+    expect($client->getUrl())->toEqual('');
+    expect($client->addPath('path1')->getUrl())->toEqual('path1');
+    expect($client->addPath('path2', '3')->getUrl())->toEqual('path1/path2/3');
 })->with(['mocked client' => [
     fn() => new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'get', '/' . uniqid())
 ]]);
 
 it('adds field filtering params when configured', function(HttpRequest $client): void {
-    $this->assertEquals('?' . http_build_query(['fields' => implode(',', ['a', 'b', 123]), 'include_fields' => 'true'], '', '&', PHP_QUERY_RFC3986), $client->getParams());
+    expect($client->getParams())->toEqual('?' . http_build_query(['fields' => implode(',', ['a', 'b', 123]), 'include_fields' => 'true'], '', '&', PHP_QUERY_RFC3986));
 })->with(['mocked client' => [
     function(): HttpRequest {
         $client = new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'get', '/' . uniqid());
@@ -36,7 +36,7 @@ it('adds field filtering params when configured', function(HttpRequest $client):
 ]]);
 
 it('adds classic pagination params when configured', function(HttpRequest $client): void {
-    $this->assertEquals('?' . http_build_query(['page' => 5, 'per_page' => 10, 'include_totals' => 'true'], '', '&', PHP_QUERY_RFC3986), $client->getParams());
+    expect($client->getParams())->toEqual('?' . http_build_query(['page' => 5, 'per_page' => 10, 'include_totals' => 'true'], '', '&', PHP_QUERY_RFC3986));
 })->with(['mocked client' => [
     function(): HttpRequest {
         $client = new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'get', '/' . uniqid());
@@ -46,7 +46,7 @@ it('adds classic pagination params when configured', function(HttpRequest $clien
 ]]);
 
 it('adds checkpoints pagination params when configured', function(HttpRequest $client): void {
-    $this->assertEquals('?' . http_build_query(['from' => 123456, 'take' => 25], '', '&', PHP_QUERY_RFC3986), $client->getParams());
+    expect($client->getParams())->toEqual('?' . http_build_query(['from' => 123456, 'take' => 25], '', '&', PHP_QUERY_RFC3986));
 })->with(['mocked client' => [
     function(): HttpRequest {
         $client = new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'get', '/' . uniqid());
@@ -56,7 +56,7 @@ it('adds checkpoints pagination params when configured', function(HttpRequest $c
 ]]);
 
 test('withParam() adds a parameter to the URL', function(string $parameter, string $value, HttpRequest $client): void {
-    $this->assertEquals('?' . $parameter . '=' . $value, $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('?' . $parameter . '=' . $value);
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => (string) uniqid(),
@@ -70,9 +70,9 @@ test('withParam() adds multiple parameters to the URL', function(array $paramete
         '&' . $parameters[2] . '=123',
     ];
 
-    $this->assertEquals($expectedParameterStrings[0], $client->withParam($parameters[0], $values[0])->getParams());
-    $this->assertEquals($expectedParameterStrings[0] . $expectedParameterStrings[1], $client->withParam($parameters[1], $values[1])->getParams());
-    $this->assertEquals($expectedParameterStrings[0] . $expectedParameterStrings[1] . $expectedParameterStrings[2], $client->withParam($parameters[2], $values[2])->getParams());
+    expect($client->withParam($parameters[0], $values[0])->getParams())->toEqual($expectedParameterStrings[0]);
+    expect($client->withParam($parameters[1], $values[1])->getParams())->toEqual($expectedParameterStrings[0] . $expectedParameterStrings[1]);
+    expect($client->withParam($parameters[2], $values[2])->getParams())->toEqual($expectedParameterStrings[0] . $expectedParameterStrings[1] . $expectedParameterStrings[2]);
 })->with(['mocked client and data' => [
     fn() => [(string) uniqid(), (string) uniqid(), (string) uniqid()],
     fn() => [(string) uniqid(), true, 123],
@@ -80,7 +80,7 @@ test('withParam() adds multiple parameters to the URL', function(array $paramete
 ]]);
 
 test('withParam() adds a parameter to the URL with a `true` value', function(string $parameter, bool $value, HttpRequest $client): void {
-    $this->assertEquals('?' . $parameter . '=true', $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('?' . $parameter . '=true');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => true,
@@ -88,7 +88,7 @@ test('withParam() adds a parameter to the URL with a `true` value', function(str
 ]]);
 
 test('withParam() adds a parameter to the URL with a `false` value', function(string $parameter, bool $value, HttpRequest $client): void {
-    $this->assertEquals('?' . $parameter . '=false', $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('?' . $parameter . '=false');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => false,
@@ -96,7 +96,7 @@ test('withParam() adds a parameter to the URL with a `false` value', function(st
 ]]);
 
 test('withParam() adds a parameter to the URL with an int value', function(string $parameter, int $value, HttpRequest $client): void {
-    $this->assertEquals('?' . $parameter . '=' . $value, $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('?' . $parameter . '=' . $value);
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => random_int(0, PHP_INT_MAX),
@@ -104,7 +104,7 @@ test('withParam() adds a parameter to the URL with an int value', function(strin
 ]]);
 
 test('withParam() skips adding parameters with empty values', function(string $parameter, string $value, HttpRequest $client): void {
-    $this->assertEquals('', $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => '',
@@ -112,7 +112,7 @@ test('withParam() skips adding parameters with empty values', function(string $p
 ]]);
 
 test('withParam() skips adding parameters with null values', function(string $parameter, ?string $value, HttpRequest $client): void {
-    $this->assertEquals('', $client->withParam($parameter, $value)->getParams());
+    expect($client->withParam($parameter, $value)->getParams())->toEqual('');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => null,
@@ -120,7 +120,7 @@ test('withParam() skips adding parameters with null values', function(string $pa
 ]]);
 
 test('withParam() replaces a parameter in the URL', function(string $parameter, string $value, string $replacementValue, HttpRequest $client): void {
-    $this->assertEquals('?' . $parameter . '=' . $replacementValue, $client->withParam($parameter, $value)->withParam($parameter, $replacementValue)->getParams());
+    expect($client->withParam($parameter, $value)->withParam($parameter, $replacementValue)->getParams())->toEqual('?' . $parameter . '=' . $replacementValue);
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => (string) uniqid(),
@@ -132,7 +132,7 @@ test('withFormParam() adds a form parameter to the request body with a `true` va
     $client->withFormParam($parameter, $value);
     $client->call();
 
-    $this->assertEquals($parameter . '=true', $client->getLastRequest()->getBody()->__toString());
+    expect($client->getLastRequest()->getBody()->__toString())->toEqual($parameter . '=true');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => true,
@@ -143,7 +143,7 @@ test('withFormParam() adds a form parameter to the request body with a `false` v
     $client->withFormParam($parameter, $value);
     $client->call();
 
-    $this->assertEquals($parameter . '=false', $client->getLastRequest()->getBody()->__toString());
+    expect($client->getLastRequest()->getBody()->__toString())->toEqual($parameter . '=false');
 })->with(['mocked client and data' => [
     fn() => (string) uniqid(),
     fn() => false,

--- a/tests/Unit/Utility/HttpResponsePaginatorTest.php
+++ b/tests/Unit/Utility/HttpResponsePaginatorTest.php
@@ -60,7 +60,7 @@ test('returns a count of 0 when there are no results', function(): void {
 
     $this->paginator = $sdk->getResponsePaginator();
 
-    $this->assertEquals(0, count($this->paginator));
+    expect(count($this->paginator))->toEqual(0);
 });
 
 test('returns a count when there are results', function(): void {
@@ -77,7 +77,7 @@ test('returns a count when there are results', function(): void {
     $sdk->users()->getAll([], $this->usePagination);
     $this->paginator = $sdk->getResponsePaginator();
 
-    $this->assertEquals(2, count($this->paginator));
+    expect(count($this->paginator))->toEqual(2);
 });
 
 test('throws an error when used with a non-GET endpoint', function(): void {
@@ -114,10 +114,10 @@ test('returns loaded results', function(): void {
     $sdk->users()->getAll([], $this->usePagination);
     $this->paginator = $sdk->getResponsePaginator();
 
-    $this->assertEquals(3, count($this->paginator));
+    expect(count($this->paginator))->toEqual(3);
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . ($index + 1), $result);
+        expect($result)->toEqual('user' . ($index + 1));
     }
 });
 
@@ -142,13 +142,13 @@ test('returns network requests for paginated results', function(): void {
     $sdk->users()->getAll();
     $this->paginator = $sdk->getResponsePaginator();
 
-    $this->assertEquals(4, count($this->paginator));
+    expect(count($this->paginator))->toEqual(4);
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . ($index + 1), $result);
+        expect($result)->toEqual('user' . ($index + 1));
     }
 
-    $this->assertEquals(1, $this->paginator->countNetworkRequests());
+    expect($this->paginator->countNetworkRequests())->toEqual(1);
 });
 
 test('ignores network errors and exits iteration', function(): void {
@@ -174,11 +174,11 @@ test('ignores network errors and exits iteration', function(): void {
     $this->paginator = $sdk->getResponsePaginator();
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('user' . ($index + 1), $result);
+        expect($result)->toEqual('user' . ($index + 1));
     }
 
-    $this->assertEquals(200, count($this->paginator));
-    $this->assertEquals(1, $this->paginator->countNetworkRequests());
+    expect(count($this->paginator))->toEqual(200);
+    expect($this->paginator->countNetworkRequests())->toEqual(1);
 });
 
 test('uses checkpoint pagination params when appropriate', function(): void {
@@ -202,10 +202,10 @@ test('uses checkpoint pagination params when appropriate', function(): void {
     $this->paginator = $sdk->getResponsePaginator();
 
     foreach ($this->paginator as $index => $result) {
-        $this->assertEquals('org' . ($index + 1), $result);
+        expect($result)->toEqual('org' . ($index + 1));
     }
 
-    $this->assertEquals(2, $this->paginator->countNetworkRequests());
+    expect($this->paginator->countNetworkRequests())->toEqual(2);
 
     $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
     $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_CANNOT_COUNT_CHECKPOINT_PAGINATION);

--- a/tests/Unit/Utility/HttpResponsePaginatorTest.php
+++ b/tests/Unit/Utility/HttpResponsePaginatorTest.php
@@ -16,11 +16,8 @@ beforeEach(function(): void {
 test('throws an error when paginating without any request prepared', function(): void {
     $sdk = (new MockManagementApi())->mock();
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
-
     $this->paginator = $sdk->getResponsePaginator();
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
 
 test('throws an error when attempting to initiate pagination on a failed network request', function(): void {
     $sdk = new MockManagementApi(null);
@@ -39,11 +36,8 @@ test('throws an error when attempting to initiate pagination on a failed network
         // Ignore the mocked network error.
     }
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
-
     $this->paginator = $sdk->getResponsePaginator();
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
 
 test('returns a count of 0 when there are no results', function(): void {
     $sdk = (new MockManagementApi([
@@ -84,21 +78,15 @@ test('throws an error when used with a non-GET endpoint', function(): void {
     $sdk = (new MockManagementApi())->mock();
     $sdk->users()->create(uniqid(), [uniqid()]);
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_METHOD_UNSUPPORTED);
-
     $this->paginator = $sdk->getResponsePaginator();
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_METHOD_UNSUPPORTED);
 
 test('throws an error when used with an unsupported endpoint', function(): void {
     $sdk = (new MockManagementApi())->mock();
     $sdk->logStreams()->getAll();
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
-
     $this->paginator = $sdk->getResponsePaginator();
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_BAD_RESPONSE);
 
 test('returns loaded results', function(): void {
     $sdk = (new MockManagementApi([
@@ -207,11 +195,8 @@ test('uses checkpoint pagination params when appropriate', function(): void {
 
     expect($this->paginator->countNetworkRequests())->toEqual(2);
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_CANNOT_COUNT_CHECKPOINT_PAGINATION);
-
     count($this->paginator);
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class, \Auth0\SDK\Exception\PaginatorException::MSG_HTTP_CANNOT_COUNT_CHECKPOINT_PAGINATION);
 
 test('throws an error if checkpoint pagination is used on an unsupported endpoint', function(): void {
     $sdk = (new MockManagementApi())->mock();
@@ -220,8 +205,5 @@ test('throws an error if checkpoint pagination is used on an unsupported endpoin
 
     $badEndpointPath = $sdk->getLastRequest()->getLastRequest()->getUri()->getPath();
 
-    $this->expectException(\Auth0\SDK\Exception\PaginatorException::class);
-    $this->expectExceptionMessage(sprintf(\Auth0\SDK\Exception\PaginatorException::MSG_HTTP_ENDPOINT_DOES_NOT_SUPPORT_CHECKPOINT_PAGINATION, $badEndpointPath));
-
     $this->paginator = $sdk->getResponsePaginator();
-});
+})->throws(\Auth0\SDK\Exception\PaginatorException::class);

--- a/tests/Unit/Utility/HttpResponsePaginatorTest.php
+++ b/tests/Unit/Utility/HttpResponsePaginatorTest.php
@@ -7,7 +7,7 @@ use Auth0\SDK\Utility\Request\RequestOptions;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Auth0\Tests\Utilities\MockManagementApi;
 
-uses()->group('network')->group('pagination');
+uses()->group('utility', 'utility.http_response_paginator', 'networking');
 
 beforeEach(function(): void {
     $this->usePagination = new RequestOptions(null, new PaginatedRequest(0, 1, true));

--- a/tests/Unit/Utility/HttpResponseTest.php
+++ b/tests/Unit/Utility/HttpResponseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\HttpResponse;
+use Psr\Http\Message\ResponseInterface;
+
+uses()->group('utility', 'utility.http_response', 'networking');
+
+test('getHeaders() returns the expected response', function(): void {
+    $response = Mockery::mock(ResponseInterface::class);
+    $response->shouldReceive('getStatusCode')->andReturn(200);
+    $response->shouldReceive('getHeaders')->andReturn(['X-TEST' => 'Testing']);
+    $response->shouldReceive('getBody')->andReturn('');
+
+    expect(HttpResponse::getHeaders($response))
+        ->toEqualCanonicalizing(['X-TEST' => 'Testing']);
+});

--- a/tests/Unit/Utility/HttpTelemetryTest.php
+++ b/tests/Unit/Utility/HttpTelemetryTest.php
@@ -19,20 +19,20 @@ test('setCorePackage() is assigned by default', function(): void {
     $this->assertArrayHasKey('env', $header_data);
     $this->assertArrayHasKey('php', $header_data['env']);
 
-    $this->assertEquals('auth0-php', $header_data['name']);
-    $this->assertEquals(Auth0::VERSION, $header_data['version']);
-    $this->assertEquals(phpversion(), $header_data['env']['php']);
+    expect($header_data['name'])->toEqual('auth0-php');
+    expect($header_data['version'])->toEqual(Auth0::VERSION);
+    expect($header_data['env']['php'])->toEqual(phpversion());
 });
 
 test('setCorePackage() restores default data correctly', function(): void {
     HttpTelemetry::setPackage('test_name', '1.2.3');
     $headers = HttpTelemetry::get();
 
-    $this->assertCount(3, $headers);
+    expect($headers)->toHaveCount(3);
     $this->assertArrayHasKey('name', $headers);
-    $this->assertEquals('test_name', $headers['name']);
+    expect($headers['name'])->toEqual('test_name');
     $this->assertArrayHasKey('version', $headers);
-    $this->assertEquals('1.2.3', $headers['version']);
+    expect($headers['version'])->toEqual('1.2.3');
 
     HttpTelemetry::setCorePackage();
     $header_data = HttpTelemetry::get();
@@ -42,20 +42,20 @@ test('setCorePackage() restores default data correctly', function(): void {
     $this->assertArrayHasKey('env', $header_data);
     $this->assertArrayHasKey('php', $header_data['env']);
 
-    $this->assertEquals('auth0-php', $header_data['name']);
-    $this->assertEquals(Auth0::VERSION, $header_data['version']);
-    $this->assertEquals(phpversion(), $header_data['env']['php']);
+    expect($header_data['name'])->toEqual('auth0-php');
+    expect($header_data['version'])->toEqual(Auth0::VERSION);
+    expect($header_data['env']['php'])->toEqual(phpversion());
 });
 
 test('setPackage() assigns data correctly', function(): void {
     HttpTelemetry::setPackage('test_name', '1.2.3');
     $headers = HttpTelemetry::get();
 
-    $this->assertCount(3, $headers);
+    expect($headers)->toHaveCount(3);
     $this->assertArrayHasKey('name', $headers);
-    $this->assertEquals('test_name', $headers['name']);
+    expect($headers['name'])->toEqual('test_name');
     $this->assertArrayHasKey('version', $headers);
-    $this->assertEquals('1.2.3', $headers['version']);
+    expect($headers['version'])->toEqual('1.2.3');
 });
 
 test('setEnvProperty() assigns data correctly', function(): void {
@@ -63,17 +63,17 @@ test('setEnvProperty() assigns data correctly', function(): void {
     $headers = HttpTelemetry::get();
 
     $this->assertArrayHasKey('env', $headers);
-    $this->assertCount(2, $headers['env']);
+    expect($headers['env'])->toHaveCount(2);
     $this->assertArrayHasKey('test_env_name', $headers['env']);
-    $this->assertEquals('2.3.4', $headers['env']['test_env_name']);
+    expect($headers['env']['test_env_name'])->toEqual('2.3.4');
 
     HttpTelemetry::setEnvProperty('test_env_name', '3.4.5');
     $headers = HttpTelemetry::get();
-    $this->assertEquals('3.4.5', $headers['env']['test_env_name']);
+    expect($headers['env']['test_env_name'])->toEqual('3.4.5');
 
     HttpTelemetry::setEnvProperty('test_env_name_2', '4.5.6');
     $headers = HttpTelemetry::get();
-    $this->assertEquals('4.5.6', $headers['env']['test_env_name_2']);
+    expect($headers['env']['test_env_name_2'])->toEqual('4.5.6');
 });
 
 test('setEnvironmentData() assigns data correctly', function(): void {
@@ -83,17 +83,17 @@ test('setEnvironmentData() assigns data correctly', function(): void {
     $headers = HttpTelemetry::get();
 
     $this->assertArrayHasKey('env', $headers);
-    $this->assertCount(1, $headers['env']);
+    expect($headers['env'])->toHaveCount(1);
     $this->assertArrayHasKey('test_env_name', $headers['env']);
-    $this->assertEquals('2.3.4', $headers['env']['test_env_name']);
+    expect($headers['env']['test_env_name'])->toEqual('2.3.4');
 
     HttpTelemetry::setEnvProperty('test_env_name', '3.4.5');
     $headers = HttpTelemetry::get();
-    $this->assertEquals('3.4.5', $headers['env']['test_env_name']);
+    expect($headers['env']['test_env_name'])->toEqual('3.4.5');
 
     HttpTelemetry::setEnvProperty('test_env_name_2', '4.5.6');
     $headers = HttpTelemetry::get();
-    $this->assertEquals('4.5.6', $headers['env']['test_env_name_2']);
+    expect($headers['env']['test_env_name_2'])->toEqual('4.5.6');
 });
 
 test('build() creates the expected header structure', function(): void {
@@ -110,5 +110,5 @@ test('build() creates the expected header structure', function(): void {
     HttpTelemetry::setEnvProperty('test_env_name_3', '6.7.8');
 
     $header_built = base64_decode(HttpTelemetry::build());
-    $this->assertEquals(json_encode($header_data), $header_built);
+    expect($header_built)->toEqual(json_encode($header_data));
 });

--- a/tests/Unit/Utility/HttpTelemetryTest.php
+++ b/tests/Unit/Utility/HttpTelemetryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Utility\HttpTelemetry;
 
-uses()->group('networking', 'utility', 'utility.http_telemetry');
+uses()->group('utility', 'utility.http_telemetry', 'networking');
 
 beforeEach(function(): void {
     HttpTelemetry::reset();

--- a/tests/Unit/Utility/HttpTelemetryTest.php
+++ b/tests/Unit/Utility/HttpTelemetryTest.php
@@ -2,101 +2,113 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\Utility;
-
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Utility\HttpTelemetry;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class InformationHeadersTest.
- */
-class HttpTelemetryTest extends TestCase
-{
-    /**
-     * Set the package data and make sure it's returned correctly.
-     */
-    public function testThatSetPackageSetsDataCorrectly(): void
-    {
-        HttpTelemetry::reset();
-        HttpTelemetry::setPackage('test_name', '1.2.3');
-        $headers = HttpTelemetry::get();
+uses()->group('networking', 'utility', 'utility.http_telemetry');
 
-        $this->assertCount(3, $headers);
-        $this->assertArrayHasKey('name', $headers);
-        $this->assertEquals('test_name', $headers['name']);
-        $this->assertArrayHasKey('version', $headers);
-        $this->assertEquals('1.2.3', $headers['version']);
+beforeEach(function(): void {
+    HttpTelemetry::reset();
+});
 
-        HttpTelemetry::reset();
-    }
+test('setCorePackage() is assigned by default', function(): void {
+    $header_data = HttpTelemetry::get();
 
-    /**
-     * Set and override an env property and make sure it's returned correctly.
-     */
-    public function testThatSetEnvPropertySetsDataCorrectly(): void
-    {
-        HttpTelemetry::reset();
-        HttpTelemetry::setEnvProperty('test_env_name', '2.3.4');
-        $headers = HttpTelemetry::get();
+    $this->assertArrayHasKey('name', $header_data);
+    $this->assertArrayHasKey('version', $header_data);
+    $this->assertArrayHasKey('env', $header_data);
+    $this->assertArrayHasKey('php', $header_data['env']);
 
-        $this->assertArrayHasKey('env', $headers);
-        $this->assertCount(2, $headers['env']);
-        $this->assertArrayHasKey('test_env_name', $headers['env']);
-        $this->assertEquals('2.3.4', $headers['env']['test_env_name']);
+    $this->assertEquals('auth0-php', $header_data['name']);
+    $this->assertEquals(Auth0::VERSION, $header_data['version']);
+    $this->assertEquals(phpversion(), $header_data['env']['php']);
+});
 
-        HttpTelemetry::setEnvProperty('test_env_name', '3.4.5');
-        $headers = HttpTelemetry::get();
-        $this->assertEquals('3.4.5', $headers['env']['test_env_name']);
+test('setCorePackage() restores default data correctly', function(): void {
+    HttpTelemetry::setPackage('test_name', '1.2.3');
+    $headers = HttpTelemetry::get();
 
-        HttpTelemetry::setEnvProperty('test_env_name_2', '4.5.6');
-        $headers = HttpTelemetry::get();
-        $this->assertEquals('4.5.6', $headers['env']['test_env_name_2']);
+    $this->assertCount(3, $headers);
+    $this->assertArrayHasKey('name', $headers);
+    $this->assertEquals('test_name', $headers['name']);
+    $this->assertArrayHasKey('version', $headers);
+    $this->assertEquals('1.2.3', $headers['version']);
 
-        HttpTelemetry::reset();
-    }
+    HttpTelemetry::setCorePackage();
+    $header_data = HttpTelemetry::get();
 
-    /**
-     * Set the package and env and make sure it's built correctly.
-     */
-    public function testThatBuildReturnsCorrectData(): void
-    {
-        HttpTelemetry::reset();
-        $header_data = [
-            'name' => 'test_name_2',
-            'version' => '5.6.7',
-            'env' => [
-                'php' => PHP_VERSION,
-                'test_env_name_3' => '6.7.8',
-            ],
-        ];
-        HttpTelemetry::setPackage($header_data['name'], $header_data['version']);
-        HttpTelemetry::setEnvProperty('test_env_name_3', '6.7.8');
+    $this->assertArrayHasKey('name', $header_data);
+    $this->assertArrayHasKey('version', $header_data);
+    $this->assertArrayHasKey('env', $header_data);
+    $this->assertArrayHasKey('php', $header_data['env']);
 
-        $header_built = base64_decode(HttpTelemetry::build());
-        $this->assertEquals(json_encode($header_data), $header_built);
+    $this->assertEquals('auth0-php', $header_data['name']);
+    $this->assertEquals(Auth0::VERSION, $header_data['version']);
+    $this->assertEquals(phpversion(), $header_data['env']['php']);
+});
 
-        HttpTelemetry::reset();
-    }
+test('setPackage() assigns data correctly', function(): void {
+    HttpTelemetry::setPackage('test_name', '1.2.3');
+    $headers = HttpTelemetry::get();
 
-    /**
-     * Check that setting the core package works correctly.
-     */
-    public function testThatCorePackageIsSet(): void
-    {
-        HttpTelemetry::reset();
-        HttpTelemetry::setCorePackage();
-        $header_data = HttpTelemetry::get();
+    $this->assertCount(3, $headers);
+    $this->assertArrayHasKey('name', $headers);
+    $this->assertEquals('test_name', $headers['name']);
+    $this->assertArrayHasKey('version', $headers);
+    $this->assertEquals('1.2.3', $headers['version']);
+});
 
-        $this->assertArrayHasKey('name', $header_data);
-        $this->assertArrayHasKey('version', $header_data);
-        $this->assertArrayHasKey('env', $header_data);
-        $this->assertArrayHasKey('php', $header_data['env']);
+test('setEnvProperty() assigns data correctly', function(): void {
+    HttpTelemetry::setEnvProperty('test_env_name', '2.3.4');
+    $headers = HttpTelemetry::get();
 
-        $this->assertEquals('auth0-php', $header_data['name']);
-        $this->assertEquals(Auth0::VERSION, $header_data['version']);
-        $this->assertEquals(phpversion(), $header_data['env']['php']);
+    $this->assertArrayHasKey('env', $headers);
+    $this->assertCount(2, $headers['env']);
+    $this->assertArrayHasKey('test_env_name', $headers['env']);
+    $this->assertEquals('2.3.4', $headers['env']['test_env_name']);
 
-        HttpTelemetry::reset();
-    }
-}
+    HttpTelemetry::setEnvProperty('test_env_name', '3.4.5');
+    $headers = HttpTelemetry::get();
+    $this->assertEquals('3.4.5', $headers['env']['test_env_name']);
+
+    HttpTelemetry::setEnvProperty('test_env_name_2', '4.5.6');
+    $headers = HttpTelemetry::get();
+    $this->assertEquals('4.5.6', $headers['env']['test_env_name_2']);
+});
+
+test('setEnvironmentData() assigns data correctly', function(): void {
+    HttpTelemetry::setEnvironmentData([
+        'test_env_name' => '2.3.4'
+    ]);
+    $headers = HttpTelemetry::get();
+
+    $this->assertArrayHasKey('env', $headers);
+    $this->assertCount(1, $headers['env']);
+    $this->assertArrayHasKey('test_env_name', $headers['env']);
+    $this->assertEquals('2.3.4', $headers['env']['test_env_name']);
+
+    HttpTelemetry::setEnvProperty('test_env_name', '3.4.5');
+    $headers = HttpTelemetry::get();
+    $this->assertEquals('3.4.5', $headers['env']['test_env_name']);
+
+    HttpTelemetry::setEnvProperty('test_env_name_2', '4.5.6');
+    $headers = HttpTelemetry::get();
+    $this->assertEquals('4.5.6', $headers['env']['test_env_name_2']);
+});
+
+test('build() creates the expected header structure', function(): void {
+    $header_data = [
+        'name' => 'test_name_2',
+        'version' => '5.6.7',
+        'env' => [
+            'php' => PHP_VERSION,
+            'test_env_name_3' => '6.7.8',
+        ],
+    ];
+
+    HttpTelemetry::setPackage($header_data['name'], $header_data['version']);
+    HttpTelemetry::setEnvProperty('test_env_name_3', '6.7.8');
+
+    $header_built = base64_decode(HttpTelemetry::build());
+    $this->assertEquals(json_encode($header_data), $header_built);
+});

--- a/tests/Unit/Utility/PKCETest.php
+++ b/tests/Unit/Utility/PKCETest.php
@@ -17,7 +17,7 @@ test('generateCodeVerifier() generates a value of an expected length', function(
     $code_verifier = PKCE::generateCodeVerifier(43);
 
     $this->assertNotEmpty($code_verifier);
-    $this->assertEquals(43, mb_strlen($code_verifier));
+    expect(mb_strlen($code_verifier))->toEqual(43);
 });
 
 test('generateCodeChallenge() generates an expected value', function(): void {
@@ -26,5 +26,5 @@ test('generateCodeChallenge() generates an expected value', function(): void {
     $code_challenge = PKCE::generateCodeChallenge($codeVerifier);
 
     $this->assertNotEmpty($code_challenge);
-    $this->assertEquals('f3X4JO4FpNodO254hdZAMCYKE4fzFn8ezYlLUr5qjH4', $code_challenge);
+    expect($code_challenge)->toEqual('f3X4JO4FpNodO254hdZAMCYKE4fzFn8ezYlLUr5qjH4');
 });

--- a/tests/Unit/Utility/PKCETest.php
+++ b/tests/Unit/Utility/PKCETest.php
@@ -2,35 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Auth0\Tests\Unit\Utility;
-
 use Auth0\SDK\Utility\PKCE;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class PKCETest.
- */
-class PKCETest extends TestCase
-{
-    public function testThatGenerateCodeVerifierThrowsExceptionWhenLengthIsInvalid(): void
-    {
-        $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-        $this->expectExceptionMessage(\Auth0\SDK\Exception\ArgumentException::MSG_PKCE_CODE_VERIFIER_LENGTH);
-        PKCE::generateCodeVerifier(10);
-    }
+uses()->group('pkce', 'utility', 'utility.pkce');
 
-    public function testThatGenerateCodeVerifierGenerateExpectedValue(): void
-    {
-        $code_verifier = PKCE::generateCodeVerifier(43);
-        $this->assertNotEmpty($code_verifier);
-        $this->assertSame(43, mb_strlen($code_verifier));
-    }
+test('generateCodeVerifier() throws an exception when an invalid length is used', function(): void {
+    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
+    $this->expectExceptionMessage(\Auth0\SDK\Exception\ArgumentException::MSG_PKCE_CODE_VERIFIER_LENGTH);
 
-    public function testThanGenerateCodeChallengeGenerateExpectedValue(): void
-    {
-        $codeVerifier = 'Q6D5aiJHs6QdEILJoCz5pFw3Wmi9UiP8ovQbvlgd3Gc';
-        $code_challenge = PKCE::generateCodeChallenge($codeVerifier);
-        $this->assertNotEmpty($code_challenge);
-        $this->assertSame('f3X4JO4FpNodO254hdZAMCYKE4fzFn8ezYlLUr5qjH4', $code_challenge);
-    }
-}
+    PKCE::generateCodeVerifier(10);
+});
+
+test('generateCodeVerifier() generates a value of an expected length', function(): void {
+    $code_verifier = PKCE::generateCodeVerifier(43);
+
+    $this->assertNotEmpty($code_verifier);
+    $this->assertEquals(43, mb_strlen($code_verifier));
+});
+
+test('generateCodeChallenge() generates an expected value', function(): void {
+    $codeVerifier = 'Q6D5aiJHs6QdEILJoCz5pFw3Wmi9UiP8ovQbvlgd3Gc';
+
+    $code_challenge = PKCE::generateCodeChallenge($codeVerifier);
+
+    $this->assertNotEmpty($code_challenge);
+    $this->assertEquals('f3X4JO4FpNodO254hdZAMCYKE4fzFn8ezYlLUr5qjH4', $code_challenge);
+});

--- a/tests/Unit/Utility/PKCETest.php
+++ b/tests/Unit/Utility/PKCETest.php
@@ -7,7 +7,6 @@ use Auth0\SDK\Utility\PKCE;
 uses()->group('utility', 'utility.pkce');
 
 test('generateCodeVerifier() throws an exception when an invalid length is used', function(): void {
-
     PKCE::generateCodeVerifier(10);
 })->throws(\Auth0\SDK\Exception\ArgumentException::class, \Auth0\SDK\Exception\ArgumentException::MSG_PKCE_CODE_VERIFIER_LENGTH);
 

--- a/tests/Unit/Utility/PKCETest.php
+++ b/tests/Unit/Utility/PKCETest.php
@@ -7,11 +7,9 @@ use Auth0\SDK\Utility\PKCE;
 uses()->group('utility', 'utility.pkce');
 
 test('generateCodeVerifier() throws an exception when an invalid length is used', function(): void {
-    $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);
-    $this->expectExceptionMessage(\Auth0\SDK\Exception\ArgumentException::MSG_PKCE_CODE_VERIFIER_LENGTH);
 
     PKCE::generateCodeVerifier(10);
-});
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, \Auth0\SDK\Exception\ArgumentException::MSG_PKCE_CODE_VERIFIER_LENGTH);
 
 test('generateCodeVerifier() generates a value of an expected length', function(): void {
     $code_verifier = PKCE::generateCodeVerifier(43);

--- a/tests/Unit/Utility/PKCETest.php
+++ b/tests/Unit/Utility/PKCETest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Auth0\SDK\Utility\PKCE;
 
-uses()->group('pkce', 'utility', 'utility.pkce');
+uses()->group('utility', 'utility.pkce');
 
 test('generateCodeVerifier() throws an exception when an invalid length is used', function(): void {
     $this->expectException(\Auth0\SDK\Exception\ArgumentException::class);

--- a/tests/Unit/Utility/Request/FilteredRequestTest.php
+++ b/tests/Unit/Utility/Request/FilteredRequestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Request\FilteredRequest;
+
+uses()->group('utility', 'utility.request', 'utility.request.request_options', 'utility.request.request_options.filtered_request');
+
+test('setFields() works as expected', function(): void {
+    $filters = new FilteredRequest();
+
+    $filters->setFields(['a', 'b', 'c']);
+
+    expect($filters->getFields())->toEqualCanonicalizing(['a', 'b', 'c']);
+});
+
+test('clearFields() works as expected', function(): void {
+    $filters = new FilteredRequest();
+
+    $filters->setFields(['a', 'b', 'c']);
+    $filters->clearFields();
+
+    expect($filters->getFields())->toBeNull();
+});
+
+test('setIncludeFields() works as expected', function(): void {
+    $filters = new FilteredRequest();
+
+    $filters->setIncludeFields(true);
+    expect($filters->getIncludeFields())->toBeTrue();
+
+    $filters->setIncludeFields(false);
+    expect($filters->getIncludeFields())->toBeFalse();
+
+    $filters->setIncludeFields(null);
+    expect($filters->getIncludeFields())->toBeNull();
+});

--- a/tests/Unit/Utility/Request/PaginatedRequestTest.php
+++ b/tests/Unit/Utility/Request/PaginatedRequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Request\PaginatedRequest;
+
+uses()->group('utility', 'utility.request', 'utility.request.request_options', 'utility.request.request_options.paginated_request');
+
+test('setPage() and getPage() work as expected', function(): void {
+    $filters = new PaginatedRequest();
+
+    $filters->setPage(5);
+    expect($filters->getPage())->toEqual(5);
+});
+
+test('setPerPage() and getPerPage() work as expected', function(): void {
+    $filters = new PaginatedRequest();
+
+    $filters->setPerPage(5);
+    expect($filters->getPerPage())->toEqual(5);
+});
+
+test('setFrom() and getFrom() work as expected', function(): void {
+    $filters = new PaginatedRequest();
+
+    $filters->setFrom('test');
+    expect($filters->getFrom())->toEqual('test');
+});
+
+test('setTake() and getTake() work as expected', function(): void {
+    $filters = new PaginatedRequest();
+
+    $filters->setTake(5);
+    expect($filters->getTake())->toEqual(5);
+});
+
+test('setIncludeTotals() works as expected', function(): void {
+    $filters = new PaginatedRequest();
+
+    $filters->setIncludeTotals(true);
+    expect($filters->getIncludeTotals())->toBeTrue();
+
+    $filters->setIncludeTotals(false);
+    expect($filters->getIncludeTotals())->toBeFalse();
+
+    $filters->setIncludeTotals(null);
+    expect($filters->getIncludeTotals())->toBeNull();
+});

--- a/tests/Unit/Utility/Request/RequestOptionsTest.php
+++ b/tests/Unit/Utility/Request/RequestOptionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Request\FilteredRequest;
+use Auth0\SDK\Utility\Request\PaginatedRequest;
+use Auth0\SDK\Utility\Request\RequestOptions;
+
+uses()->group('utility', 'utility.request', 'utility.request.request_options');
+
+test('setFields() accepts a `FilteredRequest` instance', function(): void {
+    $filters = new FilteredRequest();
+    $request = new RequestOptions();
+
+    $request->setFields($filters);
+
+    expect($request->getFields())->toEqual($filters);
+});
+
+test('setPagination() accepts a `PaginatedRequest` instance', function(): void {
+    $pagination = new PaginatedRequest();
+    $request = new RequestOptions();
+
+    $request->setPagination($pagination);
+
+    expect($request->getPagination())->toEqual($pagination);
+});

--- a/tests/Unit/Utility/Toolkit/AssertTest.php
+++ b/tests/Unit/Utility/Toolkit/AssertTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Toolkit;
+
+uses()->group('utility', 'utility.toolkit', 'utility.toolkit.assert');
+
+test('isPermissions() throws an exception if value is not an array', function(): void {
+    $permissions = true;
+
+    Toolkit::assert([
+        [$permissions, new \Exception('foobar')],
+    ])->isPermissions();
+})->throws(\Exception::class, 'foobar');
+
+test('isPermissions() throws an exception if value is an empty array', function(): void {
+    $permissions = [];
+
+    Toolkit::assert([
+        [$permissions, new \Exception('foobar')],
+    ])->isPermissions();
+})->throws(\Exception::class, 'foobar');
+
+test('isPermissions() throws an exception if a value does not have `permission_name`', function(): void {
+    $permissions = [
+        [
+            'permission_name' => 'Testing',
+            'resource_server_identifier' => uniqid()
+        ],
+        [
+            'resource_server_identifier' => uniqid()
+        ]
+    ];
+
+    Toolkit::assert([
+        [$permissions, new \Exception('foobar')],
+    ])->isPermissions();
+})->throws(\Exception::class, 'foobar');
+
+test('isPermissions() throws an exception if a value does not have `resource_server_identifier`', function(): void {
+    $permissions = [
+        [
+            'permission_name' => 'Testing',
+            'resource_server_identifier' => uniqid()
+        ],
+        [
+            'permission_name' => 'Testing'
+        ]
+    ];
+
+    Toolkit::assert([
+        [$permissions, new \Exception('foobar')],
+    ])->isPermissions();
+})->throws(\Exception::class, 'foobar');
+
+test('isString() throws an exception if value is not a string', function(): void {
+    Toolkit::assert([
+        [true, new \Exception('foobar')],
+    ])->isString();
+})->throws(\Exception::class, 'foobar');
+
+test('isString() throws an exception if value is an empty string', function(): void {
+    Toolkit::assert([
+        ['', new \Exception('foobar')],
+    ])->isString();
+})->throws(\Exception::class, 'foobar');
+
+test('isArray() throws an exception if value is not an array', function(): void {
+    Toolkit::assert([
+        [true, new \Exception('foobar')],
+    ])->isArray();
+})->throws(\Exception::class, 'foobar');
+
+test('isArray() throws an exception if value is an empty array', function(): void {
+    Toolkit::assert([
+        [[], new \Exception('foobar')],
+    ])->isArray();
+})->throws(\Exception::class, 'foobar');

--- a/tests/Unit/Utility/Toolkit/Filter/ArrayFilterTest.php
+++ b/tests/Unit/Utility/Toolkit/Filter/ArrayFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Toolkit;
+
+uses()->group('utility', 'utility.toolkit', 'utility.toolkit.filter', 'utility.toolkit.filter.array');
+
+test('first() skips non-array values', function(): void {
+    $items = [[], null, [true]];
+
+    $result = Toolkit::filter($items)->array()->first(new \Exception('foo'));
+
+    expect($result)->toEqual([true]);
+});
+
+test('empty() returns an empty array when its values are null', function(): void {
+    $items = [[], null, [true]];
+
+    $result = Toolkit::filter($items)->array()->empty();
+
+    expect($result)->toEqual([null, null, [true]]);
+});
+

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -84,7 +84,7 @@ test('some() does not throw an error if some values are null, and removes keys w
     $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
     $expected = ['a' => 'Testing', 'b' => 123];
 
-    [$result] = Toolkit::some(new \Exception('foobar'), $items);
+    $result = Toolkit::some(new \Exception('foobar'), ...$items);
 
     expect($result)->toEqual($expected);
 });
@@ -92,7 +92,7 @@ test('some() does not throw an error if some values are null, and removes keys w
 test('some() returns false if all values are null when no exception is provided', function(): void {
     $items = ['a' => null, 'b' => null, 'c' => null];
 
-    $result = Toolkit::some(null, $items);
+    $result = Toolkit::some(null, ...$items);
 
     expect($result)->toBeFalse();
 });
@@ -100,5 +100,5 @@ test('some() returns false if all values are null when no exception is provided'
 test('some() throws an error if all values are null', function(): void {
     $items = ['a' => null, 'b' => null, 'c' => null];
 
-    Toolkit::some(new \Exception('foobar'), $items);
+    Toolkit::some(new \Exception('foobar'), ...$items);
 })->throws(\Exception::class, 'foobar');

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -59,7 +59,7 @@ test('merge() merges two or more arrays and ignores items with null values', fun
 });
 
 test('every() returns true if no value is false', function(): void {
-    $items = ['a' => 'Testing', 'b' => 123, 'c' => uniqid()];
+    $items = ['Testing', 123, uniqid()];
 
     $result = Toolkit::every(null, ...$items);
 
@@ -67,13 +67,13 @@ test('every() returns true if no value is false', function(): void {
 });
 
 test('every() throws an error if any value is null', function(): void {
-    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
+    $items = ['Testing', 123, null];
 
     Toolkit::every(new \Exception('foobar'), ...$items);
 })->throws(\Exception::class, 'foobar');
 
 test('every() returns false if any value is null when no exception is provided', function(): void {
-    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
+    $items = ['Testing', 123, null];
 
     $result = Toolkit::every(null, ...$items);
 
@@ -81,8 +81,8 @@ test('every() returns false if any value is null when no exception is provided',
 });
 
 test('some() does not throw an error if some values are null, and removes keys with null values in the response', function(): void {
-    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
-    $expected = ['a' => 'Testing', 'b' => 123];
+    $items = ['Testing', 123, null];
+    $expected = ['Testing', 123];
 
     $result = Toolkit::some(new \Exception('foobar'), ...$items);
 
@@ -90,7 +90,7 @@ test('some() does not throw an error if some values are null, and removes keys w
 });
 
 test('some() returns false if all values are null when no exception is provided', function(): void {
-    $items = ['a' => null, 'b' => null, 'c' => null];
+    $items = [null, null, null];
 
     $result = Toolkit::some(null, ...$items);
 
@@ -98,7 +98,7 @@ test('some() returns false if all values are null when no exception is provided'
 });
 
 test('some() throws an error if all values are null', function(): void {
-    $items = ['a' => null, 'b' => null, 'c' => null];
+    $items = [null, null, null];
 
     Toolkit::some(new \Exception('foobar'), ...$items);
 })->throws(\Exception::class, 'foobar');

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Utility\Toolkit;
+
+uses()->group('utility', 'utility.toolkit');
+
+// beforeEach(function(): void {
+//     $this->toolkit = Toolkit
+// });
+
+test('assert() returns an instance of \Auth0\SDK\Utility\Toolkit\Assert', function(): void {
+    expect(Toolkit::assert([1,2,3]))->toBeInstanceOf(\Auth0\SDK\Utility\Toolkit\Assert::class);
+});
+
+test('filter() returns an instance of \Auth0\SDK\Utility\Toolkit\Filter', function(): void {
+    expect(Toolkit::filter([1,2,3]))->toBeInstanceOf(\Auth0\SDK\Utility\Toolkit\Filter::class);
+});
+
+test('times() runs a function a number of times', function(): void {
+    $times = 0;
+
+    Toolkit::times(5, function() use (&$times) {
+        $times++;
+    });
+
+    expect($times)->toEqual(5);
+});
+
+test('each() passes each item in an array through a function', function(): void {
+    $items = ['a', 'b', 'c'];
+
+    Toolkit::each($items, function(&$item, $key) {
+        $item = $item . $key;
+    });
+
+    expect($items)->toEqual(['a0', 'b1', 'c2']);
+});
+
+test('each() will break loop if false is returned', function(): void {
+    $items = ['a', 'b', 'c'];
+
+    Toolkit::each($items, function(&$item, $key) {
+        $item = $item . $key;
+        return false;
+    });
+
+    expect($items)->toEqual(['a0', 'b', 'c']);
+});
+
+test('merge() merges two or more arrays and ignores items with null values', function(): void {
+    $array1 = ['a' => 'string test', 'b' => 123456, 'c' => null];
+    $array2 = ['b' => 654321, 'a' => null];
+
+    $final = Toolkit::merge($array1, $array2);
+
+    expect($final)->toEqual(['b' => 654321, 'a' => 'string test']);
+});
+
+test('every() returns true if no value is false', function(): void {
+    $items = ['a' => 'Testing', 'b' => 123, 'c' => uniqid()];
+
+    $result = Toolkit::every(null, ...$items);
+
+    expect($result)->toBeTrue();
+});
+
+test('every() throws an error if any value is null', function(): void {
+    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
+
+    Toolkit::every(new \Exception('foobar'), ...$items);
+})->throws(\Exception::class, 'foobar');
+
+test('every() returns false if any value is null when no exception is provided', function(): void {
+    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
+
+    $result = Toolkit::every(null, ...$items);
+
+    expect($result)->toBeFalse();
+});
+
+test('some() does not throw an error if some values are null, and removes keys with null values in the response', function(): void {
+    $items = ['a' => 'Testing', 'b' => 123, 'c' => null];
+    $expected = ['a' => 'Testing', 'b' => 123];
+
+    [$result] = Toolkit::some(new \Exception('foobar'), $items);
+
+    expect($result)->toEqual($expected);
+});
+
+test('some() returns false if all values are null when no exception is provided', function(): void {
+    $items = ['a' => null, 'b' => null, 'c' => null];
+
+    $result = Toolkit::some(null, $items);
+
+    expect($result)->toBeFalse();
+});
+
+test('some() throws an error if all values are null', function(): void {
+    $items = ['a' => null, 'b' => null, 'c' => null];
+
+    Toolkit::some(new \Exception('foobar'), $items);
+})->throws(\Exception::class, 'foobar');

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -61,7 +61,7 @@ test('merge() merges two or more arrays and ignores items with null values', fun
 test('every() returns true if no value is false', function(): void {
     $items = ['Testing', 123, uniqid()];
 
-    $result = Toolkit::every(null, ...$items);
+    $result = Toolkit::every(null, $items);
 
     expect($result)->toBeTrue();
 });
@@ -69,13 +69,13 @@ test('every() returns true if no value is false', function(): void {
 test('every() throws an error if any value is null', function(): void {
     $items = ['Testing', 123, null];
 
-    Toolkit::every(new \Exception('foobar'), ...$items);
+    Toolkit::every(new \Exception('foobar'), $items);
 })->throws(\Exception::class, 'foobar');
 
 test('every() returns false if any value is null when no exception is provided', function(): void {
     $items = ['Testing', 123, null];
 
-    $result = Toolkit::every(null, ...$items);
+    $result = Toolkit::every(null, $items);
 
     expect($result)->toBeFalse();
 });
@@ -84,7 +84,7 @@ test('some() does not throw an error if some values are null, and removes keys w
     $items = ['Testing', 123, null];
     $expected = ['Testing', 123];
 
-    $result = Toolkit::some(new \Exception('foobar'), ...$items);
+    $result = Toolkit::some(new \Exception('foobar'), $items);
 
     expect($result)->toEqual($expected);
 });
@@ -92,7 +92,7 @@ test('some() does not throw an error if some values are null, and removes keys w
 test('some() returns false if all values are null when no exception is provided', function(): void {
     $items = [null, null, null];
 
-    $result = Toolkit::some(null, ...$items);
+    $result = Toolkit::some(null, $items);
 
     expect($result)->toBeFalse();
 });
@@ -100,5 +100,5 @@ test('some() returns false if all values are null when no exception is provided'
 test('some() throws an error if all values are null', function(): void {
     $items = [null, null, null];
 
-    Toolkit::some(new \Exception('foobar'), ...$items);
+    Toolkit::some(new \Exception('foobar'), $items);
 })->throws(\Exception::class, 'foobar');

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -6,10 +6,6 @@ use Auth0\SDK\Utility\Toolkit;
 
 uses()->group('utility', 'utility.toolkit');
 
-// beforeEach(function(): void {
-//     $this->toolkit = Toolkit
-// });
-
 test('assert() returns an instance of \Auth0\SDK\Utility\Toolkit\Assert', function(): void {
     expect(Toolkit::assert([1,2,3]))->toBeInstanceOf(\Auth0\SDK\Utility\Toolkit\Assert::class);
 });

--- a/tests/Unit/Utility/TransientStoreHandlerTest.php
+++ b/tests/Unit/Utility/TransientStoreHandlerTest.php
@@ -20,13 +20,13 @@ beforeEach(function(): void {
 });
 
 test('getStore() returns the assigned storage instance', function(): void {
-    $this->assertEquals($this->store, $this->transient->getStore());
+    expect($this->transient->getStore())->toEqual($this->store);
 });
 
 test('store() assigns data correctly', function(string $key, string $value): void {
     $this->transient->store($key, $value);
 
-    $this->assertEquals($value, $this->store->get($key));
+    expect($this->store->get($key))->toEqual($value);
 })->with(['random data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -35,8 +35,8 @@ test('store() assigns data correctly', function(string $key, string $value): voi
 test('issue() assigns data correctly', function(string $key): void {
     $value = $this->transient->issue($key);
 
-    $this->assertEquals($value, $this->store->get($key));
-    $this->assertGreaterThanOrEqual(16, mb_strlen($value));
+    expect($this->store->get($key))->toEqual($value);
+    expect(mb_strlen($value))->toBeGreaterThanOrEqual(16);
 })->with(['random key' => [
     fn() => uniqid(),
 ]]);
@@ -44,10 +44,10 @@ test('issue() assigns data correctly', function(string $key): void {
 test('getOnce() assigns data correctly and is only retrievable once', function(string $key, string $value): void {
     $this->transient->store($key, $value);
 
-    $this->assertEquals($value, $this->store->get($key));
-    $this->assertEquals($value, $this->transient->getOnce($key));
-    $this->assertNull($this->transient->getOnce($key));
-    $this->assertNull($this->store->get($key));
+    expect($this->store->get($key))->toEqual($value);
+    expect($this->transient->getOnce($key))->toEqual($value);
+    expect($this->transient->getOnce($key))->toBeNull();
+    expect($this->store->get($key))->toBeNull();
 })->with(['random data' => [
     fn() => uniqid(),
     fn() => uniqid(),
@@ -56,25 +56,25 @@ test('getOnce() assigns data correctly and is only retrievable once', function(s
 test('verify() correctly verifies data', function(string $key, string $value): void {
     $this->transient->store($key, $value);
 
-    $this->assertTrue($this->transient->verify($key, $value));
-    $this->assertFalse($this->transient->verify($key, $value));
-    $this->assertNull($this->transient->getOnce($key));
-    $this->assertNull($this->store->get($key));
+    expect($this->transient->verify($key, $value))->toBeTrue();
+    expect($this->transient->verify($key, $value))->toBeFalse();
+    expect($this->transient->getOnce($key))->toBeNull();
+    expect($this->store->get($key))->toBeNull();
 })->with(['random data' => [
     fn() => uniqid(),
     fn() => uniqid(),
 ]]);
 
 test('isset() returns correct state', function(string $key, string $value): void {
-    $this->assertFalse($this->transient->isset($key));
+    expect($this->transient->isset($key))->toBeFalse();
 
     $this->transient->store($key, $value);
 
-    $this->assertTrue($this->transient->isset($key));
+    expect($this->transient->isset($key))->toBeTrue();
 
     $this->transient->getOnce($key);
 
-    $this->assertFalse($this->transient->isset($key));
+    expect($this->transient->isset($key))->toBeFalse();
 })->with(['random data' => [
     fn() => uniqid(),
     fn() => uniqid(),

--- a/tests/Unit/Utility/TransientStoreHandlerTest.php
+++ b/tests/Unit/Utility/TransientStoreHandlerTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Store\InMemoryStorage;
+use Auth0\SDK\Store\MemoryStore;
 use Auth0\SDK\Utility\TransientStoreHandler;
 
 uses()->group('networking', 'utility', 'utility.http_telemetry');
@@ -15,7 +15,7 @@ beforeEach(function(): void {
         'strategy' => 'none',
     ]);
 
-    $this->store = new InMemoryStorage($this->configuration, $this->namespace);
+    $this->store = new MemoryStore($this->configuration, $this->namespace);
     $this->transient = new TransientStoreHandler($this->store);
 });
 

--- a/tests/Unit/Utility/TransientStoreHandlerTest.php
+++ b/tests/Unit/Utility/TransientStoreHandlerTest.php
@@ -6,7 +6,7 @@ use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Store\MemoryStore;
 use Auth0\SDK\Utility\TransientStoreHandler;
 
-uses()->group('networking', 'utility', 'utility.http_telemetry');
+uses()->group('utility', 'utility.transient_store_handler');
 
 beforeEach(function(): void {
     $this->namespace = uniqid();

--- a/tests/Utilities/MockApi.php
+++ b/tests/Utilities/MockApi.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Auth0\Tests\Utilities;
 
 use Auth0\SDK\Utility\HttpClient;
-use Http\Discovery\Psr18ClientDiscovery;
-use Http\Discovery\Strategy\MockClientStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -28,9 +26,6 @@ abstract class MockApi
     public function __construct(
         ?array $responses = []
     ) {
-        // Allow mock HttpClient to be auto-discovered for use in testing.
-        Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);
-
         // Create an instance of the intended API.
         $this->setClient();
 

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -4,14 +4,36 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Utilities;
 
+use DomainException;
 use Firebase\JWT\JWT;
+use stdClass;
 
 /**
  * Class TokenGenerator.
  */
 class TokenGenerator
 {
-    protected static function getClaims(
+    public const ALG_RS256 = 1;
+    public const ALG_HS256 = 2;
+
+    public const TOKEN_ID = 1;
+    public const TOKEN_ACCESS = 2;
+
+    protected static function getAccessTokenClaims(
+        array $overrides
+    ): array {
+        $defaults = [
+            'aud' => '__test_client_id__',
+            'nonce' => '__test_nonce__',
+            'auth_time' => time() - 100,
+            'exp' => time() + 1000,
+            'iat' => time() - 1000,
+        ];
+
+        return array_merge($defaults, $overrides);
+    }
+
+    protected static function getIdTokenClaims(
         array $overrides
     ): array {
         $defaults = [
@@ -22,6 +44,7 @@ class TokenGenerator
             'auth_time' => time() - 100,
             'exp' => time() + 1000,
             'iat' => time() - 1000,
+            'azp' => '__test_azp__'
         ];
 
         return array_merge($defaults, $overrides);
@@ -53,7 +76,7 @@ class TokenGenerator
         string $key = '__test_client_secret__',
         $headers = []
     ): string {
-        $claims = self::getClaims($claims);
+        $claims = self::getIdTokenClaims($claims);
         return JWT::encode($claims, $key, 'HS256', null, $headers + ['alg' => 'HS256']);
     }
 
@@ -62,7 +85,7 @@ class TokenGenerator
         ?string $privateKey = null,
         $headers = []
     ): string {
-        $claims = self::getClaims($claims);
+        $claims = self::getIdTokenClaims($claims);
 
         if ($privateKey === null) {
             $rsaKeyPair = self::generateRsaKeyPair();
@@ -84,4 +107,71 @@ class TokenGenerator
 
         return $decoded;
     }
+
+    public static function create(
+        int $tokenType = self::TOKEN_ID,
+        int $algorithm = self::ALG_RS256,
+        array $claims = [],
+        array $headers = []
+    ): TokenGeneratorResponse {
+        $keys = null;
+
+        if ($tokenType === self::TOKEN_ACCESS) {
+            $claims = self::getAccessTokenClaims($claims);
+        }
+
+        if ($tokenType === self::TOKEN_ID) {
+            $claims = self::getIdTokenClaims($claims);
+        }
+
+        if ($algorithm === self::ALG_RS256) {
+            $keys = self::generateRsaKeyPair();
+            $headers = array_merge(['kid' => '__test_kid__'], $headers);
+            $token = self::withRs256($claims, $keys['private'], $headers);
+            $keys['cert'] = trim(mb_substr($keys['cert'], strpos($keys['cert'], "\n")+1));
+            $keys['cert'] = str_replace("\n", '', mb_substr($keys['cert'], 0, strrpos($keys['cert'], "\n")));
+        }
+
+        if ($algorithm === self::ALG_HS256) {
+            $token = self::withHs256($claims, '__test_client_secret__', $headers);
+        }
+
+        [$headers, $claims, $signature] = explode('.', $token);
+        $payload = join('.', [$headers, $claims]);
+        $signature = (string) TokenGenerator::decodePart($signature, false);
+        $claims = (array) TokenGenerator::decodePart($claims, true);
+        $headers = (array) TokenGenerator::decodePart($headers, true);
+
+        $response = new TokenGeneratorResponse();
+        $response->algorithm = $algorithm;
+        $response->keys = $keys;
+        $response->token = $token;
+        $response->payload = $payload;
+        $response->signature = $signature;
+        $response->headers = $headers;
+        $response->claims = $claims;
+        $response->jwks = 'https://test.auth0.com/.well-known/jwks.json';
+        $response->cache = hash('sha256', 'https://test.auth0.com/.well-known/jwks.json');
+
+        return $response;
+    }
+
+    public static function break(
+        TokenGeneratorResponse $token
+    ): TokenGeneratorResponse {
+        return $token;
+    }
+}
+
+class TokenGeneratorResponse extends \stdClass
+{
+    public int $algorithm;
+    public ?array $keys;
+    public string $token;
+    public string $payload;
+    public mixed $signature;
+    public array $headers;
+    public array $claims;
+    public string $jwks;
+    public string $cache;
 }

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Utilities;
 
-use DomainException;
 use Firebase\JWT\JWT;
-use stdClass;
 
 /**
  * Class TokenGenerator.
@@ -55,6 +53,27 @@ class TokenGenerator
         $privateKeyResource = openssl_pkey_new([
             'digest_alg' => 'sha256',
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        openssl_pkey_export($privateKeyResource, $privateKey);
+        $publicKey = openssl_pkey_get_details($privateKeyResource);
+
+        $resCsr = openssl_csr_new([], $privateKeyResource);
+        $resCert = openssl_csr_sign($resCsr, null, $privateKeyResource, 30);
+        openssl_x509_export($resCert, $x509);
+
+        return [
+            'private' => $privateKey,
+            'public' => $publicKey['key'],
+            'cert' => $x509,
+        ];
+    }
+
+    public static function generateDsaKeyPair(): array
+    {
+        $privateKeyResource = openssl_pkey_new([
+            'digest_alg' => 'sha256',
+            'private_key_type' => OPENSSL_KEYTYPE_DSA,
         ]);
 
         openssl_pkey_export($privateKeyResource, $privateKey);

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -169,7 +169,7 @@ class TokenGeneratorResponse extends \stdClass
     public ?array $keys;
     public string $token;
     public string $payload;
-    public mixed $signature;
+    public $signature;
     public array $headers;
     public array $claims;
     public string $jwks;

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -169,7 +169,7 @@ class TokenGeneratorResponse extends \stdClass
     public ?array $keys;
     public string $token;
     public string $payload;
-    public $signature;
+    public string $signature;
     public array $headers;
     public array $claims;
     public string $jwks;


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

Although this PR is large and intimidating to look it, it doesn't change anything regarding the logic of the SDK. Its purpose is to expand the unit tests to 100% coverage of the v8 SDK, and to update our unit test syntax to the modern Pest format we had already adopted with our newer test additions in v8.

The highlighted intent of this pull request:

- Expands the test coverage of our unit tests for 8.0 to 100%
- Rebuilds our legacy PHPUnit tests using [the modern Pest test framework](https://pestphp.com/) syntax
- Adopts [expectations](https://pestphp.com/docs/expectations) and [higher order tests](https://pestphp.com/docs/higher-order-tests)
- Adds the [`pest-plugin-parallel`](https://github.com/pestphp/pest-plugin-parallel) plugin for improved performance by running tests in parallel
- Adds [`hyperf/event`](https://packagist.org/packages/hyperf/event) to dev dependencies for thorough PSR-4 unit testing

Other tweaks in this PR of note:
- Renamed the newly contributed `InMemoryStorage` class to `MemoryStore` to match the naming convention of other storage classes. As it is new to v8, this is not a breaking change.
- References to the internal `httpClient` var in the `ManagementEndpoint` class now use the public `getHttpClient()` method to ensure the HTTP client is properly instantiated before its use.
- Renamed the methods on `Auth0\SDK\API\Management\Tenants` to match the naming conventions of other Management classes, which follow the naming conventions of the endpoints themselves.
- Fixed a bug with `handleInvitation()` on the `Auth0\SDK\Auth0` in which the login URL was not properly returned.
- Added an argument to `clear()` on `Auth0\SDK\Auth0` to opt out of clearing transient storage, in the event we're only needing to wipe out a stale user session to make way for a new one during code exchange.
- Added an argument to `getRequestParameter()` on `Auth0\SDK\Auth0` to support applying different internal PHP sanitization filters.
- Removed some unnecessary code from `SdkConfiguration` which is now handled by improved type checking in `ConfigurableMixin`.
- Added support for mocked HTTP responses to `TokenVerifier` for unit testing purposes.
- Added code coverage metablocks in fringe portions of the SDK that cannot be tested (for example in the event a PHP runtime was built to [not return it's version](https://www.php.net/manual/en/function.phpversion.php#refsect1-function.phpversion-returnvalues), or isn't compiled with OpenSSL, etc.)
- Made some bug fixes to the `Toolkit` in regard to object referencing.

### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

Tests can be run locally using `composer run tests`, or in a Docker container using `composer run tests:docker`.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
