### PR TITLE
[SDK-2757] Improve support for custom domain configurations

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -166,7 +166,7 @@ final class Management
         // If no token was provided or available from cache, try to get one.
         if ($managementToken === null && $this->configuration->hasClientSecret()) {
             $authentication = $authentication ?? new Authentication($this->configuration);
-            $response = $authentication->clientCredentials(['audience' => $this->configuration->formatDomain() . '/api/v2/']);
+            $response = $authentication->clientCredentials(['audience' => $this->configuration->formatDomain(true) . '/api/v2/']);
 
             if (HttpResponse::wasSuccessful($response)) {
                 $response = HttpResponse::decodeContent($response);

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -32,6 +32,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method SdkConfiguration setClientId(?string $clientId = null)
  * @method SdkConfiguration setClientSecret(?string $clientSecret = null)
  * @method SdkConfiguration setDomain(?string $domain = null)
+ * @method SdkConfiguration setCustomDomain(?string $customDomain = null)
  * @method SdkConfiguration setEventListenerProvider(?ListenerProviderInterface $eventListenerProvider = null)
  * @method SdkConfiguration setHttpClient(?ClientInterface $httpClient = null)
  * @method SdkConfiguration setHttpMaxRetries(int $httpMaxRetires = 3)
@@ -73,6 +74,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method string|null getClientId(?\Throwable $exceptionIfNull = null)
  * @method string|null getClientSecret(?\Throwable $exceptionIfNull = null)
  * @method string|string getDomain(?\Throwable $exceptionIfNull = null)
+ * @method string|string getCustomDomain(?\Throwable $exceptionIfNull = null)
  * @method ListenerProviderInterface|null getEventListenerProvider(?\Throwable $exceptionIfNull = null)
  * @method ClientInterface|null getHttpClient(?\Throwable $exceptionIfNull = null)
  * @method int getHttpMaxRetries()
@@ -114,6 +116,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method bool hasClientId()
  * @method bool hasClientSecret()
  * @method bool hasDomain()
+ * @method bool hasCustomDomain()
  * @method bool hasEventListenerProvider()
  * @method bool hasHttpClient()
  * @method bool hasHttpMaxRetries()
@@ -163,7 +166,8 @@ final class SdkConfiguration implements ConfigurableContract
      *
      * @param array<mixed>|null              $configuration         An key-value array matching this constructor's arguments. Overrides any other passed arguments with the same key name.
      * @param string|null                    $strategy              Defaults to 'webapp'. Should be assigned either 'api', 'management', or 'webapp' to specify the type of application the SDK is being applied to. Determines what configuration options will be required at initialization.
-     * @param string|null                    $domain                Auth0 domain for your tenant.
+     * @param string|null                    $domain                Auth0 domain for your tenant, found in your Auth0 Application settings.
+     * @param string|null                    $customDomain          If you have configured Auth0 to use a custom domain, configure it here.
      * @param string|null                    $clientId              Client ID, found in the Auth0 Application settings.
      * @param string|null                    $redirectUri           Authentication callback URI, as defined in your Auth0 Application settings.
      * @param string|null                    $clientSecret          Client Secret, found in the Auth0 Application settings.
@@ -209,6 +213,7 @@ final class SdkConfiguration implements ConfigurableContract
         ?array $configuration = null,
         ?string $strategy = 'webapp',
         ?string $domain = null,
+        ?string $customDomain = null,
         ?string $clientId = null,
         ?string $redirectUri = null,
         ?string $clientSecret = null,
@@ -258,11 +263,30 @@ final class SdkConfiguration implements ConfigurableContract
     }
 
     /**
+     * Return the configured custom or tenant domain, formatted with protocol.
+     *
+     * @param bool $forceTenantDomain Force the return of the tenant domain even if a custom domain is configured.
+     */
+    public function formatDomain(
+        bool $forceTenantDomain = false
+    ): string {
+        if ($this->hasCustomDomain() && ! $forceTenantDomain) {
+            return 'https://' . $this->getCustomDomain();
+        }
+
+        return 'https://' . $this->getDomain();
+    }
+
+    /**
      * Return the configured domain with protocol.
      */
-    public function formatDomain(): string
+    public function formatCustomDomain(): ?string
     {
-        return 'https://' . $this->getDomain();
+        if ($this->hasCustomDomain()) {
+            return 'https://' . $this->getCustomDomain();
+        }
+
+        return null;
     }
 
     /**

--- a/src/Token.php
+++ b/src/Token.php
@@ -133,7 +133,7 @@ final class Token
         ?int $tokenLeeway = null,
         ?int $tokenNow = null
     ): self {
-        $tokenIssuer = $tokenIssuer ?? 'https://' . $this->configuration->getDomain() . '/';
+        $tokenIssuer = $tokenIssuer ?? $this->configuration->formatDomain() . '/';
         $tokenAudience = $tokenAudience ?? $this->configuration->getAudience() ?? [];
         $tokenOrganization = $tokenOrganization ?? $this->configuration->getOrganization() ?? null;
         $tokenNonce = $tokenNonce ?? null;

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -271,6 +271,68 @@ test('formatDomain() returns a properly formatted uri', function(): void
     expect($sdk->formatDomain())->toEqual('https://' . $domain);
 });
 
+test('formatDomain() returns the custom domain when a custom domain is configured', function(): void
+{
+    $domain = uniqid();
+    $customDomain = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'customDomain' => $customDomain,
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid(),
+    ]);
+
+    expect($sdk->formatDomain())->toEqual('https://' . $customDomain);
+});
+
+test('formatDomain() returns the tenant domain even when a custom domain is configured if `forceTenantDomain` argument is `true`', function(): void
+{
+    $domain = uniqid();
+    $customDomain = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'customDomain' => $customDomain,
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid(),
+    ]);
+
+    expect($sdk->formatDomain(true))->toEqual('https://' . $domain);
+});
+
+test('formatCustomDomain() returns a properly formatted uri', function(): void
+{
+    $domain = uniqid();
+    $customDomain = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'customDomain' => $customDomain,
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid(),
+    ]);
+
+    expect($sdk->formatCustomDomain())->toEqual('https://' . $customDomain);
+});
+
+test('formatCustomDomain() returns null when a custom domain is not configured', function(): void
+{
+    $domain = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid(),
+    ]);
+
+    expect($sdk->formatCustomDomain())->toBeNull();
+});
+
 test('formatScope() returns an empty string when there are no scopes defined', function(): void
 {
     $sdk = new SdkConfiguration([


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

A community GitHub issue was reported (#538) in which Management SDK calls don't work with custom domains "out of the box." After some testing, I confirmed our current handling of the single-use `domain` configuration option in both the stable and upcoming release of the PHP are not adequate to cover the needs of custom domain users.

In particular, without providing a means of specifying both the tenant domain and a custom domain, Management SDK calls will be broken unless the customer writes custom code exchange boilerplate because of the reasons outlined here: https://auth0.com/docs/brand-and-customize/custom-domains#step-3-complete-feature-specific-setup

This PR adds a new configuration option, `customDomain`. When this is configured, the SDK will automatically adapt API calls and Token verifications to ensure the appropriate domains are used at the appropriate times. This fixes out-of-the-box Management SDK calls and provides a clearer API by explicitly separating the definitions of tenant domain and custom domain during configuration.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #538

### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

- Test coverage was added for the changes.
- All tests pass with 100% coverage.
- Run `composer run tests` or `composer run tests:docker` to run these tests locally, or review the CircleCI tests ran on this PR.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
