### PR TITLE
Fix typo in @param annotation, spelled @oaram

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -202,7 +202,7 @@ final class Auth0
     /**
      * Delete any persistent data and clear out all stored properties.
      *
-     * @oaram bool $transient When true, data in transient storage is also cleared.
+     * @param bool $transient When true, data in transient storage is also cleared.
      */
     public function clear(
         bool $transient = true


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

This causes `\Doctrine\Common\Annotations\AnnotationReader` to raise a `\Doctrine\Common\Annotations\AnnotationException` trying to load the class `oaram`.

Fixing the typo allows the Doctrine's `AnnotationReader` to ignore the `param` annotation by default.

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #557 

### Testing

This change needs integration tests to be assessed. However, you could reproduce the issue executing (as described in #557):

```php
use Doctrine\Common\Annotations\AnnotationReader;
use Auth0\SDK\Auth0;

$reader = new AnnotationReader();
$method = new ReflectionMethod(Auth0::class, 'clear');

$reader->getMethodAnnotations($method);
```

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
