### PR TITLE
[SDK-2776] Separate session-establishing code exchange behavior from state-retrieval methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The following options are available for your configuration:
 ↗ [Find PSR-17 HTTP factory libraries on Packagist.](https://packagist.org/search/?query=PSR-17&type=library&tags=psr%2017)<br />
 ↗ [Find PSR-18 HTTP client libraries on Packagist.](https://packagist.org/search/?query=PSR-18&type=library&tags=psr%2018)
 
-### Getting an active session
+### Checking for an active session
 
 ```PHP
 <?php
@@ -224,27 +224,11 @@ The following options are available for your configuration:
 $session = $auth0->getCredentials();
 
 if ($session !== null) {
-    // The Id Token for the user as a string.
-    $idToken = $session->idToken;
-
-    // The Access Token for the user, as a string.
-    $accessToken = $session->accessToken;
-
-    // A Unix timestamp representing when the Access Token is expected to expire, as an int.
-    $accessTokenExpiration = $session->accessTokenExpiration;
-
-    // A bool; if time() is greater than the value of $accessTokenExpiration, this will be true.
-    $accessTokenExpired = $session->accessTokenExpired;
-
-    // A Refresh Token, if available, as a string.
-    $refreshToken = $session->refreshToken;
-
-    // Data about the user as an array.
-    $user = $session->user;
+    // The user is signed in.
 }
 ```
 
-### Logging in
+### Authorizing User
 
 ```PHP
 <?php
@@ -258,6 +242,28 @@ if ($session === null) {
     // They are not. Redirect the end user to the login page.
     header('Location: ' . $auth0->login());
     exit;
+}
+```
+
+### Requesting Tokens
+
+After a user successfully authenticates with Auth0 from the step above, they'll be returned to your application with the `state` and `code` URL parameters necessary to request a token. This is the last step in finalizing the user session.
+
+```PHP
+<?php
+
+// 🧩 Include the configuration code from the 'SDK Initialization' step above here.
+
+$session = $auth0->getCredentials();
+
+// Is this end-user already signed in?
+if ($session === null && isset($_GET['code']) && isset($_GET['state'])) {
+    if ($auth0->exchange() === false) {
+        die("Authentication failed.");
+    }
+
+    // Authentication complete!
+    print_r($auth0->getUser());
 }
 ```
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -283,22 +283,29 @@ final class Auth0
      * Exchange authorization code for access, ID, and refresh tokens.
      *
      * @param string|null $redirectUri  Optional. Redirect URI sent with authorize request. Defaults to the SDK's configured redirectUri.
+     * @param string|null $code         Optional. The value of the `code` parameter. One will be extracted from $_GET if not specified.
+     * @param string|null $state        Optional. The value of the `state` parameter. One will be extracted from $_GET if not specified.
      *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
+     * @throws \Auth0\SDK\Exception\StateException   If the code value is missing from the request parameters.
+     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing from the request parameters, or otherwise invalid.
      * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
      * @link https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
      */
     public function exchange(
-        ?string $redirectUri = null
+        ?string $redirectUri = null,
+        ?string $code = null,
+        ?string $state = null
     ): bool {
-        $this->deferStateSaving();
+        [$redirectUri, $code, $state] = Toolkit::filter([$redirectUri, $code, $state])->string()->trim();
 
-        $code = $this->getRequestParameter('code');
-        $state = $this->getRequestParameter('state');
+        $code = $code ?? $this->getRequestParameter('code');
+        $state = $state ?? $this->getRequestParameter('state');
         $codeVerifier = null;
         $user = null;
+
+        $this->deferStateSaving();
 
         if ($code === null) {
             $this->clear();

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -631,7 +631,25 @@ final class Auth0
     }
 
     /**
-     * Get the invitation details GET request
+     * Get the code exchange details from the GET request
+     */
+    public function getExchangeParameters(): ?object
+    {
+        $code = $this->getRequestParameter('code');
+        $state = $this->getRequestParameter('state');
+
+        if ($code !== null && $state !== null) {
+            return (object) [
+                'code' => $code,
+                'state' => $state
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the invitation details from the GET request
      */
     public function getInvitationParameters(): ?object
     {

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -446,107 +446,59 @@ final class Auth0
     }
 
     /**
-     * Get ID token from persisted session or from a code exchange
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * Get ID token from an active session
      */
     public function getIdToken(): ?string
     {
-        if (! $this->getState()->hasIdToken()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getIdToken();
     }
 
     /**
-     * Get userinfo from persisted session or from a code exchange
+     * Get userinfo from an active session
      *
      * @return array<string,array|int|string>|null
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getUser(): ?array
     {
-        if (! $this->getState()->hasUser()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getUser();
     }
 
     /**
-     * Get access token from persisted session or from a code exchange
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * Get access token from an active session
      */
     public function getAccessToken(): ?string
     {
-        if (! $this->getState()->hasAccessToken()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getAccessToken();
     }
 
     /**
-     * Get refresh token from persisted session or from a code exchange
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * Get refresh token from an active session
      */
     public function getRefreshToken(): ?string
     {
-        if (! $this->getState()->hasRefreshToken()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getRefreshToken();
     }
 
     /**
-     * Get token expiration from persisted session or from a code exchange
+     * Get token scopes from an active session
      *
      * @return array<string>
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      */
     public function getAccessTokenScope(): ?array
     {
-        if (! $this->getState()->hasAccessTokenScope()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getAccessTokenScope();
     }
 
     /**
-     * Get token expiration from persisted session or from a code exchange
-     *
-     * @throws \Auth0\SDK\Exception\StateException   If the state value is missing or invalid.
-     * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
-     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     * Get token expiration from an active session
      */
     public function getAccessTokenExpiration(): ?int
     {
-        if (! $this->getState()->hasAccessTokenExpiration()) {
-            $this->exchange();
-        }
-
         return $this->getState()->getAccessTokenExpiration();
     }
 
     /**
-     * Sets, validates, and persists the ID token.
+     * Updates the active session's stored Id Token.
      *
      * @param string $idToken Id token returned from the code exchange.
      */

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -301,7 +301,8 @@ final class Auth0
         $user = null;
 
         if ($code === null) {
-            return false;
+            $this->clear();
+            throw \Auth0\SDK\Exception\StateException::missingCode();
         }
 
         $this->clear(false);

--- a/src/Exception/StateException.php
+++ b/src/Exception/StateException.php
@@ -10,6 +10,7 @@ namespace Auth0\SDK\Exception;
 final class StateException extends \Exception implements Auth0Exception
 {
     public const MSG_INVALID_STATE = 'Invalid state';
+    public const MSG_MISSING_CODE = 'Missing code';
     public const MSG_MISSING_CODE_VERIFIER = 'Missing code_verifier';
     public const MSG_BAD_ACCESS_TOKEN = 'Invalid access_token';
     public const MSG_MISSING_NONCE = 'Nonce was not found in the application storage';
@@ -21,6 +22,12 @@ final class StateException extends \Exception implements Auth0Exception
         ?\Throwable $previous = null
     ): self {
         return new self(self::MSG_INVALID_STATE, 0, $previous);
+    }
+
+    public static function missingCode(
+        ?\Throwable $previous = null
+    ): self {
+        return new self(self::MSG_MISSING_CODE, 0, $previous);
     }
 
     public static function missingCodeVerifier(

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -391,10 +391,10 @@ test('decode() throws an exception when `org_id` does not match `organization` c
     $auth0->decode($token);
 })->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
-test('exchange() returns false if no code is present', function(): void {
+test('exchange() throws an exception if no code is present', function(): void {
     $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-    expect($auth0->exchange())->toBeFalse();
-});
+    $auth0->exchange();
+})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_MISSING_CODE);
 
 test('exchange() returns false if no nonce is stored', function(): void {
     $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();
@@ -702,54 +702,6 @@ test('getCredentials() returns the expected object structure when a session is a
 
     expect($credentials->user)->toBeArray();
 });
-
-test('getIdToken() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getIdToken();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
-test('getUser() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getUser();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
-test('getRefreshToken() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getRefreshToken();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
-test('getAccessToken() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getAccessToken();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
-test('getAccessTokenScope() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getAccessTokenScope();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
-
-test('getAccessTokenExpiration() performs an exchange if a session is not available', function(): void {
-    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
-
-    $_GET['code'] = uniqid();
-
-    $auth0->getAccessTokenExpiration();
-})->throws(\Auth0\SDK\Exception\StateException::class, \Auth0\SDK\Exception\StateException::MSG_INVALID_STATE);
 
 test('setIdToken() properly stores data', function(): void {
     $token = (new \Auth0\Tests\Utilities\TokenGenerator())->withHs256();

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -770,3 +770,28 @@ test('getInvitationParameters() does not return invalid request parameters', fun
 
     $this->assertIsNotObject($auth0->getInvitationParameters());
 });
+
+test('getExchangeParameters() returns request parameters when valid', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = uniqid();
+
+    $extracted = $auth0->getExchangeParameters();
+
+    $this->assertIsObject($extracted, 'Invitation parameters were not extracted from the $_GET (environment variable seeded with query parameters during a GET request) successfully.');
+
+    $this->assertObjectHasAttribute('code', $extracted);
+    $this->assertObjectHasAttribute('state', $extracted);
+
+    expect($extracted->code)->toEqual($_GET['code']);
+    expect($extracted->state)->toEqual($_GET['state']);
+});
+
+test('getExchangeParameters() does not return invalid request parameters', function(): void {
+    $auth0 = new \Auth0\SDK\Auth0($this->configuration);
+
+    $_GET['code'] = 123;
+
+    $this->assertIsNotObject($auth0->getExchangeParameters());
+});


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->
Previously, in SDK v7, the local state-retrieval methods (such as `getUser()`) would invoke a code exchange (internally calling `exchange()`) whenever a session was not available, whether it was desired or not. This new major is a good opportunity to clear up the confusion and problem points this presented. This PR changes this behavior to make the exchange expressly opt-in, and separates the state-retrieval from the session-establishing exchange code.

In v7:
```php
try {
    $profile = $auth0->getUser(); // This implicitly causes all host application code that retrieves the user state to act like a de facto callback route.
} catch (\Auth0\SDK\Exception\CoreException $e) {
    die("getUser() would require boilerplate around every call to properly handle instances where an exchange unexpectedly failed.");
    $this->logout();
}

if (! $profile) {
    auth()->login();
    exit;
}

echo "Authenticated.";
print_r($profile);
```

In v8, following this PR:
```php
$session = $auth0->getCredentials();

if ($session === null) {
    if ($auth0->getExchangeParameters() !== null) {
        $auth0->exchange();
    } else {
        header("Location: " . $auth->login());
        exit;
    }
}

echo "Authenticated.";
print_r($auth0->getUser());
```
### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

- Tests have been added and updated to cover these changes.
- All tests pass with 100% coverage.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
