### PR TITLE
[SDK-2780] Update PHPDoc method comments' API links for v8 GA

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -415,6 +415,9 @@ final class Authentication
      * @throws \Auth0\SDK\Exception\ConfigurationException When a Client Secret is not configured.
      * @throws \Auth0\SDK\Exception\ConfigurationException When a redirect uri is not configured.
      * @throws \Auth0\SDK\Exception\NetworkException       When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/authentication#authorization-code-flow45
+     * @link https://auth0.com/docs/api/authentication#authorization-code-flow-with-pkce46
      */
     public function codeExchange(
         string $code,
@@ -453,6 +456,9 @@ final class Authentication
      * @throws \Auth0\SDK\Exception\ConfigurationException When a Client ID is not configured.
      * @throws \Auth0\SDK\Exception\ConfigurationException When a Client Secret is not configured.
      * @throws \Auth0\SDK\Exception\NetworkException       When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/authentication#resource-owner-password
+     * @link https://auth0.com/docs/authorization/flows/resource-owner-password-flow
      */
     public function login(
         string $username,
@@ -490,7 +496,8 @@ final class Authentication
      * @throws \Auth0\SDK\Exception\ConfigurationException When a Client Secret is not configured.
      * @throws \Auth0\SDK\Exception\NetworkException       When the API request fails due to a network error.
      *
-     * @link https://auth0.com/docs/api-auth/grant/password
+     * @link https://auth0.com/docs/api/authentication#resource-owner-password
+     * @link https://auth0.com/docs/authorization/flows/resource-owner-password-flow
      */
     public function loginWithDefaultDirectory(
         string $username,
@@ -522,7 +529,8 @@ final class Authentication
      * @throws \Auth0\SDK\Exception\ConfigurationException When a Client Secret is not configured.
      * @throws \Auth0\SDK\Exception\NetworkException       When the API request fails due to a network error.
      *
-     * @link https://auth0.com/docs/api-auth/grant/client-credentials
+     * @link https://auth0.com/docs/api/authentication#client-credentials-flow
+     * @link https://auth0.com/docs/authorization/flows/client-credentials-flow
      */
     public function clientCredentials(
         ?array $params = null,

--- a/src/API/Management/EmailTemplates.php
+++ b/src/API/Management/EmailTemplates.php
@@ -116,7 +116,7 @@ final class EmailTemplates extends ManagementEndpoint
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `templateName` or `body` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
      *
-     * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
+     * @link https://auth0.com/docs/api/management/v2#!/Email_Templates/put_email_templates_by_templateName
      */
     public function update(
         string $templateName,

--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -29,6 +29,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` or `displayName` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/post_organizations
      */
     public function create(
         string $name,
@@ -69,6 +71,8 @@ final class Organizations extends ManagementEndpoint
      * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
      *
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations
      */
     public function getAll(
         ?RequestOptions $options = null
@@ -89,6 +93,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations_by_id
      */
     public function get(
         string $id,
@@ -116,6 +122,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `name` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name
      */
     public function getByName(
         string $name,
@@ -148,6 +156,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `displayName` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/patch_organizations_by_id
      */
     public function update(
         string $id,
@@ -191,6 +201,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/delete_organizations_by_id
      */
     public function delete(
         string $id,
@@ -220,6 +232,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/post_enabled_connections
      */
     public function addEnabledConnection(
         string $id,
@@ -260,6 +274,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections
      */
     public function getEnabledConnections(
         string $id,
@@ -288,6 +304,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections_by_connectionId
      */
     public function getEnabledConnection(
         string $id,
@@ -319,6 +337,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/patch_enabled_connections_by_connectionId
      */
     public function updateEnabledConnection(
         string $id,
@@ -352,6 +372,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `connectionId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/delete_enabled_connections_by_connectionId
      */
     public function removeEnabledConnection(
         string $id,
@@ -382,6 +404,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `members` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/post_members
      */
     public function addMembers(
         string $id,
@@ -420,6 +444,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_members
      */
     public function getMembers(
         string $id,
@@ -448,6 +474,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `members` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/delete_members
      */
     public function removeMembers(
         string $id,
@@ -488,6 +516,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `userId`, or `roles` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/post_organization_member_roles
      */
     public function addMemberRoles(
         string $id,
@@ -529,6 +559,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `userId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_organization_member_roles
      */
     public function getMemberRoles(
         string $id,
@@ -560,6 +592,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `userId`, or `roles` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/delete_organization_member_roles
      */
     public function removeMemberRoles(
         string $id,
@@ -606,6 +640,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id`, `clientId`, `inviter`, or `invitee` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/post_invitations
      */
     public function createInvitation(
         string $id,
@@ -659,6 +695,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations
      */
     public function getInvitations(
         string $id,
@@ -687,6 +725,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `invitationId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations_by_invitation_id
      */
     public function getInvitation(
         string $id,
@@ -717,6 +757,8 @@ final class Organizations extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` or `invitationId` are provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Organizations/delete_invitations_by_invitation_id
      */
     public function deleteInvitation(
         string $id,

--- a/src/API/Management/Tickets.php
+++ b/src/API/Management/Tickets.php
@@ -62,6 +62,8 @@ final class Tickets extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `body` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change
      */
     public function createPasswordChange(
         array $body,

--- a/src/API/Management/UserBlocks.php
+++ b/src/API/Management/UserBlocks.php
@@ -25,6 +25,8 @@ final class UserBlocks extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks_by_id
      */
     public function get(
         string $id,
@@ -52,6 +54,8 @@ final class UserBlocks extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks_by_id
      */
     public function delete(
         string $id,
@@ -79,6 +83,8 @@ final class UserBlocks extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `identifier` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks
      */
     public function getByIdentifier(
         string $identifier,
@@ -107,6 +113,8 @@ final class UserBlocks extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `identifier` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks
      */
     public function deleteByIdentifier(
         string $identifier,

--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -96,6 +96,8 @@ final class Users extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id
      */
     public function get(
         string $id,
@@ -514,6 +516,8 @@ final class Users extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `id` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Users/get_user_organizations
      */
     public function getOrganizations(
         string $id,

--- a/src/API/Management/UsersByEmail.php
+++ b/src/API/Management/UsersByEmail.php
@@ -25,6 +25,8 @@ final class UsersByEmail extends ManagementEndpoint
      *
      * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `email` is provided.
      * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
      */
     public function get(
         string $email,

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -288,7 +288,7 @@ final class Auth0
      * @throws \Auth0\SDK\Exception\StateException   If access token is missing from the response.
      * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
      *
-     * @link https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
+     * @link https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow
      */
     public function exchange(
         ?string $redirectUri = null


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->
In preparation for GA, this PR includes minor updates to existing, as well as the new additions of, @\link metalinks in PHPDoc function methods to the relevant API documentation on the website. It ensures all PHPDoc @\link's inherited from v7 are up-to-date.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
