### PR TITLE
[SDK-2828] Update CI to test against 8.1.0RC3 and use CircleCI matrix jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ commands:
       - run:
           name: Configure pcov
           command: |
+            apk add autoconf
             pecl install pcov
             docker-php-ext-enable pcov
 
@@ -62,7 +63,7 @@ commands:
     steps:
       - run:
           name: Run static code analysis (Psalm)
-          command: php -d memory_limit=2G ./vendor/bin/psalm --threads=$(nproc)
+          command: php -d memory_limit=2G ./vendor/bin/psalm
 
   run-pest:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
   setup-composer:
     steps:
       - run:
-          name: Install COMPOSER
+          name: Install dependencies
           command: |
             EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
@@ -42,7 +42,7 @@ commands:
   setup-pcov:
     steps:
       - run:
-          name: Configure PCOV
+          name: Configure pcov
           command: |
             pecl install pcov
             docker-php-ext-enable pcov
@@ -50,7 +50,7 @@ commands:
   setup-snyk:
     steps:
       - run:
-          name: Configure SNYK
+          name: Configure snyk
           command: |
             npm install -g snyk
 
@@ -129,7 +129,7 @@ jobs:
       - run-infection
 
 workflows:
-  tests:
+  test:
     jobs:
       - php:
           matrix:
@@ -140,12 +140,9 @@ workflows:
             parameters:
               php: ["7.4"]
       - snyk:
+          type: approval
           matrix:
             parameters:
               php: ["7.4", "8.0"]
           context:
             - snyk-env
-          filters:
-            branches:
-              only:
-                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ commands:
 
       - checkout
 
-  setup-composer:
-    steps:
       - run:
           name: Install dependencies
           command: |
@@ -93,7 +91,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
       - run-phpinsights
   phpstan:
     parameters:
@@ -103,7 +100,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
       - run-phpstan
   psalm:
     parameters:
@@ -113,7 +109,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
       - run-psalm
   pest:
     parameters:
@@ -123,7 +118,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
       - setup-pcov
       - run-pest
   snyk:
@@ -134,8 +128,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
-      - setup-snyk
       - run-snyk
   infection:
     parameters:
@@ -145,7 +137,6 @@ jobs:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
       - setup
-      - setup-composer
       - setup-pcov
       - run-infection
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,8 @@ version: 2.1
 commands:
   prepare:
     parameters:
-      php:
+      php-version:
         type: string
-      composer:
-        type: string
-      cache:
-        type: integer
 
     steps:
       - run:
@@ -19,97 +15,41 @@ commands:
       - checkout
 
       - run:
-          name: Prepare environment
-          command: |
-            mkdir -p /root/project/php-ext-cache
-            mkdir -p /root/project/npm-cache
-            mkdir -p /usr/local/lib/node_modules
-
-      - restore_cache:
-          keys:
-            - PHP<< parameters.php >>-{{ checksum "composer.json" }}-<< parameters.cache >>
-
-      - run:
           name: Configure environment
           command: |
-            PHP_EXT_DIR=$(php-config --extension-dir)
-            NPM_MODULES=$(npm root -g)
-
-            find /root/project/php-ext-cache/ -name '*.so' -exec cp -prv '{}' ${PHP_EXT_DIR}/ ';'
-            cp -a /root/project/npm-cache/. ${NPM_MODULES}
-
-            if [ ! -f ${PHP_EXT_DIR}/pcov.so ]; then
-                pecl install pcov
-            fi
-
-            if [ ! -f ${PHP_EXT_DIR}/posix.so ]; then
-                docker-php-ext-install posix
-            fi
-
-            if [ ! -f ${PHP_EXT_DIR}/pcntl.so ]; then
-                docker-php-ext-install pcntl
-            fi
-
-            if [ ! -f ${PHP_EXT_DIR}/mbstring.so ]; then
-                docker-php-ext-install mbstring
-            fi
+            pecl install pcov
+            docker-php-ext-install posix
+            docker-php-ext-install pcntl
+            docker-php-ext-install mbstring
 
             docker-php-ext-enable pcov posix pcntl mbstring
 
       - run:
           name: Install dependencies
           command: |
-            if [ `npm list -g | grep -c snyk` -eq 0 ]; then
-              npm install -g snyk
-            else
-              npm update -g
+            npm install -g snyk
+
+            EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+            if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+                >&2 echo 'ERROR: Invalid installer checksum'
+                rm composer-setup.php
+                exit 1
             fi
 
-            if [ ! -f composer.phar ]; then
-              EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-              php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-              ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+            php composer-setup.php --quiet
+            RESULT=$?
+            rm composer-setup.php
 
-              if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
-                  >&2 echo 'ERROR: Invalid installer checksum'
-                  rm composer-setup.php
-                  exit 1
-              fi
-
-              php composer-setup.php --quiet
-              RESULT=$?
-              rm composer-setup.php
-            fi
-
-            if [ ! -f vendor ]; then
-              php composer.phar install --no-interaction --prefer-dist << parameters.composer >>
-            else
-              php composer.phar update --no-interaction --prefer-dist
-            fi
-
-      - run:
-          name: Cache extensions
-          command: |
-            PHP_EXT_DIR=$(php-config --extension-dir)
-            NPM_MODULES=$(npm root -g)
-
-            find ${PHP_EXT_DIR}/ -name '*.so' -exec cp -prv '{}' '/root/project/php-ext-cache/' ';'
-            cp -a ${NPM_MODULES}/. /root/project/npm-cache
-
-      - save_cache:
-          key: PHP<< parameters.php >>-{{ checksum "composer.json" }}-<< parameters.cache >>
-          paths:
-            - vendor
-            - php-ext-cache
-            - npm-cache
-            - composer.lock
-            - composer.phar
+            php composer.phar install --no-interaction --prefer-dist
 
   run-phpinsights:
     steps:
       - run:
           name: Run code quality analysis (PHP Insights)
-          command: php -d memory-limit=2G ./vendor/bin/phpinsights -v --no-interaction --min-quality=90 --min-complexity=50 --min-architecture=90 --min-style=90
+          command: php -d memory-limit=2G ./vendor/bin/phpinsights -v --no-interaction --min-quality=100 --min-complexity=50 --min-architecture=100 --min-style=100
 
   run-phpstan:
     steps:
@@ -124,22 +64,16 @@ commands:
           command: php -d memory_limit=2G ./vendor/bin/psalm --threads=$(nproc)
 
   run-pest:
-    parameters:
-      clover:
-        type: string
     steps:
       - run:
           name: Run unit tests (Pest)
-          command: php -d memory_limit=2G ./vendor/bin/pest --stop-on-failure --min=95 --coverage-clover=<< parameters.clover >>/coverage.xml --coverage-xml=<< parameters.clover >>/coverage-xml --log-junit=<< parameters.clover >>/junit.xml
+          command: php -d memory_limit=2G ./vendor/bin/pest --stop-on-failure --min=100
 
   run-infection:
-    parameters:
-      clover:
-        type: string
     steps:
       - run:
           name: Run mutation tests (Infection)
-          command: php -d memory_limit=2G ./vendor/bin/infection --skip-initial-tests --threads=$(nproc) --test-framework=pest --coverage=<< parameters.clover >> --no-progress --only-covered --min-msi=48 --min-covered-msi=70
+          command: php -d memory_limit=2G ./vendor/bin/infection --threads=$(nproc) --test-framework=pest --no-progress --only-covered --min-msi=48 --min-covered-msi=70
 
   run-snyk:
     steps:
@@ -148,63 +82,58 @@ commands:
           command: snyk test --org=auth0-sdks --project-name=auth0-PHP
 
 jobs:
-  run-tests:
+  test:
     parameters:
-      php:
+      php-version:
         type: string
-      composer:
-        type: string
-        default: ""
-      snyk:
-        type: boolean
-        default: false
-      infection:
-        type: boolean
-        default: false
-      clover:
-        type: string
-        default: "build/coverage"
     docker:
-      - image: php:<< parameters.php >>-cli-alpine
+      - image: php:<< parameters.php-version >>-cli-alpine
     steps:
       - prepare:
-          php: << parameters.php >>
-          composer: << parameters.composer >>
-          cache: 5
+          php: << parameters.php-version >>
       - run-phpinsights
       - run-phpstan
       - run-psalm
-      - run-pest:
-          clover: << parameters.clover >>
-      - when:
-          condition:
-            and:
-              - equal: [main, <<pipeline.git.branch >>]
-              - equal: [true, << parameters.snyk >>]
-          steps:
-            - run-snyk
-      - when:
-          condition:
-            and:
-              - equal: [main, <<pipeline.git.branch >>]
-              - equal: [true, << parameters.infection >>]
-          steps:
-            - run-infection:
-                clover: << parameters.clover >>
+      - run-pest
+  snyk:
+    parameters:
+      php-version:
+        type: string
+    docker:
+      - image: php:<< parameters.php-version >>-cli-alpine
+    steps:
+      - prepare:
+          php: << parameters.php-version >>
+        - run-snyk
+  infection:
+    parameters:
+      php-version:
+        type: string
+    docker:
+      - image: php:<< parameters.php-version >>-cli-alpine
+    steps:
+      - prepare:
+          php: << parameters.php-version >>
+      - run-infection
 
 workflows:
   run-tests:
     jobs:
-      - run-tests:
-          name: run-tests-7.4
-          php: "7.4.22"
-          snyk: true
-          infection: true
+      - test:
+          matrix:
+            parameters:
+              php-version: ["7.4", "8.0", "8.1.0RC3"]
+      - infection:
+          matrix:
+            parameters:
+              php-version: ["7.4"]
+      - snyk:
+          matrix:
+            parameters:
+              php-version: ["7.4", "8.0"]
           context:
             - snyk-env
-      - run-tests:
-          name: run-tests-8.0
-          php: "8.0.9"
-      - run-tests:
-          name: run-tests-8.1
-          php: "8.1.0RC1"
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ commands:
 
       - checkout
 
+      - run:
+          name: Configure environment
+          command: |
+            docker-php-ext-install posix
+            docker-php-ext-install pcntl
+            docker-php-ext-install mbstring
+            docker-php-ext-enable posix pcntl mbstring
+
   setup-composer:
     steps:
       - run:
@@ -132,7 +140,7 @@ workflows:
             parameters:
               php: ["7.4"]
       - hold:
-        type: approval
+          type: approval
       - snyk:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,31 +42,31 @@ commands:
     steps:
       - run:
           name: Run code quality analysis (PHP Insights)
-          command: php -d memory-limit=2G ./vendor/bin/phpinsights -v --no-interaction --min-quality=100 --min-complexity=50 --min-architecture=100 --min-style=100
+          command: php -d memory-limit=-1 ./vendor/bin/phpinsights -v --no-interaction --min-quality=100 --min-complexity=50 --min-architecture=100 --min-style=100
 
   run-phpstan:
     steps:
       - run:
           name: Run static code analysis (PHPStan)
-          command: php -d memory_limit=2G ./vendor/bin/phpstan analyse --ansi
+          command: php -d memory_limit=-1 ./vendor/bin/phpstan analyse --ansi
 
   run-psalm:
     steps:
       - run:
           name: Run static code analysis (Psalm)
-          command: php -d memory_limit=2G ./vendor/bin/psalm
+          command: php -d memory_limit=-1 ./vendor/bin/psalm
 
   run-pest:
     steps:
       - run:
           name: Run unit tests (Pest)
-          command: php -d memory_limit=2G ./vendor/bin/pest --stop-on-failure --min=100
+          command: php -d memory_limit=-1 ./vendor/bin/pest --stop-on-failure --min=100
 
   run-infection:
     steps:
       - run:
           name: Run mutation tests (Infection)
-          command: php -d memory_limit=2G ./vendor/bin/infection --threads=$(nproc) --test-framework=pest --no-progress --only-covered --min-msi=48 --min-covered-msi=70
+          command: php -d memory_limit=-1 ./vendor/bin/infection --threads=$(nproc) --test-framework=pest --no-progress --only-covered --min-msi=48 --min-covered-msi=70 --initial-tests-php-options='-d memory_limit=-1'
 
   run-snyk:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,6 @@ version: 2.1
 
 commands:
   prepare:
-    parameters:
-      php-version:
-        type: string
-
     steps:
       - run:
           name: Configure environment
@@ -84,36 +80,33 @@ commands:
 jobs:
   test:
     parameters:
-      php-version:
+      php:
         type: string
     docker:
-      - image: php:<< parameters.php-version >>-cli-alpine
+      - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare:
-          php: << parameters.php-version >>
+      - prepare
       - run-phpinsights
       - run-phpstan
       - run-psalm
       - run-pest
   snyk:
     parameters:
-      php-version:
+      php:
         type: string
     docker:
-      - image: php:<< parameters.php-version >>-cli-alpine
+      - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare:
-          php: << parameters.php-version >>
+      - prepare
       - run-snyk
   infection:
     parameters:
-      php-version:
+      php:
         type: string
     docker:
-      - image: php:<< parameters.php-version >>-cli-alpine
+      - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare:
-          php: << parameters.php-version >>
+      - prepare
       - run-infection
 
 workflows:
@@ -122,15 +115,15 @@ workflows:
       - test:
           matrix:
             parameters:
-              php-version: ["7.4", "8.0", "8.1.0RC3"]
+              php: ["7.4", "8.0", "8.1.0RC3"]
       - infection:
           matrix:
             parameters:
-              php-version: ["7.4"]
+              php: ["7.4"]
       - snyk:
           matrix:
             parameters:
-              php-version: ["7.4", "8.0"]
+              php: ["7.4", "8.0"]
           context:
             - snyk-env
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
     steps:
       - prepare:
           php: << parameters.php-version >>
-        - run-snyk
+      - run-snyk
   infection:
     parameters:
       php-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,9 @@ commands:
       - run:
           name: Configure environment
           command: |
-            apk update && apk add npm gcc autoconf make musl-dev oniguruma-dev gnupg
+            apk update && apk add npm
 
       - checkout
-
-      - run:
-          name: Configure environment
-          command: |
-            docker-php-ext-install posix
-            docker-php-ext-install pcntl
-            docker-php-ext-install mbstring
-            docker-php-ext-enable posix pcntl mbstring
 
   setup-composer:
     steps:
@@ -91,7 +83,37 @@ commands:
           command: snyk test --org=auth0-sdks --project-name=auth0-PHP
 
 jobs:
-  php:
+  phpinsights:
+    parameters:
+      php:
+        type: string
+    docker:
+      - image: php:<< parameters.php >>-cli-alpine
+    steps:
+      - setup
+      - setup-composer
+      - run-phpinsights
+  phpstan:
+    parameters:
+      php:
+        type: string
+    docker:
+      - image: php:<< parameters.php >>-cli-alpine
+    steps:
+      - setup
+      - setup-composer
+      - run-phpstan
+  psalm:
+    parameters:
+      php:
+        type: string
+    docker:
+      - image: php:<< parameters.php >>-cli-alpine
+    steps:
+      - setup
+      - setup-composer
+      - run-psalm
+  pest:
     parameters:
       php:
         type: string
@@ -101,9 +123,6 @@ jobs:
       - setup
       - setup-composer
       - setup-pcov
-      - run-phpinsights
-      - run-phpstan
-      - run-psalm
       - run-pest
   snyk:
     parameters:
@@ -131,14 +150,26 @@ jobs:
 workflows:
   test:
     jobs:
-      - php:
+      - phpinsights:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1.0RC3"]
+      - phpstan:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1.0RC3"]
+      - psalm:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1.0RC3"]
+      - pest:
           matrix:
             parameters:
               php: ["7.4", "8.0", "8.1.0RC3"]
       - infection:
           matrix:
             parameters:
-              php: ["7.4"]
+              php: ["7.4", "8.0"]
       - hold:
           type: approval
       - snyk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,6 @@ commands:
             pecl install pcov
             docker-php-ext-enable pcov
 
-  setup-snyk:
-    steps:
-      - run:
-          name: Configure snyk
-          command: |
-            apk add npm
-            npm install -g snyk
-
   run-phpinsights:
     steps:
       - run:
@@ -80,7 +72,10 @@ commands:
     steps:
       - run:
           name: Run vulnerabilities tests (Snyk)
-          command: snyk test --org=auth0-sdks --project-name=auth0-PHP
+          command: |
+            apk add npm
+            npm install -g snyk
+            snyk test --org=auth0-sdks --project-name=auth0-PHP
 
 jobs:
   phpinsights:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
           command: snyk test --org=auth0-sdks --project-name=auth0-PHP
 
 jobs:
-  test:
+  php:
     parameters:
       php:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Configure pcov
           command: |
-            apk add autoconf gcc
+            apk add autoconf gcc make
             pecl install pcov
             docker-php-ext-enable pcov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Configure pcov
           command: |
-            apk add autoconf
+            apk add autoconf gcc
             pecl install pcov
             docker-php-ext-enable pcov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ commands:
           command: |
             apk add npm
             npm install -g snyk
-            snyk test --org=auth0-sdks --project-name=auth0-PHP
+            snyk test --dev --org=auth0-sdks --project-name=auth0-PHP
 
 jobs:
   phpinsights:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
       - run:
           name: Configure environment
           command: |
-            apk update && apk add npm
+            apk update
 
       - checkout
 
@@ -45,6 +45,7 @@ commands:
       - run:
           name: Configure snyk
           command: |
+            apk add npm
             npm install -g snyk
 
   run-phpinsights:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Configure pcov
           command: |
-            apk add autoconf gcc make
+            apk add autoconf gcc make musl-dev
             pecl install pcov
             docker-php-ext-enable pcov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,6 @@ commands:
 
       - checkout
 
-      - run:
-          name: Configure environment
-          command: |
-            docker-php-ext-install posix
-            docker-php-ext-install pcntl
-            docker-php-ext-install mbstring
-            docker-php-ext-enable posix pcntl mbstring
-
   setup-composer:
     steps:
       - run:
@@ -139,10 +131,13 @@ workflows:
           matrix:
             parameters:
               php: ["7.4"]
+      - hold:
+        type: approval
       - snyk:
-          type: approval
           matrix:
             parameters:
               php: ["7.4", "8.0"]
           context:
             - snyk-env
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  prepare:
+  setup:
     steps:
       - run:
           name: Configure environment
@@ -13,18 +13,16 @@ commands:
       - run:
           name: Configure environment
           command: |
-            pecl install pcov
             docker-php-ext-install posix
             docker-php-ext-install pcntl
             docker-php-ext-install mbstring
+            docker-php-ext-enable posix pcntl mbstring
 
-            docker-php-ext-enable pcov posix pcntl mbstring
-
+  setup-composer:
+    steps:
       - run:
-          name: Install dependencies
+          name: Install COMPOSER
           command: |
-            npm install -g snyk
-
             EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
@@ -40,6 +38,21 @@ commands:
             rm composer-setup.php
 
             php composer.phar install --no-interaction --prefer-dist
+
+  setup-pcov:
+    steps:
+      - run:
+          name: Configure PCOV
+          command: |
+            pecl install pcov
+            docker-php-ext-enable pcov
+
+  setup-snyk:
+    steps:
+      - run:
+          name: Configure SNYK
+          command: |
+            npm install -g snyk
 
   run-phpinsights:
     steps:
@@ -85,7 +98,9 @@ jobs:
     docker:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare
+      - setup
+      - setup-composer
+      - setup-pcov
       - run-phpinsights
       - run-phpstan
       - run-psalm
@@ -97,7 +112,9 @@ jobs:
     docker:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare
+      - setup
+      - setup-composer
+      - setup-snyk
       - run-snyk
   infection:
     parameters:
@@ -106,13 +123,15 @@ jobs:
     docker:
       - image: php:<< parameters.php >>-cli-alpine
     steps:
-      - prepare
+      - setup
+      - setup-composer
+      - setup-pcov
       - run-infection
 
 workflows:
-  run-tests:
+  tests:
     jobs:
-      - test:
+      - php:
           matrix:
             parameters:
               php: ["7.4", "8.0", "8.1.0RC3"]

--- a/docker/php-8.1.dockerfile
+++ b/docker/php-8.1.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0RC1-cli-alpine
+FROM php:8.1.0RC3-cli-alpine
 
 # Setup essentials for building PHP extensions
 RUN apk update && \

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,10 +6,7 @@
     },
     "logs": {
         "text": "infection.log",
-        "perMutator": "infection.mutators.md",
-        "badge": {
-            "branch": "main"
-        }
+        "perMutator": "infection.mutators.md"
     },
     "mutators": {
         "@default": true


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR contains the following changes:
- Applies @lbalmaceda's recent suggestion of applying CircleCI matrix jobs, improving test concurrency and reducing complexity
- Bumps the PHP runtime we're testing against to 8.1.0RC3 from RC1
- Adds an approval hold for Snyk tests, so they have an opportunity to run on all PR, rather than just running on the main branch at merge
- Add `--dev` flag to `snyk test` to test dev dependencies as well, as those are more often than not installed

Note that we will need to update branch protection on "main" to:
- ❌ Remove the obsolete status checks:
  - run-tests-7.4
  - run-tests-8.0
- ✔️ Add protection status checks for:
  - psalm-7.4
  - psalm-8.0
  - phpstan-7.4
  - phpstan-8.0
  - phpinsights-7.4
  - phpinsights-8.0
  - pest-7.4
  - pest-8.0
  - infection-7.4
  - infection-8.0
  - snyk-7.4
  - snyk-8.0

PHP 8.1 will not be released until this November, and shouldn't have status check requirements enabled for it until general availability.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
