### PR TITLE
Resolve SessionStore::purge() not iterating over session storage when a falsey value is stored

### DIFF
--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -104,7 +104,7 @@ final class SessionStore implements StoreInterface
         $session = $_SESSION;
         $prefix = $this->sessionPrefix . '_';
 
-        while (current($session)) {
+        while (key($session)) {
             $sessionKey = key($session);
 
             if (is_string($sessionKey) && mb_substr($sessionKey, 0, strlen($prefix)) === $prefix) {


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

Background: When a developer invokes the purge() method on whatever session handler is configured, the chosen session class is expected to clear our the local user session. Developers using the PHP native sessions handler for storage will have the PHP global $_SESSION iterated over and parsed for keys prefixed with the SDK's namespace, which are then deleted.

Bug: This PR addresses an issue in which PHP's language feature [`current()`](https://www.php.net/manual/en/function.current.php) will return false when a falsey value is stored in the PHP native session key-store, causing the iteration check of `while(current(...))` to exit early.

Fix: The [`key()`](https://www.php.net/manual/en/function.key.php) feature functions as a suitable drop-in replacement for this check without the falsey value issue, allowing the SDK to successfully clear our a user's local session when the developer is using native PHP sessions that contain falsey values.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #576

### Testing

<!--
  Would you please describe how reviewers can test this? Be specific about anything not tested and the reasons why. Tests must be added for new functionality, and existing tests should complete without errors.
-->

No additional/new testing was necessary for these changes. Coverage remains at 100%.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
