### PR TITLE
Document that v8 won't call exchange in getUser

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,7 +57,7 @@ These classes were updated in SDK 8.0:
   - Public method `deleteAllPersistentData()` renamed to `clear()`.
   - Public methods `getNonce()` and `urlSafeBase64Decode()` were removed.
   - Public methods `getAccessTokenExpiration()` and `setAccessTokenExpiration()` were added for retrieving for storing an access token expiration timestamp in session storage, respectively.
-  - Public methods `getUser()`, `getAccessToken()`, `getIdToken()` and `getRefreshToken()` won't implicitly call `exchange()` for you anymore. They will just return what's stored locally. So, in order to get the Store filled, you must call `Auth0::exchange()` yourself before calling any of these methods.
+  - Public methods `getUser()`, `getAccessToken()`, `getIdToken()` and `getRefreshToken()` no longer implicitly invoke `exchange()` as was previously the case, and instead return only what is already available in an available session. This change was made to avoid unintentionally invoking the token exchange at inappropriate times, and to allow developers to more easily check for an available session without accidentally executing unwanted code. Developers will need to call `Auth0::exchange()` themselves when a code exchange is desired to establish a session and store user data, which will then be available for return from the beforementioned methods.
   - Public method `getCredentials()` added as a convenience. This method returns the Id Token, Access Token, Refresh Token, Access Token expiration timestamp, and user data from an available session without invoking an authorization flow, exchange, or raising an error if a session is not available.
 
 - Class `Auth0\SDK\API\Authentication` updated:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -56,7 +56,7 @@ These classes were updated in SDK 8.0:
   - Public method `deleteAllPersistentData()` renamed to `clear()`.
   - Public methods `getNonce()` and `urlSafeBase64Decode()` were removed.
   - Public methods `getAccessTokenExpiration()` and `setAccessTokenExpiration()` were added for retrieving for storing an access token expiration timestamp in session storage, respectively.
-  - Public methods `getUser()`, `getAccessToken()`, `getIdToken()` and `getRefreshToken()` won`t implicitly call `exchange()` for you anymore. They will just return what's stored locally. So, in order to get the Store filled, you must call `Auth0::exchange()` yourself before calling any of these methods.
+  - Public methods `getUser()`, `getAccessToken()`, `getIdToken()` and `getRefreshToken()` won't implicitly call `exchange()` for you anymore. They will just return what's stored locally. So, in order to get the Store filled, you must call `Auth0::exchange()` yourself before calling any of these methods.
   - Public method `getCredentials()` added as a convenience. This method returns the Id Token, Access Token, Refresh Token, Access Token expiration timestamp, and user data from an available session without invoking an authorization flow, exchange, or raising an error if a session is not available.
 
 - Class `Auth0\SDK\API\Authentication` updated:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -56,6 +56,7 @@ These classes were updated in SDK 8.0:
   - Public method `deleteAllPersistentData()` renamed to `clear()`.
   - Public methods `getNonce()` and `urlSafeBase64Decode()` were removed.
   - Public methods `getAccessTokenExpiration()` and `setAccessTokenExpiration()` were added for retrieving for storing an access token expiration timestamp in session storage, respectively.
+  - Public methods `getUser()`, `getAccessToken()`, `getIdToken()` and `getRefreshToken()` won`t implicitly call `exchange()` for you anymore. They will just return what's stored locally. So, in order to get the Store filled, you must call `Auth0::exchange()` yourself before calling any of these methods.
   - Public method `getCredentials()` added as a convenience. This method returns the Id Token, Access Token, Refresh Token, Access Token expiration timestamp, and user data from an available session without invoking an authorization flow, exchange, or raising an error if a session is not available.
 
 - Class `Auth0\SDK\API\Authentication` updated:


### PR DESCRIPTION


### Changes

In the past - AFAIR not being explicitly documented - getUser called exchange, so as long as your afterLogin redirect target called getUser, there was no need to call exchange yourself. this changed in v8, potentially breaking clients that did so before. This should be documented in the v8 migration notes.

### References
No references

### Testing

Just documentation fixes

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
