### PR TITLE
Document that v8 login won't redirect anymore

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,6 +40,7 @@ These classes were updated in SDK 8.0:
   - Public method `login()` updated:
     - Method now accepts an argument, `params`: an array of parameters to pass with the API request.
     - Arguments `state`, `connection`, and `additionalParameters` have been removed. Use the new `params` argument for these uses.
+    - Method won't redirect to the Auth0 login page any more. It will instead return a login URL. It's now the callers responsibility to send the http redirect.
   - Public method `signup()` added as a convenience. This method will pass the ?screen_hint=signup param, supported by the New Universal Login Experience.
   - Public method `getLoginUrl()` moved to `Auth0\SDK\API\Authentication\getLoginLink()`, and:
     - Argument `params` is now a nullable array.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,7 +40,7 @@ These classes were updated in SDK 8.0:
   - Public method `login()` updated:
     - Method now accepts an argument, `params`: an array of parameters to pass with the API request.
     - Arguments `state`, `connection`, and `additionalParameters` have been removed. Use the new `params` argument for these uses.
-    - Method won't redirect to the Auth0 login page any more. It will instead return a login URL. It's now the callers responsibility to send the http redirect.
+    - Method now returns an intended login URL as a string. Method no longer sends redirect headers itself to better integrate with application frameworks. Developers should redirect users to the returned URL using a method appropriate for the application type/framework. For example, the redirect() method in Laravel or Symfony, Header("Location: $url") with plain PHP, etc.
   - Public method `signup()` added as a convenience. This method will pass the ?screen_hint=signup param, supported by the New Universal Login Experience.
   - Public method `getLoginUrl()` moved to `Auth0\SDK\API\Authentication\getLoginLink()`, and:
     - Argument `params` is now a nullable array.


### PR DESCRIPTION
### Changes

In v7, `Auth0::login()` included `header('Location: '.$login_url); exit;`. v8 now instead returns the login URL and it's up to the application to actually execute the redirect. This should be explicitly documented in the UPGRADE guidance.

### References

No issues to reference, just a small clarification in the docs

### Testing

Just documentation changes, no test neccessary

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
