### PR TITLE
Fix psalm test warnings around specificity of integer types and positive values

### DIFF
--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -101,17 +101,19 @@ final class SessionStore implements StoreInterface
      */
     public function purge(): void
     {
-        $session = $_SESSION;
+        $session = $_SESSION ?? [];
         $prefix = $this->sessionPrefix . '_';
 
-        while (key($session)) {
-            $sessionKey = key($session);
+        if (count($session) > 0) {
+            while (key($session)) {
+                $sessionKey = (string) (key($session) ?? '');
 
-            if (is_string($sessionKey) && mb_substr($sessionKey, 0, strlen($prefix)) === $prefix) {
-                unset($_SESSION[$sessionKey]);
+                if (mb_substr($sessionKey, 0, strlen($prefix)) === $prefix) {
+                    unset($_SESSION[$sessionKey]);
+                }
+
+                next($session);
             }
-
-            next($session);
         }
     }
 

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -583,12 +583,14 @@ final class HttpRequest
     private function sleep(
         int $milliseconds
     ): self {
-        $this->waits[] = $milliseconds;
+        if ($milliseconds > 0) {
+            $this->waits[] = $milliseconds;
 
-        // Don't actually trigger a sleep if we're running tests.
-        if (! defined('AUTH0_TESTS_DIR')) {
-            // usleep() uses microseconds, so * 1000 for the correct conversion.
-            usleep($milliseconds * 1000);
+            // Don't actually trigger a sleep if we're running tests.
+            if (! defined('AUTH0_TESTS_DIR')) {
+                // usleep() uses microseconds, so * 1000 for the correct conversion.
+                usleep($milliseconds * 1000);
+            }
         }
 
         return $this;


### PR DESCRIPTION
### Changes

This PR addresses some new test warnings introduced by upgraded Psalm test suite rules.

### References

These changes address an upstream change introduced in Psalm with [PR 6861](https://github.com/vimeo/psalm/pull/6861), cut later with a minor release, that suddenly started causing our test suite to fail.

### Testing

Run standard tests using `composer run tests` or more specifically `composer run tests:psalm` before this PR patch and after to see the Psalm warnings resolved. Tests continue to otherwise pass at 100% coverage.

### Contributor Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
