### PR TITLE
Add PHP 8.1 GA to test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,29 +141,29 @@ workflows:
       - phpinsights:
           matrix:
             parameters:
-              php: ["7.4", "8.0", "8.1.0RC4"]
+              php: ["7.4", "8.0", "8.1"]
       - phpstan:
           matrix:
             parameters:
-              php: ["7.4", "8.0", "8.1.0RC4"]
+              php: ["7.4", "8.0", "8.1"]
       - psalm:
           matrix:
             parameters:
-              php: ["7.4", "8.0", "8.1.0RC4"]
+              php: ["7.4", "8.0", "8.1"]
       - pest:
           matrix:
             parameters:
-              php: ["7.4", "8.0", "8.1.0RC4"]
+              php: ["7.4", "8.0", "8.1"]
       - infection:
           matrix:
             parameters:
-              php: ["7.4", "8.0"]
+              php: ["7.4", "8.0", "8.1"]
       - hold:
           type: approval
       - snyk:
           matrix:
             parameters:
-              php: ["7.4", "8.0"]
+              php: ["7.4", "8.0", "8.1"]
           context:
             - snyk-env
           requires:

--- a/docker/php-8.1.dockerfile
+++ b/docker/php-8.1.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0RC4-cli-alpine
+FROM php:8.1-cli-alpine
 
 # Setup essentials for building PHP extensions
 RUN apk update && \


### PR DESCRIPTION
### Changes

PHP 8.1 was released to GA during Thanksgiving holiday. This PR ups our 8.1 test suite target from the release candidate builds to the stable build.

### References

- https://www.php.net/releases/8.1/en.php

### Testing

This change affects the CircleCI build workflow and the 8.1 Dockerfile. You can test this locally using `composer run tests:8.1`, or review the output from the CircleCI workflow below.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
