### PR TITLE
Add Semgrep to CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,25 @@ jobs:
       - setup
       - setup-pcov
       - run-infection
+  semgrep:
+    parameters:
+      repo_path:
+        type: string
+        default: auth0/auth0-php
+      default_branch:
+        type: string
+        default: main
+    environment:
+      SEMGREP_RULES: >-
+        p/security-audit
+        p/secrets
+      SEMGREP_BASELINE_REF: main
+      SEMGREP_TIMEOUT: 300
+    docker:
+      - image: returntocorp/semgrep-agent:v1
+    steps:
+      - checkout
+      - semgrep-agent
 
 workflows:
   test:
@@ -158,6 +177,7 @@ workflows:
           matrix:
             parameters:
               php: ["7.4", "8.0"]
+      - semgrep
       - hold:
           type: approval
       - snyk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,29 @@ jobs:
     steps:
       - setup
       - run-psalm
+  semgrep:
+    parameters:
+      repo_path:
+        type: string
+        default: auth0/auth0-php
+      default_branch:
+        type: string
+        default: main
+    environment:
+      SEMGREP_RULES: >-
+        p/ci
+        p/security-audit
+        p/secrets
+        p/phpcs-security-audit
+      SEMGREP_BASELINE_REF: main
+      SEMGREP_TIMEOUT: 300
+    docker:
+      - image: returntocorp/semgrep-agent:v1
+    steps:
+      - checkout
+      - run:
+          name: Run static code analysis (Semgrep)
+          command: semgrep-agent
   pest:
     parameters:
       php:
@@ -134,25 +157,6 @@ jobs:
       - setup
       - setup-pcov
       - run-infection
-  semgrep:
-    parameters:
-      repo_path:
-        type: string
-        default: auth0/auth0-php
-      default_branch:
-        type: string
-        default: main
-    environment:
-      SEMGREP_RULES: >-
-        p/security-audit
-        p/secrets
-      SEMGREP_BASELINE_REF: main
-      SEMGREP_TIMEOUT: 300
-    docker:
-      - image: returntocorp/semgrep-agent:v1
-    steps:
-      - checkout
-      - semgrep-agent
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,13 +106,6 @@ jobs:
       - setup
       - run-psalm
   semgrep:
-    parameters:
-      repo_path:
-        type: string
-        default: auth0/auth0-php
-      default_branch:
-        type: string
-        default: main
     environment:
       SEMGREP_RULES: >-
         p/ci
@@ -127,7 +120,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep-agent
+          command: semgrep-agent src/*.php
   pest:
     parameters:
       php:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep-agent src/*.php
+          command: semgrep-agent src
   pest:
     parameters:
       php:
@@ -154,34 +154,34 @@ jobs:
 workflows:
   test:
     jobs:
-      - phpinsights:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
-      - phpstan:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
-      - psalm:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
-      - pest:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
-      - infection:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
+      # - phpinsights:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
+      # - phpstan:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
+      # - psalm:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
+      # - pest:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
+      # - infection:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
       - semgrep
-      - hold:
-          type: approval
-      - snyk:
-          matrix:
-            parameters:
-              php: ["7.4", "8.0", "8.1"]
-          context:
-            - snyk-env
-          requires:
-            - hold
+      # - hold:
+      #     type: approval
+      # - snyk:
+      #     matrix:
+      #       parameters:
+      #         php: ["7.4", "8.0", "8.1"]
+      #     context:
+      #       - snyk-env
+      #     requires:
+      #       - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,21 +106,13 @@ jobs:
       - setup
       - run-psalm
   semgrep:
-    environment:
-      SEMGREP_RULES: >-
-        p/ci
-        p/security-audit
-        p/secrets
-        p/phpcs-security-audit
-      SEMGREP_BASELINE_REF: main
-      SEMGREP_TIMEOUT: 300
     docker:
-      - image: returntocorp/semgrep-agent:v1
+      - image: returntocorp/semgrep:latest
     steps:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep-agent --help
+          command: semgrep --config auto src/
   pest:
     parameters:
       php:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep --config auto src/
+          command: semgrep --config auto
   pest:
     parameters:
       php:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep --config auto --metrics=off
+          command: semgrep --config auto
   pest:
     parameters:
       php:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep --config auto
+          command: semgrep --config auto --metrics=off
   pest:
     parameters:
       php:
@@ -146,34 +146,34 @@ jobs:
 workflows:
   test:
     jobs:
-      # - phpinsights:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
-      # - phpstan:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
-      # - psalm:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
-      # - pest:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
-      # - infection:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
       - semgrep
-      # - hold:
-      #     type: approval
-      # - snyk:
-      #     matrix:
-      #       parameters:
-      #         php: ["7.4", "8.0", "8.1"]
-      #     context:
-      #       - snyk-env
-      #     requires:
-      #       - hold
+      - phpinsights:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+      - phpstan:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+      - psalm:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+      - pest:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+      - infection:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+      - hold:
+          type: approval
+      - snyk:
+          matrix:
+            parameters:
+              php: ["7.4", "8.0", "8.1"]
+          context:
+            - snyk-env
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - checkout
       - run:
           name: Run static code analysis (Semgrep)
-          command: semgrep-agent src
+          command: semgrep-agent --help
   pest:
     parameters:
       php:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ workflows:
           matrix:
             parameters:
               php: ["7.4", "8.0", "8.1"]
+      - semgrep
       - hold:
           type: approval
       - snyk:


### PR DESCRIPTION
### Changes

This PR adds [Semgrep](https://semgrep.dev/) to the CircleCI workflow. Product Security is encouraging our SDKs to add Semgrep to our test suite tooling as opportunities allow.

### Testing

Results of the CircleCI workflow are visible attached to this PR, or via the CircleCI dashboard.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
