### PR TITLE
Require `domain` configuration with `management` strategy

### DIFF
--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -527,6 +527,10 @@ final class SdkConfiguration implements ConfigurableContract
      */
     private function validateStateManagement(): void
     {
+        if (! $this->hasDomain()) {
+            throw \Auth0\SDK\Exception\ConfigurationException::requiresDomain();
+        }
+
         if (! $this->hasManagementToken()) {
             if (! $this->hasClientId()) {
                 throw \Auth0\SDK\Exception\ConfigurationException::requiresClientId();

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -232,10 +232,18 @@ test('a `api` strategy requires an audience', function(): void
     ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_AUDIENCE);
 
-test('a `management` strategy requires a client id if a management token is not provided', function(): void
+test('a `management` strategy requires a domain', function(): void
 {
     $sdk = new SdkConfiguration([
         'strategy' => 'management'
+    ]);
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
+
+test('a `management` strategy requires a client id if a management token is not provided', function(): void
+{
+    $sdk = new SdkConfiguration([
+        'strategy' => 'management',
+        'domain' => uniqid()
     ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
 
@@ -243,6 +251,7 @@ test('a `management` strategy requires a client secret if a management token is 
 {
     $sdk = new SdkConfiguration([
         'strategy' => 'management',
+        'domain' => uniqid(),
         'clientId' => uniqid()
     ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_SECRET);
@@ -251,6 +260,7 @@ test('a `management` strategy does not require a client id or secret if a manage
 {
     $sdk = new SdkConfiguration([
         'strategy' => 'management',
+        'domain' => uniqid(),
         'managementToken' => uniqid()
     ]);
 


### PR DESCRIPTION
### Changes

This PR adds a check that `domain` is properly configured when using the `management` strategy.

This is not considered a breaking change, as Management API calls under this strategy would not have worked without it being assigned anyway.

Tests have been updated to cover the change; coverage remains at 100%.

### References

Resolves #583

### Testing

Run `composer run tests` to test changes locally, or review the CircleCI results attached to this PR.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
