### PR TITLE
Auth0->exchange(): optimize redundant setcookie() calls

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -207,7 +207,6 @@ final class Auth0 implements Auth0Interface
      * Delete any persistent data and clear out all stored properties.
      *
      * @param bool $transient When true, data in transient storage is also cleared.
-     * @param bool $immediate When true, disables deferred state saving and writes immediately
      */
     public function clear(
         bool $transient = true

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -210,8 +210,7 @@ final class Auth0 implements Auth0Interface
      * @param bool $immediate When true, disables deferred state saving and writes immediately
      */
     public function clear(
-        bool $transient = true,
-        bool $immediate = true
+        bool $transient = true
     ): self {
         // Delete all data in the session storage medium.
         if ($this->configuration()->hasSessionStorage()) {
@@ -224,9 +223,7 @@ final class Auth0 implements Auth0Interface
         }
 
         // If state saving had been deferred, disable it and force a update to persistent storage.
-        if ($immediate) {
-            $this->deferStateSaving(false);
-        }
+        $this->deferStateSaving(false);
 
         // Reset the internal state.
         $this->getState()->reset();
@@ -313,14 +310,13 @@ final class Auth0 implements Auth0Interface
         $codeVerifier = null;
         $user = null;
 
+        $this->clear(false);
         $this->deferStateSaving();
 
         if ($code === null) {
             $this->clear();
             throw \Auth0\SDK\Exception\StateException::missingCode();
         }
-
-        $this->clear(false, false);
 
         if ($state === null || ! $this->getTransientStore()->verify('state', $state)) {
             $this->clear();

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -207,9 +207,11 @@ final class Auth0 implements Auth0Interface
      * Delete any persistent data and clear out all stored properties.
      *
      * @param bool $transient When true, data in transient storage is also cleared.
+     * @param bool $immediate When true, disables deferred state saving and writes immediately
      */
     public function clear(
-        bool $transient = true
+        bool $transient = true,
+        bool $immediate = true
     ): self {
         // Delete all data in the session storage medium.
         if ($this->configuration()->hasSessionStorage()) {
@@ -222,7 +224,9 @@ final class Auth0 implements Auth0Interface
         }
 
         // If state saving had been deferred, disable it and force a update to persistent storage.
-        $this->deferStateSaving(false);
+        if ($immediate) {
+            $this->deferStateSaving(false);
+        }
 
         // Reset the internal state.
         $this->getState()->reset();
@@ -316,7 +320,7 @@ final class Auth0 implements Auth0Interface
             throw \Auth0\SDK\Exception\StateException::missingCode();
         }
 
-        $this->clear(false);
+        $this->clear(false, false);
 
         if ($state === null || ! $this->getTransientStore()->verify('state', $state)) {
             $this->clear();

--- a/src/Contract/Auth0Interface.php
+++ b/src/Contract/Auth0Interface.php
@@ -98,11 +98,9 @@ interface Auth0Interface
      * Delete any persistent data and clear out all stored properties.
      *
      * @param bool $transient When true, data in transient storage is also cleared.
-     * @param bool $immediate When true, disables deferred state saving and writes immediately
      */
     public function clear(
-        bool $transient = true,
-        bool $immediate = true
+        bool $transient = true
     ): self;
 
     /**

--- a/src/Contract/Auth0Interface.php
+++ b/src/Contract/Auth0Interface.php
@@ -98,9 +98,11 @@ interface Auth0Interface
      * Delete any persistent data and clear out all stored properties.
      *
      * @param bool $transient When true, data in transient storage is also cleared.
+     * @param bool $immediate When true, disables deferred state saving and writes immediately
      */
     public function clear(
-        bool $transient = true
+        bool $transient = true,
+        bool $immediate = true
     ): self;
 
     /**


### PR DESCRIPTION
Fixes `exchange()`'s usage of deferred saving to work as seemingly intended: only write once, at the end.

Partially helps #539, though the resulting session cookie headers are _still_ larger than nginx's default limits, at least in my nearly-stock Auth0 tenant.

### Changes

`Auth0->exchange()` currently has the following flow:
```
$this->deferStateSaving(); // good
$this->clear(false); // this calls deferStateSaving(false), immediately reverting the previous line
// ... (do the exchange) ...
$this->setAccessToken(...); // this calls setcookie() since we're not deferred
$this->setAccessTokenScope(...); // calls setcookie()
$this->setAccessTokenExpiration(...); // calls setcookie()
// ... (several other conditional sets that modify state and thus call setcookie())
$this->deferStateSaving(false); // this _should_ be when we call setcookie(), but we've actually had deferred=false since the early clear()
```

This PR alters the unconditional `clear()` in `exchange()` to _not_ call `deferStateSaving(false)`, allowing the clear to be combined with the subsequent writes.

This allows `Auth0->exchange()` to complete while only doing the encrypt work once, and emitting only 1 `Set-Cookie:` header. Its a time and header size optimization, though not quite enough to resolve #539 entirely.

### References

Related to #539 and #578

### Testing

1. Call Auth0->exchange() as part of a normal login flow, using the minimal SDK config in the [Getting Started](https://github.com/auth0/auth0-PHP#sdk-initialization), which defaults to using cookies for session storage
2. Observe (eg. with a breakpoint set in `CookieStore->setState()`) that the state is only written once (each for Session/Transient), and/or use `xdebug_get_headers()` to observe that following a successful exchange(), there is only 1 `Set-Cookie:` header per unique cookie.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
