### PR TITLE
[SDK-3081] Fix: Update session properties after a token is refreshed

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -418,6 +418,11 @@ final class Auth0 implements Auth0Interface
 
         $this->setAccessToken($response['access_token']);
 
+        if (isset($response['expires_in']) && is_numeric($response['expires_in'])) {
+            $expiresIn = time() + (int) $response['expires_in'];
+            $this->setAccessTokenExpiration($expiresIn);
+        }
+
         if (isset($response['id_token'])) {
             $this->setIdToken($response['id_token']);
         }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -427,6 +427,14 @@ final class Auth0 implements Auth0Interface
             $this->setIdToken($response['id_token']);
         }
 
+        if (isset($response['refresh_token'])) {
+            $this->setRefreshToken($response['refresh_token']);
+        }
+
+        if (isset($response['scope'])) {
+            $this->setAccessTokenScope(explode(' ', $response['scope']));
+        }
+
         $this->deferStateSaving(false);
 
         return $this;

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -654,7 +654,7 @@ test('renew() succeeds under expected and valid conditions', function(): void {
 
     $httpClient->mockResponses([
         \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4","id_token":"' . $token . '"}'),
-        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '","expires_in":"123"}'),
     ]);
 
     $_GET['code'] = uniqid();
@@ -672,6 +672,7 @@ test('renew() succeeds under expected and valid conditions', function(): void {
 
     expect($auth0->getAccessToken())->toEqual('__test_access_token__');
     expect($auth0->getIdToken())->toEqual($token);
+    expect($auth0->getAccessTokenExpiration())->toBeGreaterThanOrEqual(time() + 123);
 
     expect($requestBody['scope'])->toEqual('openid');
     expect($requestBody['client_secret'])->toEqual('__test_client_secret__');

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -654,7 +654,7 @@ test('renew() succeeds under expected and valid conditions', function(): void {
 
     $httpClient->mockResponses([
         \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"2.3.4","id_token":"' . $token . '"}'),
-        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '","expires_in":"123"}'),
+        \Auth0\Tests\Utilities\HttpResponseGenerator::create('{"access_token":"__test_access_token__","id_token":"' . $token . '","expires_in":"123","refresh_token":"5.6.7","scope":"test1 test2 test3"}'),
     ]);
 
     $_GET['code'] = uniqid();
@@ -673,6 +673,8 @@ test('renew() succeeds under expected and valid conditions', function(): void {
     expect($auth0->getAccessToken())->toEqual('__test_access_token__');
     expect($auth0->getIdToken())->toEqual($token);
     expect($auth0->getAccessTokenExpiration())->toBeGreaterThanOrEqual(time() + 123);
+    expect($auth0->getRefreshToken())->toEqual('5.6.7');
+    expect($auth0->getAccessTokenScope())->toEqual(['test1', 'test2', 'test3']);
 
     expect($requestBody['scope'])->toEqual('openid');
     expect($requestBody['client_secret'])->toEqual('__test_client_secret__');


### PR DESCRIPTION
This PR resolves an issue where the local cache of the token expiration timestamp (`expires_in`) is not properly updated after a refresh token is used, causing the SDK to wrongly continue reporting the token as expired.