### PR TITLE
Release 8.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
-## [8.0.5](https://github.com/auth0/auth0-PHP/tree/8.0.4) (2022-01-04)
+## [8.0.6](https://github.com/auth0/auth0-PHP/tree/8.0.6) (2022-01-25)
+
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.0.4..8.0.5)
+
+**Fixed**
+
+- Auth0->renew(): now correctly updates all appropriate session details after a successful token refresh [#593](https://github.com/auth0/auth0-PHP/pull/593) ([evansims](https://github.com/evansims))
+
+## [8.0.5](https://github.com/auth0/auth0-PHP/tree/8.0.5) (2022-01-04)
 
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.0.4..8.0.5)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -22,7 +22,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.0.5';
+    public const VERSION = '8.0.6';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.0.4..8.0.5)

**Fixed**

- Auth0->renew(): now correctly updates all appropriate session details after a successful token refresh [#593](https://github.com/auth0/auth0-PHP/pull/593) ([evansims](https://github.com/evansims))