### PR TITLE
[SDK-3117] Add Attack Protection endpoints

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\SDK\API;
 
 use Auth0\SDK\API\Management\Actions;
+use Auth0\SDK\API\Management\AttackProtection;
 use Auth0\SDK\API\Management\Blacklists;
 use Auth0\SDK\API\Management\ClientGrants;
 use Auth0\SDK\API\Management\Clients;
@@ -29,6 +30,7 @@ use Auth0\SDK\API\Management\Users;
 use Auth0\SDK\API\Management\UsersByEmail;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Contract\API\Management\ActionsInterface;
+use Auth0\SDK\Contract\API\Management\AttackProtectionInterface;
 use Auth0\SDK\Contract\API\Management\BlacklistsInterface;
 use Auth0\SDK\Contract\API\Management\ClientGrantsInterface;
 use Auth0\SDK\Contract\API\Management\ClientsInterface;
@@ -186,6 +188,11 @@ final class Management implements ManagementInterface
     public function actions(): ActionsInterface
     {
         return $this->getClassInstance(Actions::class);
+    }
+
+    public function attackProtection(): AttackProtectionInterface
+    {
+        return $this->getClassInstance(AttackProtection::class);
     }
 
     public function blacklists(): BlacklistsInterface

--- a/src/API/Management/AttackProtection.php
+++ b/src/API/Management/AttackProtection.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\API\Management;
+
+use Auth0\SDK\Contract\API\Management\AttackProtectionInterface;
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Auth0\SDK\Utility\Toolkit;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class Attack Protection.
+ * Handles requests to the Attack Protection endpoint of the v2 Management API.
+ *
+ * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection
+ */
+final class AttackProtection extends ManagementEndpoint implements AttackProtectionInterface
+{
+    /**
+     * Get breached password detection settings.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection
+     */
+    public function getBreachedPasswordDetection(
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('attack-protection', 'breached-password-detection')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Get the brute force configuration.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_brute_force_protection
+     */
+    public function getBruteForceProtection(
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('attack-protection', 'brute-force-protection')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Get the suspicious IP throttling configuration.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_suspicious_ip_throttling
+     */
+    public function getSuspiciousIpThrottling(
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        return $this->getHttpClient()
+            ->method('get')
+            ->addPath('attack-protection', 'suspicious-ip-throttling')
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Update breached password detection settings.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException When an invalid `body` is provided.
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection
+     */
+    public function updateBreachedPasswordDetection(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('patch')
+            ->addPath('attack-protection', 'breached-password-detection')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Update the brute force configuration.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection
+     */
+    public function updateBruteForceProtection(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('patch')
+            ->addPath('attack-protection', 'brute-force-protection')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+
+    /**
+     * Update the suspicious IP throttling configuration.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling
+     */
+    public function updateSuspiciousIpThrottling(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface {
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$body, \Auth0\SDK\Exception\ArgumentException::missing('body')],
+        ])->isArray();
+
+        return $this->getHttpClient()
+            ->method('patch')
+            ->addPath('attack-protection', 'suspicious-ip-throttling')
+            ->withBody((object) $body)
+            ->withOptions($options)
+            ->call();
+    }
+}

--- a/src/Contract/API/Management/AttackProtectionInterface.php
+++ b/src/Contract/API/Management/AttackProtectionInterface.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Contract\API\Management;
+
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Interface AttackProtectionInterface
+ */
+interface AttackProtectionInterface
+{
+    /**
+     * Get breached password detection settings.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection
+     */
+    public function getBreachedPasswordDetection(
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+
+    /**
+     * Get the brute force configuration.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_brute_force_protection
+     */
+    public function getBruteForceProtection(
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+
+    /**
+     * Get the suspicious IP throttling configuration.
+     * Required scope: `read:attack_protection`
+     *
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException  When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_suspicious_ip_throttling
+     */
+    public function getSuspiciousIpThrottling(
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+
+    /**
+     * Update breached password detection settings.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection
+     */
+    public function updateBreachedPasswordDetection(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+
+    /**
+     * Update the brute force configuration.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection
+     */
+    public function updateBruteForceProtection(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+
+    /**
+     * Update the suspicious IP throttling configuration.
+     * Required scope: `update:attack_protection`
+     *
+     * @param array<mixed>        $body    Body content to pass with the API request. See @link for supported options.
+     * @param RequestOptions|null $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @link for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException When the API request fails due to a network error.
+     *
+     * @link https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling
+     */
+    public function updateSuspiciousIpThrottling(
+        array $body,
+        ?RequestOptions $options = null
+    ): ResponseInterface;
+}

--- a/tests/Unit/API/Management/AttackProtectionTest.php
+++ b/tests/Unit/API/Management/AttackProtectionTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('management', 'management.attack_protection');
+
+beforeEach(function(): void {
+    $this->endpoint = $this->api->mock()->attackProtection();
+});
+
+test('getBreachedPasswordDetection() issues valid requests', function(): void {
+    $this->endpoint->getBreachedPasswordDetection();
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/breached-password-detection');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+});
+
+test('getBruteForceProtection() issues valid requests', function(): void {
+    $this->endpoint->getBruteForceProtection();
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/brute-force-protection');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+});
+
+test('getSuspiciousIpThrottling() issues valid requests', function(): void {
+    $this->endpoint->getSuspiciousIpThrottling();
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/suspicious-ip-throttling');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+});
+
+test('updateBreachedPasswordDetection() throws an error with an empty body', function(): void {
+    $this->endpoint->updateBreachedPasswordDetection([]);
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+test('updateBruteForceProtection() throws an error with an empty body', function(): void {
+    $this->endpoint->updateBruteForceProtection([]);
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+test('updateSuspiciousIpThrottling() throws an error with an empty body', function(): void {
+    $this->endpoint->updateSuspiciousIpThrottling([]);
+})->throws(\Auth0\SDK\Exception\ArgumentException::class, sprintf(\Auth0\SDK\Exception\ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'body'));
+
+test('updateBreachedPasswordDetection() issues valid requests', function(array $body): void {
+    $this->endpoint->updateBreachedPasswordDetection($body);
+
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/breached-password-detection');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+
+    expect($this->api->getRequestBody())
+        ->toHaveKey('enabled')
+        ->toHaveKey('shields')
+        ->toHaveKey('admin_notification_frequency')
+        ->toHaveKey('method')
+        ->enabled
+            ->toEqual(true)
+        ->shields
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('block'),
+                fn ($string) => $string->toEqual('admin_notification'),
+            )
+        ->admin_notification_frequency
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('immediately'),
+                fn ($string) => $string->toEqual('weekly'),
+            )
+        ->method
+            ->toEqual('standard');
+
+    expect($this->api->getRequestBodyAsString())
+        ->toEqual(json_encode($body))
+        ->json();
+})->with(['valid request' => [
+    fn() => [
+        'enabled' => true,
+        'shields' => [
+            'block',
+            'admin_notification'
+        ],
+        'admin_notification_frequency' => [
+            'immediately',
+            'weekly'
+        ],
+        'method' => 'standard',
+    ]
+]]);
+
+test('updateBruteForceProtection() issues valid requests', function(array $body): void {
+    $this->endpoint->updateBruteForceProtection($body);
+
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/brute-force-protection');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+
+    expect($this->api->getRequestBody())
+        ->toHaveKey('enabled')
+        ->toHaveKey('shields')
+        ->toHaveKey('allowlist')
+        ->toHaveKey('mode')
+        ->toHaveKey('max_attempts')
+        ->enabled
+            ->toEqual(false)
+        ->shields
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('block'),
+                fn ($string) => $string->toEqual('user_notification'),
+            )
+        ->allowlist
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('143.204.0.105'),
+                fn ($string) => $string->toEqual('2600:9000:208f:ca00:d:f5f5:b40:93a1'),
+            )
+        ->mode
+            ->toEqual('count_per_identifier_and_ip')
+        ->max_attempts
+            ->toEqual(10);
+
+    expect($this->api->getRequestBodyAsString())
+        ->toEqual(json_encode($body))
+        ->json();
+})->with(['valid request' => [
+    fn() => [
+        'enabled' => false,
+        'shields' => [
+            'block',
+            'user_notification'
+        ],
+        'allowlist' => [
+            '143.204.0.105',
+            '2600:9000:208f:ca00:d:f5f5:b40:93a1'
+        ],
+        'mode' => 'count_per_identifier_and_ip',
+        'max_attempts' => 10
+    ]
+]]);
+
+test('updateSuspiciousIpThrottling() issues valid requests', function(array $body): void {
+    $this->endpoint->updateSuspiciousIpThrottling($body);
+
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEqual('https://api.test.local/api/v2/attack-protection/suspicious-ip-throttling');
+    expect($this->api->getRequestQuery())->toBeEmpty();
+
+    expect($this->api->getRequestBody())
+        ->toHaveKey('enabled')
+        ->toHaveKey('shields')
+        ->toHaveKey('allowlist')
+        ->toHaveKey('stage')
+        ->enabled
+            ->toEqual(false)
+        ->shields
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('block'),
+                fn ($string) => $string->toEqual('admin_notification'),
+            )
+        ->allowlist
+            ->toBeArray()
+            ->toHaveLength(2)
+            ->sequence(
+                fn ($string) => $string->toEqual('143.204.0.105'),
+                fn ($string) => $string->toEqual('2600:9000:208f:ca00:d:f5f5:b40:93a1'),
+            )
+        ->stage
+            ->toBeArray()
+            ->toHaveKey('pre-login')
+            ->toHaveKey('pre-user-registration');
+
+    expect($this->api->getRequestBody()['stage']['pre-login'])
+        ->toBeArray()
+        ->sequence(
+            fn ($value, $key) => $key->toEqual('max_attempts') && $value->toEqual(100),
+            fn ($value, $key) => $key->toEqual('rate') && $value->toEqual(864000),
+        );
+
+    expect($this->api->getRequestBody()['stage']['pre-user-registration'])
+        ->toBeArray()
+        ->sequence(
+            fn ($value, $key) => $key->toEqual('max_attempts') && $value->toEqual(50),
+            fn ($value, $key) => $key->toEqual('rate') && $value->toEqual(1728000),
+        );
+
+    expect($this->api->getRequestBodyAsString())
+        ->toEqual(json_encode($body))
+        ->json();
+})->with(['valid request' => [
+    fn() => [
+        'enabled' => false,
+        'shields' => [
+            'block',
+            'admin_notification'
+        ],
+        'allowlist' => [
+            '143.204.0.105',
+            '2600:9000:208f:ca00:d:f5f5:b40:93a1'
+        ],
+        'stage' => [
+            'pre-login' => [
+                'max_attempts' => 100,
+                'rate' => 864000,
+            ],
+            'pre-user-registration' => [
+                'max_attempts' => 50,
+                'rate' => 1728000,
+            ],
+        ]
+    ]
+]]);


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes

This PR:
- Adds a `Auth0\SDK\API\Management\AttackProtection` class for making API calls to the Management API's [Attack Protection endpoints](https://auth0.com/docs/api/management/v2#!/Attack_Protection).
- Adds a `Auth0\SDK\Contract\API\Management\AttackProtectionInterface` contract for the class, for mockability in customer tests.
- Updates the `Auth0\SDK\API\Management` Management API class factory to add support for the AttackProtection class.
- Adds the `AttackProtectionTest` unit tests for the new endpoints.

### References

Please see internal Jira ticket SDK-3117 for further details.

### Testing

- This PR introduces new tests. All new methods are covered.
- 100% unit test coverage is ensured.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
