### PR TITLE
Update `firebase/php-jwt` dependency to 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "require-dev": {
     "ergebnis/phpstan-rules": "^0.15",
-    "firebase/php-jwt": "^5.0",
+    "firebase/php-jwt": "^6.0",
     "hyperf/event": "^2.2",
     "infection/infection": "^0.23",
     "mockery/mockery": "^1.4",


### PR DESCRIPTION
This PR updates the `firebase/php-jwt` development dependency to address [CVE-2021-46743](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46743) — although, it should be noted, this dependency is only used to generate test tokens for running our unit tests, and the vulnerability is therefor not a concern for production use.