### PR TITLE
throw InvalidTokenException on JsonException

### DIFF
--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -208,4 +208,11 @@ final class InvalidTokenException extends \Exception implements Auth0Exception
     ): self {
         return new self(sprintf(self::MSG_MISMATCHED_ORG_ID_CLAIM, $expected, $found), 0, $previous);
     }
+
+    public static function jsonError(
+        string $message,
+        ?\Throwable $previous = null
+    ): self {
+        return new self($message, 0, $previous);
+    }
 }

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -83,8 +83,14 @@ final class Parser
 
         $this->tokenRaw = $jwt;
         $this->tokenParts = $parts;
-        $this->tokenHeaders = $this->decodeHeaders($parts[0]);
-        $this->tokenClaims = $this->decodeClaims($parts[1]);
+
+        try {
+            $this->tokenHeaders = $this->decodeHeaders($parts[0]);
+            $this->tokenClaims = $this->decodeClaims($parts[1]);
+        } catch (\JsonException $exception) {
+            throw \Auth0\SDK\Exception\InvalidTokenException::jsonError($exception->getMessage());
+        }
+
         $this->tokenSignature = $this->decodeSignature($parts[2]);
 
         // @codeCoverageIgnoreStart

--- a/tests/Unit/Token/ParserTest.php
+++ b/tests/Unit/Token/ParserTest.php
@@ -19,6 +19,26 @@ beforeEach(function() {
     ]);
 });
 
+it('throws an exception with json error on decoding headers', function(
+    SdkConfiguration $configuration
+): void {
+    $jwt = sprintf('1234567879.%s.%s', uniqid(), uniqid());
+
+    $token = new Parser($jwt, $configuration);
+})->with(['mocked configured' => [
+    fn() => $this->configuration
+]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, 'Malformed UTF-8 characters, possibly incorrectly encoded');
+
+it('throws an exception with json error on decoding claims', function(
+    SdkConfiguration $configuration
+): void {
+    $jwt = sprintf('%s.1234567879.%s', uniqid(), uniqid());
+
+    $token = new Parser($jwt, $configuration);
+})->with(['mocked configured' => [
+    fn() => $this->configuration
+]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, 'Malformed UTF-8 characters, possibly incorrectly encoded');
+
 it('throws an exception with malformed token separators', function(
     SdkConfiguration $configuration
 ): void {


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

### Changes
The `Parser::parse()` method can throw `JsonException`. In the scope of this PR, the change involves catching `JsonException` and throwing `InvalidTokenException` in such a case.

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->
