### PR TITLE
[SDK-3268] Add bearer token extraction helper

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -527,7 +527,7 @@ final class Auth0 implements Auth0Interface
      * @param array<string>|null $get Optional. An array of viable parameter names to search against $_GET as a token candidate.
      * @param array<string>|null $post Optional. An array of viable parameter names to search against $_POST as a token candidate.
      * @param array<string>|null $server Optional. An array of viable parameter names to search against $_SERVER as a token candidate.
-     * @param array<string>|null $haystack Optional. An array of viable names to search against $_SERVER as a token candidate.
+     * @param array<string>|null $haystack Optional. A key-value array in which to search for `$needles` as token candidates.
      * @param array<string>|null $needles Optional. An array of viable keys to search against `$haystack` as token candidates.
      */
     public function getBearerToken(

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -522,6 +522,73 @@ final class Auth0 implements Auth0Interface
     }
 
     /**
+     * Get an available bearer token from a variety of input sources.
+     *
+     * @param array<string>|null $get Optional. An array of viable parameter names to search against $_GET as a token candidate.
+     * @param array<string>|null $post Optional. An array of viable parameter names to search against $_POST as a token candidate.
+     * @param array<string>|null $server Optional. An array of viable parameter names to search against $_SERVER as a token candidate.
+     * @param array<string>|null $haystack Optional. An array of viable names to search against $_SERVER as a token candidate.
+     * @param array<string>|null $needles Optional. An array of viable keys to search against `$haystack` as token candidates.
+     */
+    public function getBearerToken(
+        ?array $get = null,
+        ?array $post = null,
+        ?array $server = null,
+        ?array $haystack = null,
+        ?array $needles = null
+    ): ?TokenInterface {
+        if ($get !== null && count($get) >= 1 && count($_GET) >= 1) {
+            foreach ($get as $parameterName) {
+                if (isset($_GET[$parameterName]) && is_string($_GET[$parameterName])) {
+                    $candidate = $this->processBearerToken($_GET[$parameterName]);
+
+                    if ($candidate !== null) {
+                        return $candidate;
+                    }
+                }
+            }
+        }
+
+        if ($post !== null && count($post) >= 1 && count($_POST) >= 1) {
+            foreach ($post as $parameterName) {
+                if (isset($_POST[$parameterName]) && is_string($_POST[$parameterName])) {
+                    $candidate = $this->processBearerToken($_POST[$parameterName]);
+
+                    if ($candidate !== null) {
+                        return $candidate;
+                    }
+                }
+            }
+        }
+
+        if ($server !== null && count($server) >= 1 && count($_SERVER) >= 1) {
+            foreach ($server as $parameterName) {
+                if (isset($_SERVER[$parameterName]) && is_string($_SERVER[$parameterName])) {
+                    $candidate = $this->processBearerToken($_SERVER[$parameterName]);
+
+                    if ($candidate !== null) {
+                        return $candidate;
+                    }
+                }
+            }
+        }
+
+        if ($needles !== null && $haystack !== null && count($needles) >= 1 && count($haystack) >= 1) {
+            foreach ($needles as $needle) {
+                if (isset($haystack[$needle])) {
+                    $candidate = $this->processBearerToken($haystack[$needle]);
+
+                    if ($candidate !== null) {
+                        return $candidate;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Updates the active session's stored Id Token.
      *
      * @param string $idToken Id token returned from the code exchange.
@@ -753,5 +820,22 @@ final class Auth0 implements Auth0Interface
         }
 
         return $this;
+    }
+
+    private function processBearerToken(
+        string $token
+    ): ?TokenInterface {
+        $token = trim($token);
+        $token = substr($token, 0, 7) === 'Bearer ' ? trim(substr($token, 7)) : $token;
+
+        if (strlen($token) >= 1) {
+            try {
+                return $this->decode($token, null, null, null, null, null, null, \Auth0\SDK\Token::TYPE_TOKEN);
+            } catch (\Auth0\SDK\Exception\InvalidTokenException $exception) {
+                return null;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -527,7 +527,7 @@ final class Auth0 implements Auth0Interface
      * @param array<string>|null $get Optional. An array of viable parameter names to search against $_GET as a token candidate.
      * @param array<string>|null $post Optional. An array of viable parameter names to search against $_POST as a token candidate.
      * @param array<string>|null $server Optional. An array of viable parameter names to search against $_SERVER as a token candidate.
-     * @param array<string>|null $haystack Optional. A key-value array in which to search for `$needles` as token candidates.
+     * @param array<string,string>|null $haystack Optional. A key-value array in which to search for `$needles` as token candidates.
      * @param array<string>|null $needles Optional. An array of viable keys to search against `$haystack` as token candidates.
      */
     public function getBearerToken(

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -844,7 +844,9 @@ test('getBearerToken() successfully finds a candidate token in $_GET', function(
     ]));
 
     $this->assertIsObject($auth0->getBearerToken(
-        get: [$testParameterName]
+        [
+            $testParameterName
+        ],
     ));
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -862,7 +864,10 @@ test('getBearerToken() successfully finds a candidate token in $_POST', function
     ]));
 
     $this->assertIsObject($auth0->getBearerToken(
-        post: [$testParameterName]
+        null,
+        [
+            $testParameterName
+        ],
     ));
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -880,7 +885,11 @@ test('getBearerToken() successfully finds a candidate token in $_SERVER', functi
     ]));
 
     $this->assertIsObject($auth0->getBearerToken(
-        server: [$testParameterName]
+        null,
+        null,
+        [
+            $testParameterName
+        ],
     ));
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -897,8 +906,10 @@ test('getBearerToken() successfully finds a candidate token needle in a haystack
     ]));
 
     $this->assertIsObject($auth0->getBearerToken(
-        needles: [uniqid(), $testParameterName, uniqid(), uniqid(), uniqid()],
-        haystack: [
+        null,
+        null,
+        null,
+        [
             uniqid() => uniqid(),
             uniqid() => uniqid(),
             uniqid() => uniqid(),
@@ -906,7 +917,14 @@ test('getBearerToken() successfully finds a candidate token needle in a haystack
             uniqid() => uniqid(),
             uniqid() => uniqid(),
             uniqid() => uniqid(),
-        ]
+        ],
+        [
+            uniqid(),
+            $testParameterName,
+            uniqid(),
+            uniqid(),
+            uniqid()
+        ],
     ));
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -927,8 +945,10 @@ test('getBearerToken() correctly returns null when there are no candidates', fun
     ]));
 
     $this->assertEquals($auth0->getBearerToken(
-        needles: [uniqid(), $testParameterName, uniqid(), uniqid(), uniqid()],
-        haystack: [
+        null,
+        null,
+        null,
+        [
             uniqid() => uniqid(),
             uniqid() => uniqid(),
             uniqid() => uniqid(),
@@ -936,7 +956,14 @@ test('getBearerToken() correctly returns null when there are no candidates', fun
             uniqid() => uniqid(),
             uniqid() => uniqid(),
             uniqid() => uniqid(),
-        ]
+        ],
+        [
+            uniqid(),
+            $testParameterName,
+            uniqid(),
+            uniqid(),
+            uniqid()
+        ],
     ), null);
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
@@ -953,9 +980,14 @@ test('getBearerToken() correctly returns null when the candidate value is empty'
     ]));
 
     $this->assertEquals($auth0->getBearerToken(
-        needles: [$testParameterName],
-        haystack: [
+        null,
+        null,
+        null,
+        [
             $testParameterName => '',
+        ],
+        [
+            $testParameterName
         ]
     ), null);
 })->with(['mocked rs256 bearer token' => [
@@ -976,7 +1008,7 @@ test('getBearerToken() correctly silently handles token validation exceptions', 
     ]));
 
     $this->assertEquals($auth0->getBearerToken(
-        get: [$testParameterName],
+        [$testParameterName],
     ), null);
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\Tests\Utilities;
 
 use Firebase\JWT\JWT;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Class TokenGenerator.
@@ -171,6 +172,13 @@ class TokenGenerator
         $response->claims = $claims;
         $response->jwks = 'https://test.auth0.com/.well-known/jwks.json';
         $response->cache = hash('sha256', 'https://test.auth0.com/.well-known/jwks.json');
+
+        $cache = new ArrayAdapter();
+        $item = $cache->getItem($response->cache);
+        $item->set(['__test_kid__' => ['x5c' => [$keys['cert']]]]);
+        $cache->save($item);
+
+        $response->cached = $cache;
 
         return $response;
     }


### PR DESCRIPTION
This PR adds a new method to the SDK class, `getBearerToken()`. This method is highly configurable and enable a developer to pull an available bearer token from a request from a variety of sources (request parameters, post body, etc.) while avoiding writing considerable and redundant boilerplate code.

Example usage:
```php
$sdk->getBearerToken(
  get: ['token'],
  server: ['Authorization']
);
```

This would fetch and process an available access token from either an incoming GET request via a parameter named 'token', or from the request's “Authorization” header, where it might find a bearer token. The method silently ignores invalid or missing tokens from any provided candidate.

The PR adds several new tests to add coverage for the new method. Code coverage remains at 100%.