### PR TITLE
Correct the new method name for get_authorize_link() for 8.x in UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,8 +66,8 @@ These classes were updated in SDK 8.0:
     - `configuration` added as a required instance of either an `SdkConfiguration` class, or an array of configuration options. See the [8.0 configuration](#configuring-auth0-sdk-80) and [8.0 configuration options](#updated-configuration-options) guides for usage information.
     - All other arguments have been removed.
   - Public method 'getHttpClient()' added.
-  - Public method `get_authorize_link()` renamed to `getAuthorizationLink()`, and:
-    - Method now accepts an argument, `params`: an array of parameters to pass with the request. Please see the API endpoint documentation for available options.
+  - Public method `get_authorize_link()` renamed to `getLoginLink()`, and:
+    - Method now accepts an argument, `params`: an array of parameters to pass with the request. Please see the API endpoint documentation for available options. Note also the previously optional `state` argument is now required.
   - Public method `get_samlp_link()` renamed to `getSamlpLink()`, and:
     - Argument `client_id` renamed to `clientId`.
   - Public method `get_samlp_metadata_link()` renamed to `getSamlpMetadataLink()`, and:


### PR DESCRIPTION
### Overview
This change corrects UPGRADE.md where it states that the `get_authorize_link()` method was changed to `getAuthorizationLink()` in the `Auth0\SDK\API\Authentication` class. `getAuthorizationLink()` does not exist in this class and it appears that the new method is called `getLoginLink()` since, although it has a different method signature, it appears to do the same thing. This PR also updated the documentation to indicate that the `state` parameter which was optional in the `get_authorize_link()` method is now required in the `getLoginLink()` method.

### Changes
- This PR changes the erroneous documentation which stated that the `get_authorize_link` method was renamed to `getAuthorizationLink`, where it appears to have been renamed to `getLoginLink`.
- This PR also highlights that the `state` parameter in the new method is required where it was optional in the previous method.

### References
Resolves #622

### Testing

This is a documentation update so there are no associated automated tests

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
