### PR TITLE
fix: Ensure custom tenant domains are formatted correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ psalm.xml.dist
 rector.php
 phpdoc.phar
 .phpdoc
+phpdoc.dist.xml

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -468,7 +468,7 @@ final class SdkConfiguration implements ConfigurableContract
             throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
         }
 
-        if ($propertyName === 'domain') {
+        if ($propertyName === 'domain' || $propertyName === 'customDomain') {
             if (is_string($propertyValue) && mb_strlen($propertyValue) !== 0) {
                 $host = parse_url($propertyValue, PHP_URL_HOST);
                 return $host ?? $propertyValue;

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -288,7 +288,7 @@ test('formatDomain() returns the custom domain when a custom domain is configure
 
     $sdk = new SdkConfiguration([
         'domain' => $domain,
-        'customDomain' => $customDomain,
+        'customDomain' => 'test://' . $customDomain,
         'cookieSecret' => uniqid(),
         'clientId' => uniqid(),
         'redirectUri' => uniqid(),


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

This PR includes a minor change to ensure custom domains are properly formatted in the same way as tenant domains already are.

Previously, if a protocol was provided when setting the custom domain variable, it was not stripped, which is counter to the way the tenant domain setting is handled, and problematic as this would lead to duplicate protocols being prefixed to the string.

Using an example configuration provided by the issue creator of the bug report:

```
$configuration = new SdkConfiguration([
    "strategy" => SdkConfiguration::STRATEGY_API,
    "audience" => $settings["audience"],
    "domain" => "https://tenant.eu.auth0.com/",
    "customDomain" => "https://auth.example.com/"
]);
```

**Before** this change:
```
$this->auth0->configuration()->getDomain(): tenant.eu.auth0.com
$this->auth0->configuration()->getCustomDomain(): https://auth.example.com/
$this->auth0->configuration()->formatDomain(): https://https://auth.example.com/
$this->auth0->configuration()->formatCustomDomain(): https://https://auth.example.com/
```

**After** this change:
```
$this->auth0->configuration()->getDomain(): tenant.eu.auth0.com
$this->auth0->configuration()->getCustomDomain(): https://auth.example.com/
$this->auth0->configuration()->formatDomain(): https://auth.example.com/
$this->auth0->configuration()->formatCustomDomain(): https://auth.example.com/
```

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #630

### Testing

* An `SdkConfiguration` test was updated to cover checking for duplicated protocols provided on custom domains.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
