### PR TITLE
Release 8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## [8.2.1](https://github.com/auth0/auth0-PHP/tree/8.2.1) (2022-06-06)
+
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.2.0..8.2.1)
+
+**Fixed**
+
+- Fixed an issue in `Auth0\SDK\Configuration\SdkConfiguration` where `customDomain` was not properly formatted in some configurations, leading to inconsistencies in certain SDK functions, such as Token validation. `customDomain` is now formatted identically to `domain`. [#633](https://github.com/auth0/auth0-PHP/pull/633) ([evansims](https://github.com/evansims))
+
+**Closed Issues**
+
+- Resolves [#630](https://github.com/auth0/auth0-PHP/issues/630) ([barasimumatik](https://github.com/barasimumatik))
+
 ## [8.2.0](https://github.com/auth0/auth0-PHP/tree/8.2.0) (2022-04-25)
 
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.1.0..8.2.0)

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -22,7 +22,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.2.0';
+    public const VERSION = '8.2.1';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.2.0..8.2.1)

**Fixed**

- Fixed an issue in `Auth0\SDK\Configuration\SdkConfiguration` where `customDomain` was not properly formatted in some configurations, leading to inconsistencies in certain SDK functions, such as Token validation. `customDomain` is now formatted identically to `domain`. [#633](https://github.com/auth0/auth0-PHP/pull/633) ([evansims](https://github.com/evansims))

**Closed Issues**

- Resolves [#630](https://github.com/auth0/auth0-PHP/issues/630) ([barasimumatik](https://github.com/barasimumatik))