### PR TITLE
[SDK-3456] Improvements to (cookie) session storage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The Auth0 PHP SDK is a straightforward and rigorously-tested library for accessi
   - [SDK Initialization](#sdk-initialization)
   - [Configuration Options](#configuration-options)
   - [Configuration Strategies](#configuration-strategies)
+  - [Session Storage](#session-storage)
+    - [Cookies (Default)](#cookies-default)
+    - [PHP Sessions (Recommended)](#php-sessions-recommended)
+    - [PSR-6 (Advanced)](#psr-6-advanced)
   - [Checking for an active session](#checking-for-an-active-session)
   - [Checking for an expired session](#checking-for-an-expired-session)
   - [Authorizing User](#authorizing-user)
@@ -239,6 +243,49 @@ The PHP SDK is a robust and flexible library capable of integration with many ty
 - `webapp`, the default configuration, will require `domain` and `clientId`. `clientSecret` is required when `tokenAlgorithm` is set to `HS256`. This is suitable for most application types.
 - `api` indicates you'll be using the SDK in a stateless API-only environment; only `domain` and `audience` are required in this configuration.
 - `management` is for stateless applications exclusively using Management API calls; `domain` is required. You must also provide either a `managementToken`, or assign `clientId` and `clientSecret` for the SDK to automatically aquire a token.
+
+### Session Storage
+
+When configured for a `webapp` strategy (the default strategy; see [Configuration Strategies](#configuration-strategies) above), the SDK will use a configured session storage interface to persist state data between requests. This is referred to as "stateful" storage, as it relies on a state being persisted between requests to maintain an end user's the session.
+
+Note that other "stateless" strategies such as `api` and `management` do not persist state data between requests, and therefor session storage configuration is not required.
+
+#### Cookies (Default)
+
+By default, the SDK will use cookies stored on an end-user's device to persist state data between requests. This data is stored in an encrypted state on the device. When using this storage method, the SDK will use the following configuration options to customize storage behavior:
+
+- `cookieSecret` (a string) to derive an encryption key for the session cookie.
+  - This should be a long, unique string that is ideally cryptographically generated. For example, running `openssl rand -hex 64` from a shell would deliver a viable string for this use.
+- `cookieDomain` (a string; falls back to your environment's `HTTP_HOST` if none is provided) to determine the domain to use for the session cookie.
+  - In most cases, this should be the domain of your application. To make cookies visible on all subdomains then the domain must be prefixed with a dot, like '.example.com'.
+- `cookieExpires` (an integer; defaults to `0`) to determine the expiration time (in seconds) for the session cookie.
+  - If set to `0` the cookie will expire at the end of the session (usually [but not always] when the browser closes).
+- `cookiePath` (a string; defaults to `/`) to determine the path to use for the session cookie.
+  - This is useful if you host multiple application instances on the same domain, at different paths.
+- `cookieSecure` (a boolean; defaults to `false`) to determine whether the session cookie should only be sent over secure connections.
+  - In production environments you should set this to `true`, unless you have a very good reason not to and [understand the risks](https://owasp.org/www-community/controls/SecureCookieAttribute).
+
+It's important to configure these values properly for your application to ensure session cookies are stored securely and accessible to your application, especially once it is pushed to production.
+
+Cookies are stored in an encrypted state using the `cookieSecret` as a salt, and it is therefor important to keep this value secure. Treat it like a password. Because of the size of these encrypted cookies can sometimes grow relatively large (varying based on the size of the user data), the SDK uses a technique called "chunking" to avoid hitting size limitations imposed by some browsers. The SDK will manage these chunked cookies (ending in a suffix of _1, _2, and so on) efficiently. Note that some legacy browsers that have reached end-of-life, particularly Internet Explorer, may have trouble with chunked cookies.
+
+In some environments this chunked cookie approach may not be suitable for you, such as applications that run behind a load balancer that impose stricter limits on cookie sizes. For example, some Customers have reported issues with load balances like AWS Elastic Load Balancing due to cookie header restrictions. In these cases you can use the SDK's support for [native PHP sessions](#php-sessions) instead.
+
+#### PHP Sessions (Recommended)
+
+To use native PHP sessions, you can set the `sessionStorage` configuration option to an instance of `Auth0\SDK\Store\SessionStore` during SDK initialization. Note that SDK configuration options for cookies are not applied in this case, and the SDK will instead rely on PHP's native session storage handling. You can learn more about native sessions from the PHP documentation site: [https://www.php.net/manual/en/book.session.php](https://www.php.net/manual/en/book.session.php)
+
+Although native sessions are simple, reliable and secure, they are more complicated to deploy in real production environments, particularly where load balanced application servers are in use. This is the only reason the storage medium is not the default for the SDK. In load balanced environments, you have to configure your PHP environment's session storage to be available across all of your balanced application servers. This is usually accomplished with memcache or AWS ElastiCache, but there are many options available. This topic is outside the scope of this SDK's documentation, but you should review [the PHP documentation](https://www.php.net/manual/en/book.session.php) for the `session.save_handler` and `session.save_path` settings in your PHP configuration file.
+
+#### PSR-6 (Advanced)
+
+The SDK also supports a generic storage interface for connecting PSR-6 compatible cache libraries. To use this approach, set the `sessionStorage` configuration option to an instance of `Auth0\SDK\Store\Psr6Store`. This method requires you to create custom code that implements the `Auth0\SDK\Contract\StoreInterface` interface to connect with your services/libraries of choice.
+
+This storage mechanism supports three configuration parameters at initialization: `publicStore`, `privateStore` and `storageKey`.
+
+- `publicStore` should be a custom class that implements the `Auth0\SDK\Contract\StoreInterface` interface, for connecting to your backend of choice.
+- `privateStore` is an instance of a PSR-6 compatible class that implements `Psr\Cache\CacheItemPoolInterface`.
+- `storageKey` is a string that will be used to prefix all keys stored in the cache, so it should be unique to your application.
 
 ### Checking for an active session
 

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -468,6 +468,14 @@ final class SdkConfiguration implements ConfigurableContract
             throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
         }
 
+        if ($propertyName === 'cookieSecret') {
+            if (is_string($propertyValue) && mb_strlen($propertyValue) !== 0) {
+                return $propertyValue;
+            }
+
+            throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
+        }
+
         if ($propertyName === 'domain' || $propertyName === 'customDomain') {
             if (is_string($propertyValue) && mb_strlen($propertyValue) !== 0) {
                 $host = parse_url($propertyValue, PHP_URL_HOST);

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -563,5 +563,9 @@ final class SdkConfiguration implements ConfigurableContract
         if ($this->getTokenAlgorithm() === 'HS256' && ! $this->hasClientSecret()) {
             throw \Auth0\SDK\Exception\ConfigurationException::requiresClientSecret();
         }
+
+        if (! $this->hasCookieSecret()) {
+            throw \Auth0\SDK\Exception\ConfigurationException::requiresCookieSecret();
+        }
     }
 }

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -174,6 +174,7 @@ test('an invalid strategy throws an exception', function(): void
 test('a non-existent array value is ignored', function(): void
 {
     $sdk = new SdkConfiguration([
+        'strategy' => 'none',
         'domain' => uniqid(),
         'clientId' => uniqid(),
         'organization' => [],
@@ -187,6 +188,7 @@ test('a `webapp` strategy is used by default', function(): void
     $sdk = new SdkConfiguration([
         'domain' => uniqid(),
         'clientId' => uniqid(),
+        'cookieSecret' => uniqid(),
     ]);
 
     expect($sdk->getStrategy())->toEqual('webapp');

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -76,6 +76,32 @@ test('__construct() throws an exception if domain is an empty string', function(
     ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'domain'));
 
+test('__construct() throws an exception if cookieSecret is undefined', function(): void {
+    $domain = uniqid();
+    $clientId = uniqid();
+    $redirectUri = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'cookieSecret' => null,
+        'clientId' => $clientId,
+        'redirectUri' => $redirectUri,
+    ]);
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
+
+test('__construct() throws an exception if cookieSecret is an empty string', function(): void {
+    $domain = uniqid();
+    $clientId = uniqid();
+    $redirectUri = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => $domain,
+        'cookieSecret' => '',
+        'clientId' => $clientId,
+        'redirectUri' => $redirectUri,
+    ]);
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'cookieSecret'));
+
 test('__construct() throws an exception if an invalid token algorithm is specified', function(): void {
     $domain = uniqid();
     $cookieSecret = uniqid();


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

This PR:

- Adds a `cookieSecret` check to the validator for the (default) stateful `webapp` strategy, used by regular PHP web applications. This is not a breaking change as this strategy would not work at all without this being configured, but a lack of error messaging when it was relied upon but not configured led to confusion.
- Adds a check to ensure `cookieSecret` is never an empty string.
- Updates the README to detail how the various session storage methods work, and identifies the tradeoffs in complexity for each storage method.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #636

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Minor adjustments were made to the SdkConfiguration tests to cover the changes. 

### Contributor Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
