### PR TITLE
[SDK-3631] Defer/batch "Set-Cookie" headers at `login()` for transient cookies, and `clear()`

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -93,6 +93,8 @@ final class Auth0 implements Auth0Interface
         ?string $redirectUrl = null,
         ?array $params = null
     ): string {
+        $this->deferStateSaving();
+
         $params = $params ?? [];
         $state = $params['state'] ?? $this->getTransientStore()->issue('state');
         $params['nonce'] = $params['nonce'] ?? $this->getTransientStore()->issue('nonce');
@@ -110,6 +112,8 @@ final class Auth0 implements Auth0Interface
         if ($params['max_age'] !== null) {
             $this->getTransientStore()->store('max_age', (string) $params['max_age']);
         }
+
+        $this->deferStateSaving(false);
 
         return $this->authentication()->getLoginLink((string) $state, $redirectUrl, $params);
     }
@@ -159,6 +163,8 @@ final class Auth0 implements Auth0Interface
     public function clear(
         bool $transient = true
     ): self {
+        $this->deferStateSaving();
+
         // Delete all data in the session storage medium.
         if ($this->configuration()->hasSessionStorage()) {
             $this->configuration->getSessionStorage()->purge();


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to committing work.
-->

### Changes

Building on the previous implementation of “Set-Cookie” header batching/deference during exchange(), this tweak optimizes in the same manner for clear() and login() calls. Critically, this resolves a common issue for apps behind load balancers like AWS Elastic Load Balancing where there is a hard limit on cookie header sizes, but the change is beneficial for all apps in reducing network overhead.

### References

See internal ticket SDK-3631

### Testing

See GitHub workflow results.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
