### PR TITLE
[SDK-3632] Update `getRequestParameter()` filter to use FILTER_SANITIZE_FULL_SPECIAL_CHARS and allow passing extra filter options

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -548,11 +548,11 @@ final class Auth0 implements Auth0Interface
         $responseMode = $this->configuration()->getResponseMode();
 
         if ($responseMode === 'query' && isset($_GET[$parameterName])) {
-            return filter_var(trim($_GET[$parameterName]), $filter, $filterOptions);
+            return filter_var(trim((string) $_GET[$parameterName]), $filter, $filterOptions);
         }
 
         if ($responseMode === 'form_post' && isset($_POST[$parameterName])) {
-            return filter_var(trim($_POST[$parameterName]), $filter, $filterOptions);
+            return filter_var(trim((string) $_POST[$parameterName]), $filter, $filterOptions);
         }
 
         return null;

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -542,16 +542,17 @@ final class Auth0 implements Auth0Interface
 
     public function getRequestParameter(
         string $parameterName,
-        int $filter = \FILTER_UNSAFE_RAW
+        int $filter = FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        array $filterOptions = []
     ): ?string {
         $responseMode = $this->configuration()->getResponseMode();
 
         if ($responseMode === 'query' && isset($_GET[$parameterName])) {
-            return filter_var($_GET[$parameterName], $filter, FILTER_NULL_ON_FAILURE);
+            return filter_var(trim($_GET[$parameterName]), $filter, $filterOptions);
         }
 
         if ($responseMode === 'form_post' && isset($_POST[$parameterName])) {
-            return filter_var($_POST[$parameterName], $filter, FILTER_NULL_ON_FAILURE);
+            return filter_var(trim($_POST[$parameterName]), $filter, $filterOptions);
         }
 
         return null;

--- a/src/Contract/Auth0Interface.php
+++ b/src/Contract/Auth0Interface.php
@@ -278,11 +278,13 @@ interface Auth0Interface
      * Get the specified parameter from POST or GET, depending on configured response mode.
      *
      * @param string $parameterName Name of the parameter to pull from the request.
-     * @param int $filter Defaults to \FILTER_UNSAFE_RAW. The type of PHP filter_var() filter to apply.
+     * @param int $filter Defaults to \FILTER_SANITIZE_FULL_SPECIAL_CHARS. The type of PHP filter_var() filter to apply.
+     * @param int[] $filterOptions Optional. Any additional `filter_var()` sanitization filters to pass. See: https://www.php.net/manual/en/filter.filters.sanitize.php
      */
     public function getRequestParameter(
         string $parameterName,
-        int $filter = \FILTER_UNSAFE_RAW
+        int $filter = FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        array $filterOptions = []
     ): ?string;
 
     /**


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to committing work.
-->

### Changes

This change replaces the default input sanitizer rule of `FILTER_UNSAFE_RAW` with `FILTER_SANITIZE_FULL_SPECIAL_CHARS`, which is a better default for filtering user input data and addresses `FILTER_UNSAFE_RAW` being marked for deprecation in an upcoming PHP release.

Along with this change, we are applying trim() to ensure whitespace is cleared on the input data, and allowing developers to pass custom filter options to `getRequestParameter()` when they need more control over the sanitizer rule options.

These are non-breaking changes.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3632

### Testing

See GitHub workflow results.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
