### PR TITLE
[SDK-3633] Treat passing an empty string to SdkConfiguration as the default undefined value type of NULL

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php74\Rector\Property\TypedPropertyRector;
@@ -12,6 +13,13 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->sets([
         SetList::CODE_QUALITY,
+    ]);
+
+    $rectorConfig->skip([
+        CompleteDynamicPropertiesRector::class => [
+            // Breaks PEST
+            __DIR__ . '/tests/Utilities/MockApi.php'
+        ]
     ]);
 
     $rectorConfig->rule(TypedPropertyRector::class);

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -468,18 +468,21 @@ final class SdkConfiguration implements ConfigurableContract
             throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
         }
 
-        if ($propertyName === 'cookieSecret') {
-            if (is_string($propertyValue) && mb_strlen($propertyValue) !== 0) {
-                return $propertyValue;
-            }
-
-            throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);
-        }
-
         if ($propertyName === 'domain' || $propertyName === 'customDomain') {
-            if (is_string($propertyValue) && mb_strlen($propertyValue) !== 0) {
-                $host = parse_url($propertyValue, PHP_URL_HOST);
-                return $host ?? $propertyValue;
+            if (is_string($propertyValue)) {
+                $propertyValue = trim($propertyValue);
+
+                if (strlen($propertyValue) !== 0) {
+                    if (filter_var($propertyValue, FILTER_VALIDATE_DOMAIN, [FILTER_FLAG_HOSTNAME, FILTER_NULL_ON_FAILURE]) !== null) {
+                        $host = preg_replace('#^[^:/.]*[:/]+#i', '', $propertyValue);
+                        $host = parse_url('https://' . $host, PHP_URL_HOST);
+                        $host = filter_var($host, FILTER_SANITIZE_URL, FILTER_NULL_ON_FAILURE);
+
+                        if (is_string($host) && strlen($host) !== 0) {
+                            return $host;
+                        }
+                    }
+                }
             }
 
             throw \Auth0\SDK\Exception\ConfigurationException::validationFailed($propertyName);

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -473,14 +473,12 @@ final class SdkConfiguration implements ConfigurableContract
                 $propertyValue = trim($propertyValue);
 
                 if (strlen($propertyValue) !== 0) {
-                    if (filter_var($propertyValue, FILTER_VALIDATE_DOMAIN, [FILTER_FLAG_HOSTNAME, FILTER_NULL_ON_FAILURE]) !== null) {
-                        $host = preg_replace('#^[^:/.]*[:/]+#i', '', $propertyValue);
-                        $host = parse_url('https://' . $host, PHP_URL_HOST);
-                        $host = filter_var($host, FILTER_SANITIZE_URL, FILTER_NULL_ON_FAILURE);
+                    $host = preg_replace('#^[^:/.]*[:/]+#i', '', $propertyValue);
+                    $host = parse_url('https://' . $host, PHP_URL_HOST);
+                    $host = filter_var($host, FILTER_SANITIZE_URL, FILTER_NULL_ON_FAILURE);
 
-                        if (is_string($host) && strlen($host) !== 0) {
-                            return $host;
-                        }
+                    if (is_string($host) && strlen($host) !== 0 && filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false) {
+                        return $host;
                     }
                 }
             }

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -264,7 +264,7 @@ trait ConfigurableMixin
             throw \Auth0\SDK\Exception\ConfigurationException::setIncompatible($propertyName, (string) $expectedType, $propertyType);
         }
 
-        if ($propertyType === 'string' && is_string($propertyValue) && strlen(trim($propertyValue)) === 0 && in_array('NULL', $allowedTypes, true)) {
+        if ($propertyType === 'string' && is_string($propertyValue) && trim($propertyValue) === '' && in_array('NULL', $allowedTypes, true)) {
             $propertyValue = null;
         }
 

--- a/src/Mixins/ConfigurableMixin.php
+++ b/src/Mixins/ConfigurableMixin.php
@@ -264,6 +264,10 @@ trait ConfigurableMixin
             throw \Auth0\SDK\Exception\ConfigurationException::setIncompatible($propertyName, (string) $expectedType, $propertyType);
         }
 
+        if ($propertyType === 'string' && is_string($propertyValue) && strlen(trim($propertyValue)) === 0 && in_array('NULL', $allowedTypes, true)) {
+            $propertyValue = null;
+        }
+
         if (method_exists($this, 'onStateChange')) {
             $propertyValue = $this->onStateChange($propertyName, $propertyValue);
         }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 define('AUTH0_TESTS_DIR', dirname(__FILE__));
 
-require_once join(DIRECTORY_SEPARATOR, [AUTH0_TESTS_DIR, '..', 'vendor', 'autoload.php']);
+require_once implode(DIRECTORY_SEPARATOR, [AUTH0_TESTS_DIR, '..', 'vendor', 'autoload.php']);
 
 // For unit tests, use a mock network client rather than sending real requests.
 uses()

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -15,7 +15,7 @@ beforeEach(function(): void {
     $_COOKIE = [];
 
     $this->configuration = [
-        'domain' => '__test_domain__',
+        'domain' => 'domain.test',
         'clientId' => '__test_client_id__',
         'cookieSecret' => uniqid(),
         'clientSecret' => '__test_client_secret__',
@@ -110,7 +110,7 @@ test('getLoginLink() returns expected default value', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('scope=openid%20profile%20email')
@@ -134,7 +134,7 @@ test('getLoginLink() returns expected value when supplying parameters', function
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('scope=openid%20profile%20email')
@@ -161,7 +161,7 @@ test('getLoginLink() returns expected value when overriding defaults', function(
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('scope=' . $params['scope'])
@@ -178,7 +178,7 @@ test('getLoginLink() assigns a nonce and state', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('state=')
@@ -192,7 +192,7 @@ test('login() assigns a challenge and challenge method when PKCE is enabled', fu
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('code_challenge=')
@@ -208,7 +208,7 @@ test('login() assigns `max_age` from default values', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('max_age=1000');
@@ -225,7 +225,7 @@ test('login() assigns `max_age` from overridden values', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('max_age=1001');
@@ -238,7 +238,7 @@ test('signup() returns a url with a `screen_hint` parameter', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('screen_hint=signup');
@@ -255,7 +255,7 @@ test('handleInvitation() creates a valid login url', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/authorize')
         ->query
             ->toContain('invitation=__test_invitation__')
@@ -280,7 +280,7 @@ test('logout() returns a a valid logout url', function(): void {
 
     expect($url)
         ->scheme->toEqual('https')
-        ->host->toEqual('__test_domain__')
+        ->host->toEqual('domain.test')
         ->path->toEqual('/v2/logout')
         ->query
             ->toContain('returnTo=' . $returnUrl)
@@ -684,7 +684,7 @@ test('renew() succeeds under expected and valid conditions', function(): void {
     expect($requestBody['client_secret'])->toEqual('__test_client_secret__');
     expect($requestBody['client_id'])->toEqual('__test_client_id__');
     expect($requestBody['refresh_token'])->toEqual('2.3.4');
-    expect($request->getUri()->__toString())->toEqual('https://__test_domain__/oauth/token');
+    expect($request->getUri()->__toString())->toEqual('https://domain.test/oauth/token');
 });
 
 test('getCredentials() returns null when a session is not available', function(): void {
@@ -1002,7 +1002,7 @@ test('getBearerToken() correctly silently handles token validation exceptions', 
     $_GET[$testParameterName] = $candidate->token;
 
     $auth0 = new \Auth0\SDK\Auth0(array_merge($this->configuration, [
-        'domain' => '__bad_domain__',
+        'domain' => 'domain.bad',
         'tokenJwksUri' => $candidate->jwks,
         'tokenCache' => $candidate->cached
     ]));

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -324,12 +324,12 @@ test('formatDomain() returns a properly formatted uri', function(): void
 
 test('formatDomain() returns the custom domain when a custom domain is configured', function(): void
 {
-    $domain = uniqid();
-    $customDomain = uniqid();
+    $domain = uniqid() . '.test';
+    $customDomain = uniqid() . '.test';
 
     $sdk = new SdkConfiguration([
         'domain' => $domain,
-        'customDomain' => 'test://' . $customDomain,
+        'customDomain' => $customDomain,
         'cookieSecret' => uniqid(),
         'clientId' => uniqid(),
         'redirectUri' => uniqid(),

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -74,6 +74,19 @@ test('__construct() throws an exception if domain is an empty string', function(
         'clientId' => $clientId,
         'redirectUri' => $redirectUri,
     ]);
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
+
+test('__construct() throws an exception if domain is an invalid uri', function(): void {
+    $cookieSecret = uniqid();
+    $clientId = uniqid();
+    $redirectUri = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => '₠',
+        'cookieSecret' => $cookieSecret,
+        'clientId' => $clientId,
+        'redirectUri' => $redirectUri,
+    ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'domain'));
 
 test('__construct() throws an exception if cookieSecret is undefined', function(): void {
@@ -100,7 +113,7 @@ test('__construct() throws an exception if cookieSecret is an empty string', fun
         'clientId' => $clientId,
         'redirectUri' => $redirectUri,
     ]);
-})->throws(\Auth0\SDK\Exception\ConfigurationException::class, sprintf(\Auth0\SDK\Exception\ConfigurationException::MSG_VALIDATION_FAILED, 'cookieSecret'));
+})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_COOKIE_SECRET);
 
 test('__construct() throws an exception if an invalid token algorithm is specified', function(): void {
     $domain = uniqid();

--- a/tests/Unit/Token/VerifierTest.php
+++ b/tests/Unit/Token/VerifierTest.php
@@ -26,7 +26,7 @@ dataset('jwksUri', static function () {
 dataset('tokenHs256', static function () {
     $token = (new TokenGenerator())->withHs256([]);
     [$headers, $claims, $signature] = explode('.', $token);
-    $payload = join('.', [$headers, $claims]);
+    $payload = implode('.', [$headers, $claims]);
     $signature = TokenGenerator::decodePart($signature, false);
 
     yield [ $token, $payload, $signature, $headers ];
@@ -36,7 +36,7 @@ dataset('tokenRs256', static function () {
     $keyPair = TokenGenerator::generateRsaKeyPair();
     $token = (new TokenGenerator())->withRs256([], $keyPair['private'], ['kid' => '__test_kid__']);
     [$headers, $claims, $signature] = explode('.', $token);
-    $payload = join('.', [$headers, $claims]);
+    $payload = implode('.', [$headers, $claims]);
     $signature = TokenGenerator::decodePart($signature, false);
 
     // Mimic JWKS response format: strip opening and closing comment lines from public key, remove line breaks.

--- a/tests/Unit/TokenTest.php
+++ b/tests/Unit/TokenTest.php
@@ -142,7 +142,7 @@ test('validate() returns a fluent interface', function(
     expect($token->validate(null, null, ['__test_org__'], $claims['nonce'], 100))->toEqual($token);
 })->with(['mocked data' => [
     function(): SdkConfiguration {
-        $this->configuration->setDomain('__test_domain__');
+        $this->configuration->setDomain('domain.test');
         $this->configuration->setClientId('__test_client_id__');
         $this->configuration->setTokenAlgorithm('HS256');
         $this->configuration->setClientSecret('__test_client_secret__');
@@ -161,7 +161,7 @@ test('validate() overrides globally configured algorithm', function(
     $token->validate(null, [ $claims['aud'] ]);
 })->with(['mocked data' => [
     function(): SdkConfiguration {
-        $this->configuration->setDomain('__test_domain__');
+        $this->configuration->setDomain('domain.test');
         $this->configuration->setClientId('__diff_client_id__');
         $this->configuration->setTokenAlgorithm('HS256');
         return $this->configuration;

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -67,9 +67,9 @@ test('an exponential back-off and jitter are being applied', function(): void {
 
     for ($i=0; $i < 10; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
-        $baseWait = intval(100 * pow(2, $i));
+        $baseWait = (int) (100 * pow(2, $i));
         $baseWaits[] = $baseWait;
-        $baseWaitSum = $baseWaitSum + $baseWait;
+        $baseWaitSum += $baseWait;
     }
 
     $response = $this->client->method('get')

--- a/tests/Unit/Utility/ToolkitTest.php
+++ b/tests/Unit/Utility/ToolkitTest.php
@@ -28,7 +28,7 @@ test('each() passes each item in an array through a function', function(): void 
     $items = ['a', 'b', 'c'];
 
     Toolkit::each($items, function(&$item, $key) {
-        $item = $item . $key;
+        $item .= $key;
     });
 
     expect($items)->toEqual(['a0', 'b1', 'c2']);
@@ -38,7 +38,7 @@ test('each() will break loop if false is returned', function(): void {
     $items = ['a', 'b', 'c'];
 
     Toolkit::each($items, function(&$item, $key) {
-        $item = $item . $key;
+        $item .= $key;
         return false;
     });
 

--- a/tests/Utilities/MockApi.php
+++ b/tests/Utilities/MockApi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\Tests\Utilities;
 
+use Auth0\SDK\API\Authentication;
 use Auth0\SDK\Utility\HttpClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -13,7 +14,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class MockApi
 {
-    public $client;
     /**
      * History container for mock requests.
      */

--- a/tests/Utilities/MockApi.php
+++ b/tests/Utilities/MockApi.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class MockApi
 {
+    public $client;
     /**
      * History container for mock requests.
      */
@@ -29,7 +30,7 @@ abstract class MockApi
         // Create an instance of the intended API.
         $this->setClient();
 
-        if ($responses !== null && ! count($responses)) {
+        if ($responses !== null && $responses === []) {
             $responses[] = HttpResponseGenerator::create();
         }
 

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -37,7 +37,7 @@ class TokenGenerator
     ): array {
         $defaults = [
             'sub' => '__test_sub__',
-            'iss' => 'https://__test_domain__/',
+            'iss' => 'https://domain.test/',
             'aud' => '__test_client_id__',
             'nonce' => '__test_nonce__',
             'auth_time' => time() - 100,

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -157,7 +157,7 @@ class TokenGenerator
         }
 
         [$headers, $claims, $signature] = explode('.', $token);
-        $payload = join('.', [$headers, $claims]);
+        $payload = implode('.', [$headers, $claims]);
         $signature = (string) TokenGenerator::decodePart($signature, false);
         $claims = (array) TokenGenerator::decodePart($claims, true);
         $headers = (array) TokenGenerator::decodePart($headers, true);


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR addresses an edge case where certain customer applications and downstream SDKs need to pass a more flexible configuration script to the PHP SDK, wherein we are able to treat an empty string to a configuration option that allows either a string (defined) or null (undefined) as the default state of undefined. This permits more flexible configuration by downstream applications.

Changes were made to the validation steps to remove excess code, now that empty strings are handled further up in the validation process. This PR also makes some improvements to the `domain` and `customDomain` validation steps to cover both the earlier string validation and to catch some edge cases where invalid URIs might be provided.

This is not a breaking change as an empty string value would still fail the configuration validation step when the configuration is used, but this handles the edge case more gracefully.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3633

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
