### PR TITLE
[SDK-3634] Add hardcoded debugging flag to CookieStore to disable encryption of session cookies

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -53,6 +53,8 @@ final class CookieStore implements StoreInterface
      *
      * @param SdkConfiguration $configuration   Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      * @param string           $namespace       A string in which to store cookies under on devices.
+     *
+     * @psalm-suppress RedundantCondition
      */
     public function __construct(
         SdkConfiguration $configuration,


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This change adds a hardcoded USE_CRYPTO const/flag to the CookieStore session storage class, for the purposes of aiding in debugging session cookie issues. This debug flag is immutable to downstream packages and intended for SDK development purposes only.

There are no public API changes with these modifications.

NOTE: Rector linter warnings are resolved by #643, these will be addressed when that PR is merged and main is merged back to this PR.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3634

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

See GitHub workflow results

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
