### PR TITLE
[SDK-3635] Enable configuration of SessionStore and CookieStore `samesite` property

### DIFF
--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -27,6 +27,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method SdkConfiguration setCookieDomain(?string $cookieDomain = null)
  * @method SdkConfiguration setCookieExpires(int $cookieExpires = 0)
  * @method SdkConfiguration setCookiePath(string $cookiePath = '/')
+ * @method SdkConfiguration setCookieSameSite(?string $cookieSameSite)
  * @method SdkConfiguration setCookieSecret(?string $cookieSecret)
  * @method SdkConfiguration setCookieSecure(bool $cookieSecure = false)
  * @method SdkConfiguration setClientId(?string $clientId = null)
@@ -69,6 +70,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method string|null getCookieDomain(?\Throwable $exceptionIfNull = null)
  * @method int getCookieExpires()
  * @method string getCookiePath()
+ * @method string|null getCookieSameSite(?\Throwable $exceptionIfNull = null)
  * @method string|null getCookieSecret(?\Throwable $exceptionIfNull = null)
  * @method bool getCookieSecure()
  * @method string|null getClientId(?\Throwable $exceptionIfNull = null)
@@ -111,6 +113,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * @method bool hasCookieDomain()
  * @method bool hasCookieExpires()
  * @method bool hasCookiePath()
+ * @method bool hasCookieSameSite()
  * @method bool hasCookieSecret()
  * @method bool hasCookieSecure()
  * @method bool hasClientId()
@@ -200,6 +203,7 @@ final class SdkConfiguration implements ConfigurableContract
      * @param string|null                    $cookieDomain          Defaults to value of HTTP_HOST server environment information. Cookie domain, for example 'www.example.com', for use with PHP sessions and SDK cookies. To make cookies visible on all subdomains then the domain must be prefixed with a dot like '.example.com'.
      * @param int                            $cookieExpires         Defaults to 0. How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
      * @param string                         $cookiePath            Defaults to '/'. Specifies path on the domain where the cookies will work. Use a single slash ('/') for all paths on the domain.
+     * @param string|null                    $cookieSameSite        Defaults to 'lax'. Specifies whether cookies should be restricted to first-party or same-site context.
      * @param bool                           $cookieSecure          Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
      * @param bool                           $persistUser           Defaults to true. If true, the user data will persist in session storage.
      * @param bool                           $persistIdToken        Defaults to true. If true, the Id Token will persist in session storage.
@@ -247,6 +251,7 @@ final class SdkConfiguration implements ConfigurableContract
         int $cookieExpires = 0,
         string $cookiePath = '/',
         bool $cookieSecure = false,
+        ?string $cookieSameSite = null,
         bool $persistUser = true,
         bool $persistIdToken = true,
         bool $persistAccessToken = true,

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -202,6 +202,7 @@ final class CookieStore implements StoreInterface
                     // Push the updated cookie to the host device for persistence.
                     // @codeCoverageIgnoreStart
                     if (! defined('AUTH0_TESTS_DIR')) {
+                        /** @var array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool, samesite?: 'Lax'|'lax'|'None'|'none'|'Strict'|'strict', url_encode?: int} $setOptions */
                         setcookie($cookieName, $chunk, $setOptions);
                     }
                     // @codeCoverageIgnoreEnd
@@ -222,6 +223,7 @@ final class CookieStore implements StoreInterface
             // Push the cookie deletion command to the host device.
             // @codeCoverageIgnoreStart
             if (! defined('AUTH0_TESTS_DIR')) {
+                /** @var array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool, samesite?: 'Lax'|'lax'|'None'|'none'|'Strict'|'strict', url_encode?: int} $deleteOptions */
                 setcookie($cookieName, '', $deleteOptions);
             }
             // @codeCoverageIgnoreEnd
@@ -407,7 +409,7 @@ final class CookieStore implements StoreInterface
      *
      * @param int|null $expires
      *
-     * @return array{expires?: int, path?: string, domain?: string, secure?: bool, httponly?: bool, samesite?: 'Lax'|'lax'|'None'|'none'|'Strict'|'strict', url_encode?: int}
+     * @return array{expires: int, path: string, domain?: string, secure: bool, httponly: bool, samesite: string, url_encode?: int}
      */
     private function getCookieOptions(
         ?int $expires = null
@@ -423,8 +425,12 @@ final class CookieStore implements StoreInterface
             'path' => $this->configuration->getCookiePath(),
             'secure' => $this->configuration->getCookieSecure(),
             'httponly' => true,
-            'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : 'Lax',
+            'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax'
         ];
+
+        if(! in_array(strtolower($options['samesite']), ['lax', 'none', 'strict'], true)) {
+            $options['samesite'] = 'Lax';
+        }
 
         $domain = $this->configuration->getCookieDomain() ?? $_SERVER['HTTP_HOST'] ?? null;
 

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -338,7 +338,7 @@ final class CookieStore implements StoreInterface
             'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax'
         ];
 
-        if(! in_array(strtolower($options['samesite']), ['lax', 'none', 'strict'], true)) {
+        if (! in_array(strtolower($options['samesite']), ['lax', 'none', 'strict'], true)) {
             $options['samesite'] = 'Lax';
         }
 

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -313,6 +313,45 @@ final class CookieStore implements StoreInterface
         }
     }
 
+
+    /**
+     * Build options array for use with setcookie()
+     *
+     * @param int|null $expires
+     *
+     * @return array{expires: int, path: string, domain?: string, secure: bool, httponly: bool, samesite: string, url_encode?: int}
+     */
+    public function getCookieOptions(
+        ?int $expires = null
+    ): array {
+        $expires = $expires ?? $this->configuration->getCookieExpires();
+
+        if ($expires !== 0) {
+            $expires = time() + $expires;
+        }
+
+        $options = [
+            'expires' => $expires,
+            'path' => $this->configuration->getCookiePath(),
+            'secure' => $this->configuration->getCookieSecure(),
+            'httponly' => true,
+            'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax'
+        ];
+
+        if(! in_array(strtolower($options['samesite']), ['lax', 'none', 'strict'], true)) {
+            $options['samesite'] = 'Lax';
+        }
+
+        $domain = $this->configuration->getCookieDomain() ?? $_SERVER['HTTP_HOST'] ?? null;
+
+        if ($domain !== null) {
+            /** @var string $domain */
+            $options['domain'] = $domain;
+        }
+
+        return $options;
+    }
+
     /**
      * Encrypt data for safe storage format for a cookie.
      *
@@ -402,43 +441,5 @@ final class CookieStore implements StoreInterface
 
         /** @var array<mixed> $data */
         return $data;
-    }
-
-    /**
-     * Build options array for use with setcookie()
-     *
-     * @param int|null $expires
-     *
-     * @return array{expires: int, path: string, domain?: string, secure: bool, httponly: bool, samesite: string, url_encode?: int}
-     */
-    private function getCookieOptions(
-        ?int $expires = null
-    ): array {
-        $expires = $expires ?? $this->configuration->getCookieExpires();
-
-        if ($expires !== 0) {
-            $expires = time() + $expires;
-        }
-
-        $options = [
-            'expires' => $expires,
-            'path' => $this->configuration->getCookiePath(),
-            'secure' => $this->configuration->getCookieSecure(),
-            'httponly' => true,
-            'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax'
-        ];
-
-        if(! in_array(strtolower($options['samesite']), ['lax', 'none', 'strict'], true)) {
-            $options['samesite'] = 'Lax';
-        }
-
-        $domain = $this->configuration->getCookieDomain() ?? $_SERVER['HTTP_HOST'] ?? null;
-
-        if ($domain !== null) {
-            /** @var string $domain */
-            $options['domain'] = $domain;
-        }
-
-        return $options;
     }
 }

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -157,7 +157,7 @@ final class SessionStore implements StoreInterface
                     'path' => $this->configuration->getCookiePath(),
                     'secure' => $this->configuration->getCookieSecure(),
                     'httponly' => true,
-                    'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : 'Lax',
+                    'samesite' => $this->configuration->getResponseMode() === 'form_post' ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax',
                 ]);
             }
             // @codeCoverageIgnoreEnd

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -222,3 +222,19 @@ test('decrypt() returns null if a malformed data payload is encoded', function()
 
     expect($this->store->getState())->toBeEmpty();
 });
+
+test('Configured SameSite() is reflected', function(): void {
+    $this->configuration->setCookieSameSite('strict');
+
+    $options = $this->store->getCookieOptions();
+
+    expect($options['samesite'])->toEqual('strict');
+});
+
+test('Unsupported configured SameSite() is overwritten by default of `lax`', function(): void {
+    $this->configuration->setCookieSameSite('testing');
+
+    $options = $this->store->getCookieOptions();
+
+    expect($options['samesite'])->toEqual('Lax');
+});


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This change allows downstream packages to overwrite the default cookie samesite logic handling, which defaults to lax. This feature is being added for the WordPress SDK, where customer circumstances may warrant variable degrees of security on this cookie property.

This is a non-breaking change as the default value for `samesite` remains `Lax`.

NOTE: Rector linter warnings are resolved by #643, these will be addressed when that PR is merged and main is merged back to this PR.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3635

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

See GitHub workflow results

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
