### PR TITLE
[SDK-3636] Add PSR-14 Event Dispatcher, for ultra customizable session storage purposes

### DIFF
--- a/src/Event/Psr14Store/Boot.php
+++ b/src/Event/Psr14Store/Boot.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Boot implements Auth0Event
+{
+    private StoreInterface $store;
+    private string $prefix;
+
+    public function __construct(
+        StoreInterface $store,
+        string $prefix
+    ) {
+        $this->store = $store;
+        $this->prefix = $prefix;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+
+    public function setPrefix(
+        string $prefix
+    ): self {
+        $this->prefix = $prefix;
+        return $this;
+    }
+}

--- a/src/Event/Psr14Store/Clear.php
+++ b/src/Event/Psr14Store/Clear.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Clear implements Auth0Event
+{
+    private StoreInterface $store;
+    private ?bool $success = null;
+
+    public function __construct(
+        StoreInterface $store
+    ) {
+        $this->store = $store;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getSuccess(): ?bool
+    {
+        return $this->success;
+    }
+
+    public function setSuccess(
+        ?bool $success
+    ): self {
+        $this->success = $success;
+        return $this;
+    }
+}

--- a/src/Event/Psr14Store/Defer.php
+++ b/src/Event/Psr14Store/Defer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Defer implements Auth0Event
+{
+    private StoreInterface $store;
+    private bool $state;
+
+    public function __construct(
+        StoreInterface $store,
+        bool $state
+    ) {
+        $this->store = $store;
+        $this->state = $state;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getState(): bool
+    {
+        return $this->state;
+    }
+}

--- a/src/Event/Psr14Store/Delete.php
+++ b/src/Event/Psr14Store/Delete.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Delete implements Auth0Event
+{
+    private StoreInterface $store;
+    private string $key;
+    private ?bool $success = null;
+
+    public function __construct(
+        StoreInterface $store,
+        string $key
+    ) {
+        $this->store = $store;
+        $this->key = $key;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getSuccess(): ?bool
+    {
+        return $this->success;
+    }
+
+    public function setSuccess(
+        ?bool $success
+    ): self {
+        $this->success = $success;
+        return $this;
+    }
+}

--- a/src/Event/Psr14Store/Destruct.php
+++ b/src/Event/Psr14Store/Destruct.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Destruct implements Auth0Event
+{
+    private StoreInterface $store;
+
+    public function __construct(
+        StoreInterface $store
+    ) {
+        $this->store = $store;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+}

--- a/src/Event/Psr14Store/Get.php
+++ b/src/Event/Psr14Store/Get.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Get implements Auth0Event
+{
+    private StoreInterface $store;
+    private ?bool $missed = null;
+    private ?bool $success = null;
+    private string $key;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    public function __construct(
+        StoreInterface $store,
+        string $key
+    ) {
+        $this->store = $store;
+        $this->key = $key;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value ?? null;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue(
+        $value
+    ): self {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function getMissed(): ?bool
+    {
+        return $this->missed;
+    }
+
+    public function setMissed(
+        bool $missed
+    ): self {
+        $this->missed = $missed;
+        return $this;
+    }
+
+    public function getSuccess(): ?bool
+    {
+        return $this->success;
+    }
+
+    public function setSuccess(
+        bool $success
+    ): self {
+        $this->success = $success;
+        return $this;
+    }
+}

--- a/src/Event/Psr14Store/Set.php
+++ b/src/Event/Psr14Store/Set.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Event\Psr14Store;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+
+final class Set implements Auth0Event
+{
+    private StoreInterface $store;
+    private string $key;
+    private ?bool $success = null;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param StoreInterface $store
+     * @param string $key
+     * @param mixed $value
+     */
+    public function __construct(
+        StoreInterface $store,
+        string $key,
+        $value
+    ) {
+        $this->store = $store;
+        $this->key = $key;
+        $this->value = $value;
+    }
+
+    public function getStore(): StoreInterface
+    {
+        return $this->store;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getSuccess(): ?bool
+    {
+        return $this->success;
+    }
+
+    public function setSuccess(
+        ?bool $success
+    ): self {
+        $this->success = $success;
+        return $this;
+    }
+}

--- a/src/Store/Psr14Store.php
+++ b/src/Store/Psr14Store.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Store;
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Contract\StoreInterface;
+use Auth0\SDK\Event\Psr14Store\Boot;
+use Auth0\SDK\Event\Psr14Store\Clear;
+use Auth0\SDK\Event\Psr14Store\Defer;
+use Auth0\SDK\Event\Psr14Store\Delete;
+use Auth0\SDK\Event\Psr14Store\Destruct;
+use Auth0\SDK\Event\Psr14Store\Get;
+use Auth0\SDK\Event\Psr14Store\Set;
+use Auth0\SDK\Utility\Toolkit;
+
+/**
+ * Class Psr14Store
+ * This class allows host applications to build custom session storage methods through PSR-14 event hooks.
+ */
+final class Psr14Store implements StoreInterface
+{
+    /**
+     * Instance of SdkConfiguration, for shared configuration across classes.
+     */
+    private SdkConfiguration $configuration;
+
+    /**
+     * Session base name, configurable on instantiation.
+     */
+    private string $sessionPrefix;
+
+    /**
+     * Track if a bootup event has been sent out yet.
+     */
+    private bool $booted = false;
+
+    /**
+     * Psr14Store constructor.
+     *
+     * @param SdkConfiguration $configuration Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
+     * @param string           $sessionPrefix A string to prefix session keys with.
+     */
+    public function __construct(
+        SdkConfiguration $configuration,
+        string $sessionPrefix = 'auth0'
+    ) {
+        [$sessionPrefix] = Toolkit::filter([$sessionPrefix])->string()->trim();
+
+        Toolkit::assert([
+            [$sessionPrefix, \Auth0\SDK\Exception\ArgumentException::missing('sessionPrefix')],
+        ])->isString();
+
+        $this->configuration = $configuration;
+        $this->sessionPrefix = $sessionPrefix ?? 'auth0';
+    }
+
+    /**
+     * Dispatch event to notify that the class is being destructed.
+     */
+    public function __destruct()
+    {
+        $this->configuration->eventDispatcher()->dispatch(new Destruct($this));
+    }
+
+    /**
+     * Dispatch event to toggle state deferrance.
+     *
+     * @param bool $deferring Whether to defer persisting the storage state.
+     */
+    public function defer(
+        bool $deferring
+    ): void {
+        $this->boot();
+        $this->configuration->eventDispatcher()->dispatch(new Defer($this, $deferring));
+    }
+
+    /**
+     * Dispatch event to set the value of a key-value pair.
+     *
+     * @param string $key   Session key to set.
+     * @param mixed  $value Value to use.
+     */
+    public function set(
+        string $key,
+        $value
+    ): void {
+        $this->boot();
+        $this->configuration->eventDispatcher()->dispatch(new Set($this, $key, $value));
+    }
+
+    /**
+     * Dispatch event to retrieve the value of a key-value pair.
+     *
+     * @param string $key     Session key to query.
+     * @param mixed  $default Default to return if nothing was found.
+     *
+     * @return mixed
+     */
+    public function get(
+        string $key,
+        $default = null
+    ) {
+        $this->boot();
+
+        /**
+         * @var Get $event
+         */
+        $event = $this->configuration->eventDispatcher()->dispatch(new Get($this, $key));
+        $value = $event->getValue();
+
+        if ($value === null) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Dispatch event to clear all key-value pairs.
+     */
+    public function purge(): void
+    {
+        $this->boot();
+        $this->configuration->eventDispatcher()->dispatch(new Clear($this));
+    }
+
+    /**
+     * Dispatch event to delete key-value pair.
+     *
+     * @param string $key Session key to delete.
+     */
+    public function delete(
+        string $key
+    ): void {
+        $this->boot();
+        $this->configuration->eventDispatcher()->dispatch(new Delete($this, $key));
+    }
+
+    /**
+     * Dispatch event to alert that a session should be prepared for an incoming request.
+     */
+    private function boot(): void
+    {
+        if (! $this->booted) {
+            $event = $this->configuration->eventDispatcher()->dispatch(new Boot($this, $this->sessionPrefix));
+            $this->sessionPrefix = $event->getPrefix();
+            $this->booted = true;
+        }
+
+        return;
+    }
+}

--- a/src/Store/Psr14Store.php
+++ b/src/Store/Psr14Store.php
@@ -145,6 +145,11 @@ final class Psr14Store implements StoreInterface
     {
         if (! $this->booted) {
             $event = $this->configuration->eventDispatcher()->dispatch(new Boot($this, $this->sessionPrefix));
+
+            /**
+             * @var Boot $event
+             */
+
             $this->sessionPrefix = $event->getPrefix();
             $this->booted = true;
         }

--- a/tests/Unit/Store/Psr14StoreTest.php
+++ b/tests/Unit/Store/Psr14StoreTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Event\Psr14Store\Clear;
+use Auth0\SDK\Event\Psr14Store\Defer;
+use Auth0\SDK\Event\Psr14Store\Delete;
+use Auth0\SDK\Event\Psr14Store\Destruct;
+use Auth0\SDK\Event\Psr14Store\Get;
+use Auth0\SDK\Event\Psr14Store\Set;
+use Auth0\SDK\Store\Psr14Store;
+use Auth0\Tests\Utilities\MockPsr14StoreListener;
+
+uses()->group('storage', 'storage.psr14');
+
+beforeEach(function(): void {
+    $this->listener = new MockPsr14StoreListener();
+
+    $this->configuration = new SdkConfiguration([
+        'strategy' => 'none',
+        'eventListenerProvider' => $this->listener->setup()
+    ]);
+});
+
+test('defer() behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+
+    expect($this->listener->deferred)->toBe(false);
+    $store->defer(true);
+    expect($this->listener->deferred)->toBe(true);
+});
+
+test('set(), get() and purge() behave as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+    $key = uniqid();
+    $value = uniqid();
+
+    $store->set($key, $value);
+    expect($store->get($key))->toBe($value);
+    expect($store->get('missing_key'))->toBe(null);
+    expect($store->get('random_nonsense', 123))->toBe(123);
+
+    $store->delete($key);
+    expect($store->get($key))->toBe(null);
+    expect($store->get($key, 123))->toBe(123);
+
+    $key1 = $key . uniqid();
+    $key2 = $key . uniqid();
+    $key3 = $key . uniqid();
+    $value1 = $value . uniqid();
+    $value2 = $value . uniqid();
+    $value3 = $value . uniqid();
+
+    $store->set($key1, $value1);
+    $store->set($key2, $value2);
+    $store->set($key3, $value3);
+
+    expect($store->get($key1))->toBe($value1);
+    expect($store->get($key2))->toBe($value2);
+    expect($store->get($key3))->toBe($value3);
+
+    $store->delete($key2);
+
+    expect($store->get($key1))->toBe($value1);
+    expect($store->get($key2))->toBe(null);
+    expect($store->get($key3))->toBe($value3);
+
+    $store->purge();
+
+    expect($store->get($key1))->toBe(null);
+    expect($store->get($key2))->toBe(null);
+    expect($store->get($key3))->toBe(null);
+});
+
+test('Boot event behaves as expected', function(): void {
+    expect($this->listener->prefix)->toBe(null);
+
+    $namespace = uniqid();
+    $store = new Psr14Store($this->configuration, $namespace);
+
+    expect($this->listener->prefix)->toBe(null);
+    expect($this->listener->booted)->toBe(false);
+
+    $store->set('test', uniqid());
+
+    expect($this->listener->prefix)->toBe($namespace . '123');
+    expect($this->listener->booted)->toBe(true);
+});
+
+test('Clear event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+    $clear = new Clear($store);
+
+    expect($clear->getStore())->toBe($store);
+
+    expect($clear->getSuccess())->toBe(null);
+
+    $clear->setSuccess(false);
+    expect($clear->getSuccess())->toBe(false);
+
+    $clear->setSuccess(true);
+    expect($clear->getSuccess())->toBe(true);
+});
+
+test('Defer event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+
+    $defer = new Defer($store, true);
+    expect($defer->getStore())->toBe($store);
+    expect($defer->getState())->toBe(true);
+
+    $defer = new Defer($store, false);
+    expect($defer->getStore())->toBe($store);
+    expect($defer->getState())->toBe(false);
+});
+
+test('Delete event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+    $key = uniqid();
+
+    $delete = new Delete($store, $key);
+    expect($delete->getStore())->toBe($store);
+    expect($delete->getKey())->toBe($key);
+    expect($delete->getSuccess())->toBe(null);
+
+    $delete->setSuccess(false);
+    expect($delete->getSuccess())->toBe(false);
+
+    $delete->setSuccess(true);
+    expect($delete->getSuccess())->toBe(true);
+});
+
+test('Destruct event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+
+    $delete = new Destruct($store);
+    expect($delete->getStore())->toBe($store);
+});
+
+test('Get event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+    $key = uniqid();
+
+    $get = new Get($store, $key);
+    expect($get->getStore())->toBe($store);
+    expect($get->getKey())->toBe($key);
+    expect($get->getValue())->toBeNull();
+    expect($get->getMissed())->toBeNull();
+    expect($get->getSuccess())->toBeNull();
+
+    $get->setValue(123);
+    expect($get->getValue())->toBe(123);
+
+    $get->setMissed(true);
+    expect($get->getMissed())->toBe(true);
+
+    $get->setMissed(false);
+    expect($get->getMissed())->toBe(false);
+
+    $get->setSuccess(true);
+    expect($get->getSuccess())->toBe(true);
+
+    $get->setSuccess(false);
+    expect($get->getSuccess())->toBe(false);
+});
+
+test('Set event behaves as expected', function(): void {
+    $store = new Psr14Store($this->configuration, uniqid());
+    $key = uniqid();
+    $value = uniqid();
+
+    $set = new Set($store, $key, $value);
+    expect($set->getStore())->toBe($store);
+    expect($set->getKey())->toBe($key);
+    expect($set->getValue())->toBe($value);
+    expect($set->getSuccess())->toBeNull();
+
+    $set->setSuccess(true);
+    expect($set->getSuccess())->toBe(true);
+
+    $set->setSuccess(false);
+    expect($set->getSuccess())->toBe(false);
+});

--- a/tests/Utilities/MockPsr14StoreListener.php
+++ b/tests/Utilities/MockPsr14StoreListener.php
@@ -31,13 +31,33 @@ class MockPsr14StoreListener
     {
         $listener = new ListenerProvider();
 
-        $listener->on(Boot::class, [$this, 'onBoot']);
-        $listener->on(Destruct::class, [$this, 'onDestruct']);
-        $listener->on(Defer::class, [$this, 'onDefer']);
-        $listener->on(Get::class, [$this, 'onGet']);
-        $listener->on(Set::class, [$this, 'onSet']);
-        $listener->on(Delete::class, [$this, 'onDelete']);
-        $listener->on(Clear::class, [$this, 'onClear']);
+        $listener->on(Boot::class, function (Boot $event): MockPsr14StoreListener {
+            return $this->onBoot($event);
+        });
+
+        $listener->on(Destruct::class, function (Destruct $event): MockPsr14StoreListener {
+            return $this->onDestruct($event);
+        });
+
+        $listener->on(Defer::class, function (Defer $event): MockPsr14StoreListener {
+            return $this->onDefer($event);
+        });
+
+        $listener->on(Get::class, function (Get $event): Auth0Event {
+            return $this->onGet($event);
+        });
+
+        $listener->on(Set::class, function (Set $event): Auth0Event {
+            return $this->onSet($event);
+        });
+
+        $listener->on(Delete::class, function (Delete $event): Auth0Event {
+            return $this->onDelete($event);
+        });
+
+        $listener->on(Clear::class, function (Clear $event): Auth0Event {
+            return $this->onClear($event);
+        });
 
         return $listener;
     }

--- a/tests/Utilities/MockPsr14StoreListener.php
+++ b/tests/Utilities/MockPsr14StoreListener.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Tests\Utilities;
+
+use Auth0\SDK\Contract\Auth0Event;
+use Auth0\SDK\Contract\StoreInterface;
+use Auth0\SDK\Event\Psr14Store\Boot;
+use Auth0\SDK\Event\Psr14Store\Clear;
+use Auth0\SDK\Event\Psr14Store\Defer;
+use Auth0\SDK\Event\Psr14Store\Delete;
+use Auth0\SDK\Event\Psr14Store\Destruct;
+use Auth0\SDK\Event\Psr14Store\Get;
+use Auth0\SDK\Event\Psr14Store\Set;
+use Hyperf\Event\ListenerProvider;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class MockPsr14StoreListener
+{
+    public ListenerProvider $listener;
+    public bool $booted = false;
+    public bool $destructed = false;
+    public bool $deferred = false;
+    public array $data = [];
+    public bool $success = true;
+    public ?string $prefix = null;
+    public ?StoreInterface $store = null;
+
+    public function setup(): ListenerProviderInterface
+    {
+        $listener = new ListenerProvider();
+
+        $listener->on(Boot::class, [$this, 'onBoot']);
+        $listener->on(Destruct::class, [$this, 'onDestruct']);
+        $listener->on(Defer::class, [$this, 'onDefer']);
+        $listener->on(Get::class, [$this, 'onGet']);
+        $listener->on(Set::class, [$this, 'onSet']);
+        $listener->on(Delete::class, [$this, 'onDelete']);
+        $listener->on(Clear::class, [$this, 'onClear']);
+
+        return $listener;
+    }
+
+    public function succeed(): self
+    {
+        $this->success = true;
+        return $this;
+    }
+
+    public function fail(): self
+    {
+        $this->success = false;
+        return $this;
+    }
+
+    public function onBoot(Boot $event): self
+    {
+        $this->store = $event->getStore();
+
+        $prefix = $event->getPrefix();
+        $event->setPrefix($prefix . '123');
+        $this->prefix = $event->getPrefix();
+
+        $this->booted = true;
+        return $this;
+    }
+
+    public function onDestruct(Destruct $event): self
+    {
+        $this->destructed = true;
+        return $this;
+    }
+
+    public function onDefer(Defer $event): self
+    {
+        $this->deferred = $event->getState();
+        return $this;
+    }
+
+    /**
+     * @param Get $event
+     * @return mixed
+     */
+    public function onGet(Get $event): Auth0Event
+    {
+        if (! isset($this->data[$event->getKey()])) {
+            $event->setMissed(true);
+            return $event;
+        }
+
+        $event->setSuccess($this->success);
+        $event->setValue($this->data[$event->getKey()]);
+        return $event;
+    }
+
+    public function onSet(Set $event): Auth0Event
+    {
+        $this->data[$event->getKey()] = $event->getValue();
+        $event->setSuccess($this->success);
+        return $event;
+    }
+
+    public function onDelete(Delete $event): Auth0Event
+    {
+        unset($this->data[$event->getKey()]);
+        $event->setSuccess($this->success);
+        return $event;
+    }
+
+    public function onClear(Clear $event): Auth0Event
+    {
+        $this->data = [];
+        $event->setSuccess($this->success);
+        return $event;
+    }
+}


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

At present, within our Laravel SDK, Octane support is limited because SetCookie will not work within the context of Octane — one must use the Laravel APIs to set cookies, so they properly work within the Octane lifecycle process.

This PSR-14 event storage interface will allow downstream apps to subscribe to SDK events for fetching, updating, and deleting session data, so they can wire up completely custom modes of storing session data. In Laravel’s case, this will enable us to support Octane contexts properly, by leveraging Laravel's internal cookie handling APIs.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3636

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

See GitHub workflow results

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
