### PR TITLE
[SDK-3647] Add PHP 8.2.0-dev to test matrix

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2"]
 
     steps:
       - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}
@@ -99,7 +99,7 @@ jobs:
       fail-fast: true
       max-parallel: 10
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}
@@ -141,7 +141,7 @@ jobs:
       fail-fast: true
       max-parallel: 10
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}
@@ -183,7 +183,7 @@ jobs:
       fail-fast: true
       max-parallel: 10
       matrix:
-        php: ["8.0", "8.1"]
+        php: ["8.0", "8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}
@@ -228,7 +228,7 @@ jobs:
       fail-fast: true
       max-parallel: 10
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["7.4", "8.0", "8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "pestphp/pest": "^1.21",
     "php-http/mock-client": "^1.5",
     "phpstan/phpstan": "^1.7",
-    "phpstan/phpstan-strict-rules": "^1.3",
+    "phpstan/phpstan-strict-rules": "1.4.3",
     "phpunit/phpunit": "^9.5",
     "rector/rector": "^0.13.6",
     "squizlabs/php_codesniffer": "^3.7",


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR adds the PHP 8.2.0-dev runtime to the test suite matrix.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3647

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

See GitHub workflow results.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
