### PR TITLE
[SDK-3719] Fix PHP 8.0+ SdkConfiguration named arguments usage

### DIFF
--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -1139,7 +1139,7 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setOrganization($this->organization);
         }
 
-        if (true !== $this->usePkce) {
+        if (!$this->usePkce) {
             $this->setUsePkce($this->usePkce);
         }
 
@@ -1183,7 +1183,7 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setHttpClient($this->httpClient);
         }
 
-        if (null !== $this->httpMaxRetries) {
+        if (3 !== $this->httpMaxRetries) {
             $this->setHttpMaxRetries($this->httpMaxRetries);
         }
 
@@ -1199,7 +1199,7 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setHttpStreamFactory($this->httpStreamFactory);
         }
 
-        if (false !== $this->httpTelemetry) {
+        if ($this->httpTelemetry) {
             $this->setHttpTelemetry($this->httpTelemetry);
         }
 
@@ -1227,7 +1227,7 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setCookiePath($this->cookiePath);
         }
 
-        if (false !== $this->cookieSecure) {
+        if ($this->cookieSecure) {
             $this->setCookieSecure($this->cookieSecure);
         }
 
@@ -1235,19 +1235,19 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setCookieSameSite($this->cookieSameSite);
         }
 
-        if (true !== $this->persistUser) {
+        if (!$this->persistUser) {
             $this->setPersistUser($this->persistUser);
         }
 
-        if (true !== $this->persistIdToken) {
+        if (!$this->persistIdToken) {
             $this->setPersistIdToken($this->persistIdToken);
         }
 
-        if (true !== $this->persistAccessToken) {
+        if (!$this->persistAccessToken) {
             $this->setPersistAccessToken($this->persistAccessToken);
         }
 
-        if (true !== $this->persistRefreshToken) {
+        if (!$this->persistRefreshToken) {
             $this->setPersistRefreshToken($this->persistRefreshToken);
         }
 
@@ -1259,7 +1259,7 @@ final class SdkConfiguration implements ConfigurableContract
             $this->setTransientStorageId($this->transientStorageId);
         }
 
-        if (false !== $this->queryUserInfo) {
+        if ($this->queryUserInfo) {
             $this->setQueryUserInfo($this->queryUserInfo);
         }
 

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -133,9 +133,12 @@ final class SdkConfiguration implements ConfigurableContract
         private ?CacheItemPoolInterface $managementTokenCache = null,
         private ?ListenerProviderInterface $eventListenerProvider = null
     ) {
-        $configuration = $this->filterArrayMixed($configuration, true) ?? [];
-        $this->applyConfigurationState($configuration);
+        if (null !== $configuration && [] !== $configuration) {
+            $configuration = $this->filterArrayMixed($configuration, true) ?? [];
+            $this->applyConfigurationState($configuration);
+        }
 
+        $this->validateNamedParameters();
         $this->setupStateCookies();
         $this->setupStateFactories();
 
@@ -1100,6 +1103,176 @@ final class SdkConfiguration implements ConfigurableContract
 
         if (! $this->getTransientStorage() instanceof StoreInterface) {
             $this->setTransientStorage(new CookieStore($this, $this->getTransientStorageId()));
+        }
+    }
+
+    private function validateNamedParameters(): void {
+        if (self::STRATEGY_REGULAR !== $this->strategy) {
+            $this->setStrategy($this->strategy);
+        }
+
+        if (null !== $this->domain) {
+            $this->setDomain($this->domain);
+        }
+
+        if (null !== $this->customDomain) {
+            $this->setCustomDomain($this->customDomain);
+        }
+
+        if (null !== $this->clientId) {
+            $this->setClientId($this->clientId);
+        }
+
+        if (null !== $this->redirectUri) {
+            $this->setRedirectUri($this->redirectUri);
+        }
+
+        if (null !== $this->clientSecret) {
+            $this->setClientSecret($this->clientSecret);
+        }
+
+        if (null !== $this->audience) {
+            $this->setAudience($this->audience);
+        }
+
+        if (null !== $this->organization) {
+            $this->setOrganization($this->organization);
+        }
+
+        if (true !== $this->usePkce) {
+            $this->setUsePkce($this->usePkce);
+        }
+
+        if (['openid', 'profile', 'email'] !== $this->scope) {
+            $this->setScope($this->scope);
+        }
+
+        if ('query' !== $this->responseMode) {
+            $this->setResponseMode($this->responseMode);
+        }
+
+        if ('code' !== $this->responseType) {
+            $this->setResponseType($this->responseType);
+        }
+
+        if ('RS256' !== $this->tokenAlgorithm) {
+            $this->setTokenAlgorithm($this->tokenAlgorithm);
+        }
+
+        if (null !== $this->tokenJwksUri) {
+            $this->setTokenJwksUri($this->tokenJwksUri);
+        }
+
+        if (null !== $this->tokenMaxAge) {
+            $this->setTokenMaxAge($this->tokenMaxAge);
+        }
+
+        if (60 !== $this->tokenLeeway) {
+            $this->setTokenLeeway($this->tokenLeeway);
+        }
+
+        if (null !== $this->tokenCache) {
+            $this->setTokenCache($this->tokenCache);
+        }
+
+        if (60 !== $this->tokenCacheTtl) {
+            $this->setTokenCacheTtl($this->tokenCacheTtl);
+        }
+
+        if (null !== $this->httpClient) {
+            $this->setHttpClient($this->httpClient);
+        }
+
+        if (null !== $this->httpMaxRetries) {
+            $this->setHttpMaxRetries($this->httpMaxRetries);
+        }
+
+        if (null !== $this->httpRequestFactory) {
+            $this->setHttpRequestFactory($this->httpRequestFactory);
+        }
+
+        if (null !== $this->httpResponseFactory) {
+            $this->setHttpResponseFactory($this->httpResponseFactory);
+        }
+
+        if (null !== $this->httpStreamFactory) {
+            $this->setHttpStreamFactory($this->httpStreamFactory);
+        }
+
+        if (false !== $this->httpTelemetry) {
+            $this->setHttpTelemetry($this->httpTelemetry);
+        }
+
+        if (null !== $this->sessionStorage) {
+            $this->setSessionStorage($this->sessionStorage);
+        }
+
+        if ('auth0_session' !== $this->sessionStorageId) {
+            $this->setSessionStorageId($this->sessionStorageId);
+        }
+
+        if (null !== $this->cookieSecret) {
+            $this->setCookieSecret($this->cookieSecret);
+        }
+
+        if (null !== $this->cookieDomain) {
+            $this->setCookieDomain($this->cookieDomain);
+        }
+
+        if (0 !== $this->cookieExpires) {
+            $this->setCookieExpires($this->cookieExpires);
+        }
+
+        if ('/' !== $this->cookiePath) {
+            $this->setCookiePath($this->cookiePath);
+        }
+
+        if (false !== $this->cookieSecure) {
+            $this->setCookieSecure($this->cookieSecure);
+        }
+
+        if (null !== $this->cookieSameSite) {
+            $this->setCookieSameSite($this->cookieSameSite);
+        }
+
+        if (true !== $this->persistUser) {
+            $this->setPersistUser($this->persistUser);
+        }
+
+        if (true !== $this->persistIdToken) {
+            $this->setPersistIdToken($this->persistIdToken);
+        }
+
+        if (true !== $this->persistAccessToken) {
+            $this->setPersistAccessToken($this->persistAccessToken);
+        }
+
+        if (true !== $this->persistRefreshToken) {
+            $this->setPersistRefreshToken($this->persistRefreshToken);
+        }
+
+        if (null !== $this->transientStorage) {
+            $this->setTransientStorage($this->transientStorage);
+        }
+
+        if ('auth0_transient' !== $this->transientStorageId) {
+            $this->setTransientStorageId($this->transientStorageId);
+        }
+
+        if (false !== $this->queryUserInfo) {
+            $this->setQueryUserInfo($this->queryUserInfo);
+        }
+
+        if (null !== $this->managementToken) {
+            $this->setManagementToken($this->managementToken);
+        }
+
+        if (null !== $this->managementTokenCache) {
+            $this->setManagementTokenCache($this->managementTokenCache);
+        }
+
+        if (null !== $this->eventListenerProvider) {
+            $this->setEventListenerProvider($this->eventListenerProvider);
         }
     }
 

--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -1106,7 +1106,8 @@ final class SdkConfiguration implements ConfigurableContract
         }
     }
 
-    private function validateNamedParameters(): void {
+    private function validateNamedParameters(): void
+    {
         if (self::STRATEGY_REGULAR !== $this->strategy) {
             $this->setStrategy($this->strategy);
         }

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -38,7 +38,7 @@ test('__construct() overrides arguments with configuration array', function(): v
         'cookieSecret' => $cookieSecret,
         'clientId' => $clientId,
         'redirectUri' => $redirectUri,
-    ], $domain2);
+    ], SdkConfiguration::STRATEGY_REGULAR, $domain2);
 
     expect($sdk->getDomain())->toEqual(parse_url($domain, PHP_URL_HOST));
 });


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to committing work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR addresses an issue with the SdkConfiguration class when named arguments are used for configuration in PHP 8.0+ — specifically, validation of those properties when set with named arguments.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves https://github.com/auth0/laravel-auth0/issues/319

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
