### PR TITLE
Release 8.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [8.3.2](https://github.com/auth0/auth0-PHP/tree/8.3.2) (2022-10-18)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.1...8.3.2)
+
+**Fixed**
+- [SDK-3719] Fix PHP 8.0+ SdkConfiguration named arguments usage [\#654](https://github.com/auth0/auth0-PHP/pull/654) ([evansims](https://github.com/evansims))
+
 ## [8.3.1](https://github.com/auth0/auth0-PHP/tree/8.3.1) (2022-09-24)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.0...8.3.1)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -22,7 +22,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.3.1';
+    public const VERSION = '8.3.2';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION

**Fixed**
- [SDK-3719] Fix PHP 8.0+ SdkConfiguration named arguments usage [\#654](https://github.com/auth0/auth0-PHP/pull/654) ([evansims](https://github.com/evansims))


[SDK-3719]: https://auth0team.atlassian.net/browse/SDK-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ