### PR TITLE
Fix for SdkConfiguration::setScope([]) not assigning default values

### DIFF
--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -151,7 +151,7 @@ final class SdkConfiguration implements ConfigurableContract
     /**
      * @param null|array<string> $audience An allowlist array of API identifiers/audiences.
      */
-    public function setAudience(?array $audience): self
+    public function setAudience(?array $audience = null): self
     {
         if (null !== $audience && [] === $audience) {
             $audience = null;
@@ -201,7 +201,7 @@ final class SdkConfiguration implements ConfigurableContract
         return $this->audience;
     }
 
-    public function setCookieDomain(?string $cookieDomain): self
+    public function setCookieDomain(?string $cookieDomain = null): self
     {
         if (null !== $cookieDomain && '' === trim($cookieDomain)) {
             $cookieDomain = null;
@@ -262,7 +262,7 @@ final class SdkConfiguration implements ConfigurableContract
         return true;
     }
 
-    public function setCookieSameSite(?string $cookieSameSite): self
+    public function setCookieSameSite(?string $cookieSameSite = null): self
     {
         if (null !== $cookieSameSite && '' === trim($cookieSameSite)) {
             $cookieSameSite = null;
@@ -283,7 +283,7 @@ final class SdkConfiguration implements ConfigurableContract
         return null !== $this->cookieSameSite;
     }
 
-    public function setCookieSecret(?string $cookieSecret): self
+    public function setCookieSecret(?string $cookieSecret = null): self
     {
         if (null !== $cookieSecret && '' === trim($cookieSecret)) {
             $cookieSecret = null;
@@ -304,7 +304,7 @@ final class SdkConfiguration implements ConfigurableContract
         return null !== $this->cookieSecret;
     }
 
-    public function setCookieSecure(bool $cookieSecure): self
+    public function setCookieSecure(bool $cookieSecure = false): self
     {
         $this->cookieSecure = $cookieSecure;
         return $this;
@@ -766,10 +766,14 @@ final class SdkConfiguration implements ConfigurableContract
     }
 
     /**
-     * @param array<string>|null $scope An array of scopes to request during authentication steps.
+     * @param array<string> $scope An array of scopes to request during authentication steps.
      */
-    public function setScope(array $scope = null): self
+    public function setScope(array $scope = ['openid', 'profile', 'email']): self
     {
+        if ([] === $scope) {
+            $scope = ['openid', 'profile', 'email'];
+        }
+
         $this->scope = $this->filterArray($scope) ?? [];
         return $this;
     }

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -359,7 +359,7 @@ test('formatCustomDomain() returns null when a custom domain is not configured',
     expect($sdk->formatCustomDomain())->toBeNull();
 });
 
-test('formatScope() returns an empty string when there are no scopes defined', function(): void
+test('formatScope() returns the default scopes when there are no scopes defined', function(): void
 {
     $sdk = new SdkConfiguration([
         'domain' => MockDomain::valid(),
@@ -369,7 +369,24 @@ test('formatScope() returns an empty string when there are no scopes defined', f
         'scope' => [],
     ]);
 
-    expect($sdk->formatScope())->toEqual('');
+    expect($sdk->formatScope())->toEqual('openid profile email');
+});
+
+test('formatScope() returns the correct string when there scopes are defined', function(): void
+{
+    $scope1 = uniqid();
+    $scope2 = uniqid();
+    $scope3 = uniqid();
+
+    $sdk = new SdkConfiguration([
+        'domain' => MockDomain::valid(),
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid(),
+        'scope' => [$scope1, $scope2, $scope3],
+    ]);
+
+    expect($sdk->formatScope())->toEqual(implode(' ', [$scope1, $scope2, $scope3]));
 });
 
 test('scope() successfully converts the array to a string', function(): void


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR fixes an issue where setScope() on the SdkConfiguration class did not assign the default scope values of ['openid', 'profile', 'email'] when an empty array is provided. This caused conflicts with downstream applications that expected the previous behavior that matched this.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

N/A

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
