### PR TITLE
Release 8.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [8.3.4](https://github.com/auth0/auth0-PHP/tree/8.3.4) (2022-10-19)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.3...8.3.4)
+
+**Fixed**
+- Fix `SdkConfiguration::setScope()` not assigning default values when an empty array is passed [\#659](https://github.com/auth0/auth0-PHP/pull/659) ([evansims](https://github.com/evansims))
+
 ## [8.3.3](https://github.com/auth0/auth0-PHP/tree/8.3.3) (2022-10-19)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.2...8.3.3)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -22,7 +22,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.3.3';
+    public const VERSION = '8.3.4';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.3...8.3.4)

**Fixed**
- Fix `SdkConfiguration::setScope()` not assigning default values when an empty array is passed [\#659](https://github.com/auth0/auth0-PHP/pull/659) ([evansims](https://github.com/evansims))