### PR TITLE
Release 8.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [8.3.5](https://github.com/auth0/auth0-PHP/tree/8.3.5) (2022-10-21)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.4...8.3.5)
+
+**Fixed**
+- [SDK-3722] Fix: Stateless strategies should not invoke stateful session classes [\#662](https://github.com/auth0/auth0-PHP/pull/662) ([evansims](https://github.com/evansims))
+
 ## [8.3.4](https://github.com/auth0/auth0-PHP/tree/8.3.4) (2022-10-19)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.3...8.3.4)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -23,7 +23,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.3.4';
+    public const VERSION = '8.3.5';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION

**Fixed**
- [SDK-3722] Fix: Stateless strategies should not invoke stateful session classes [\#662](https://github.com/auth0/auth0-PHP/pull/662) ([evansims](https://github.com/evansims))


[SDK-3722]: https://auth0team.atlassian.net/browse/SDK-3722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ