### PR TITLE
fix: Remove redundant Cache `getItem()` call in `Auth0\SDK\Token\Verifier::getKeySet()`

### DIFF
--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -191,11 +191,13 @@ final class Verifier
         $scheme = $jwksUri['scheme'] ?? 'https';
         $path = $jwksUri['path'] ?? '/.well-known/jwks.json';
         $host = $jwksUri['host'] ?? $this->configuration->getDomain() ?? '';
+        $item = null;
 
         $response = [];
 
         if ($this->cache !== null) {
             $item = $this->cache->getItem($jwksCacheKey);
+
             if ($item->isHit()) {
                 /** @var array<mixed> $value */
                 $value = $item->get();
@@ -223,7 +225,7 @@ final class Verifier
                 }
             }
 
-            if ($response !== [] && $this->cache !== null) {
+            if ($response !== [] && $this->cache !== null && $item !== null) {
                 $item->set($response);
                 $item->expiresAfter($this->cacheExpires ?? 60);
                 $this->cache->save($item);

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -224,7 +224,6 @@ final class Verifier
             }
 
             if ($response !== [] && $this->cache !== null) {
-                $item = $this->cache->getItem($jwksCacheKey);
                 $item->set($response);
                 $item->expiresAfter($this->cacheExpires ?? 60);
                 $this->cache->save($item);


### PR DESCRIPTION
$item has already been created on line 198: https://github.com/auth0/auth0-PHP/blob/main/src/Token/Verifier.php#L198. We only have to save the value and expiry here.

This change will only get the value of the cache once instead of twice.