### PR TITLE
fix: emailPasswordlessStart() incorrectly passing params as `array` in some configurations

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -226,6 +226,7 @@ final class Authentication implements AuthenticationInterface
             [$type, \Auth0\SDK\Exception\ArgumentException::missing('type')],
         ])->isString();
 
+        /** @var array{scope: ?string} $params */
         if ((! isset($params['scope']) || '' === $params['scope']) && $this->configuration->hasScope()) {
             $params['scope'] = $this->configuration->formatScope() ?? '';
         }
@@ -239,6 +240,7 @@ final class Authentication implements AuthenticationInterface
             ],
         ])->array()->trim()[0];
 
+        /** @var array{authParams: ?array<string>} $body */
         if (null !== $body['authParams']) {
             $body['authParams'] = (object) $body['authParams'];
         }

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -201,7 +201,7 @@ final class Authentication implements AuthenticationInterface
         return $this->getHttpClient()
             ->method('post')
             ->addPath('passwordless', 'start')
-            ->withBody(Toolkit::merge([
+            ->withBody((object) Toolkit::merge([
                 'client_id' => $this->configuration->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
                 'client_secret' => $this->configuration->getClientSecret(\Auth0\SDK\Exception\ConfigurationException::requiresClientSecret()),
             ], $body))
@@ -226,6 +226,10 @@ final class Authentication implements AuthenticationInterface
             [$type, \Auth0\SDK\Exception\ArgumentException::missing('type')],
         ])->isString();
 
+        if ((! isset($params['scope']) || '' === $params['scope']) && $this->configuration->hasScope()) {
+            $params['scope'] = $this->configuration->formatScope() ?? '';
+        }
+
         $body = Toolkit::filter([
             [
                 'email' => $email,
@@ -234,6 +238,10 @@ final class Authentication implements AuthenticationInterface
                 'authParams' => $params,
             ],
         ])->array()->trim()[0];
+
+        if (null !== $body['authParams']) {
+            $body['authParams'] = (object) $body['authParams'];
+        }
 
         /** @var array<mixed> $body */
         /** @var array<int|string> $headers */

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -200,6 +200,42 @@ test('emailPasswordlessStart() is properly formatted', function(): void {
     expect($requestBody['send'])->toEqual('code');
 });
 
+test('emailPasswordlessStart() returns authParams with default configured scopes when none are provided', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $this->sdk->authentication()->emailPasswordlessStart('someone@somewhere.somehow', 'code');
+
+    $request = $this->sdk->authentication()->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = json_decode($request->getBody()->__toString(), false);
+
+    expect($requestBody)->toHaveProperties(['authParams']);
+    expect($requestBody->authParams)->toBeObject()->toHaveProperties(['scope']);
+    expect($requestBody->authParams->scope)->toEqual('scope1 scope2 scope3');
+});
+
+test('emailPasswordlessStart() returns authParams with default configured scopes an empty array is configured', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $this->sdk->authentication()->emailPasswordlessStart('someone@somewhere.somehow', 'code', []);
+
+    $request = $this->sdk->authentication()->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = json_decode($request->getBody()->__toString(), false);
+
+    expect($requestBody)->toHaveProperties(['authParams']);
+    expect($requestBody->authParams)->toBeObject()->toHaveProperties(['scope']);
+    expect($requestBody->authParams->scope)->toEqual('scope1 scope2 scope3');
+});
+
+test('emailPasswordlessStart() returns authParams correctly configured when provided', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $this->sdk->authentication()->emailPasswordlessStart('someone@somewhere.somehow', 'code', ['scope' => 'test1 test2']);
+
+    $request = $this->sdk->authentication()->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = json_decode($request->getBody()->__toString(), false);
+
+    expect($requestBody)->toHaveProperties(['authParams']);
+    expect($requestBody->authParams)->toBeObject()->toHaveProperties(['scope']);
+    expect($requestBody->authParams->scope)->toEqual('test1 test2');
+});
+
 test('smsPasswordlessStart() throws an ArgumentException if `phoneNumber` is empty', function(): void {
     $this->configuration->setClientSecret(uniqid());
     $this->sdk->authentication()->smsPasswordlessStart('');


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR resolves [an issue](https://github.com/auth0/auth0-PHP/issues/668) reported by @luckpoint in which `Auth0\SDK\API\Authentication::emailPasswordlessStart()` could incorrectly send the `authParams` portion of the body payload as an `array` instead of an `object`, which would cause the call to fail.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #668 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

[x] Tests have been added to cover the changes.

Use `composer tests` in a locally cloned repo, or review the GitHub Status Checks below.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
