### PR TITLE
chore: Unpin `phpstan/phpstan-strict-rules` dependency from `1.4.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "pestphp/pest": "^1.21",
     "php-http/mock-client": "^1.5",
     "phpstan/phpstan": "^1.7",
-    "phpstan/phpstan-strict-rules": "1.4.3",
+    "phpstan/phpstan-strict-rules": "^1.4.4",
     "phpunit/phpunit": "^9.5",
     "rector/rector": "^0.13.6",
     "squizlabs/php_codesniffer": "^3.7",


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR unpins the `phpstan/phpstan-strict-rules` dependency from the Composer package manifest, as the upstream breaking change in `1.4.3` has been resolved in `1.4.4`.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
