### PR TITLE
Release 8.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [8.3.7](https://github.com/auth0/auth0-PHP/tree/8.3.7) (2022-11-07)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.6...8.3.7)
+
+**Fixed**
+- [SDK-3793] fix: emailPasswordlessStart() incorrectly passes `params` as `array` under some conditions [\#670](https://github.com/auth0/auth0-PHP/pull/670) ([evansims](https://github.com/evansims))
+- fix: Remove redundant Cache `getItem()` call in `Auth0\SDK\Token\Verifier::getKeySet()` [\#669](https://github.com/auth0/auth0-PHP/pull/669) ([pkivits-litebit](https://github.com/pkivits-litebit))
+
 ## [8.3.6](https://github.com/auth0/auth0-PHP/tree/8.3.6) (2022-10-24)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.5...8.3.6)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -23,7 +23,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.3.6';
+    public const VERSION = '8.3.7';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION

**Fixed**
- [SDK-3793] fix: emailPasswordlessStart() incorrectly passes `params` as `array` under some conditions [\#670](https://github.com/auth0/auth0-PHP/pull/670) ([evansims](https://github.com/evansims))
- fix: Remove redundant Cache `getItem()` call in `Auth0\SDK\Token\Verifier::getKeySet()` [\#669](https://github.com/auth0/auth0-PHP/pull/669) ([pkivits-litebit](https://github.com/pkivits-litebit))


[SDK-3793]: https://auth0team.atlassian.net/browse/SDK-3793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ