### PR TITLE
fix: Always store provided `state` in transient medium

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,7 +233,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring
+          extensions: mbstring, openssl
         env:
           update: true
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ["8.0", "8.1", "8.2"]
+        php: ["8.1", "8.2"]
 
     steps:
       - name: Set up PHP ${{ matrix.php }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,11 +27,7 @@ jobs:
           coverage: none
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get OpenSSL directory
-        run: php -i | grep openssl
 
       - name: Get composer cache directory
         id: composer-cache
@@ -65,7 +61,6 @@ jobs:
           coverage: pcov
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
@@ -112,7 +107,6 @@ jobs:
           coverage: none
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
@@ -154,7 +148,6 @@ jobs:
           coverage: none
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
@@ -196,7 +189,6 @@ jobs:
           coverage: none
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
@@ -238,7 +230,6 @@ jobs:
           coverage: none
           extensions: mbstring, openssl
         env:
-          update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         id: composer-cache
@@ -63,7 +63,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -110,7 +110,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -152,7 +152,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -194,7 +194,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -236,7 +236,7 @@ jobs:
           extensions: mbstring, openssl
         env:
           update: true
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,9 @@ jobs:
           update: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get OpenSSL directory
+        run: php -i | grep openssl
+
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,6 +77,9 @@ jobs:
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}-${{ github.run_id }}
           restore-keys: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}-${{ github.run_id }}
 
+      - name: PHP debug
+        run: php -i
+
       - name: Install dependencies with composer
         run: composer install --prefer-dist
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dependencies:
     name: Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       max-parallel: 10
@@ -45,7 +45,7 @@ jobs:
 
   pest:
     name: Pest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     needs: ["dependencies"]
 
@@ -92,7 +92,7 @@ jobs:
 
   phpstan:
     name: PHPStan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ["dependencies"]
 
     strategy:
@@ -134,7 +134,7 @@ jobs:
 
   psalm:
     name: Psalm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ["dependencies"]
 
     strategy:
@@ -176,7 +176,7 @@ jobs:
 
   pint:
     name: Laravel Pint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ["dependencies"]
 
     strategy:
@@ -218,7 +218,7 @@ jobs:
 
   rector:
     name: Rector
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ["dependencies"]
 
     strategy:

--- a/composer.json
+++ b/composer.json
@@ -93,10 +93,10 @@
     "rector:fix": "@php vendor/bin/rector process src",
     "pest": "@php vendor/bin/pest --order-by random",
     "test": [
+      "@pint",
       "@phpstan",
       "@psalm",
       "@rector",
-      "@pint",
       "@pest"
     ]
   }

--- a/src/API/Management/ManagementEndpoint.php
+++ b/src/API/Management/ManagementEndpoint.php
@@ -15,19 +15,13 @@ use Auth0\SDK\Utility\HttpResponsePaginator;
 abstract class ManagementEndpoint
 {
     /**
-     * Injected HttpClient instance to use.
-     */
-    private HttpClient $httpClient;
-
-    /**
      * ManagementEndpoint constructor.
      *
      * @param HttpClient $httpClient HttpClient instance to use.
      */
     public function __construct(
-        HttpClient $httpClient
+        private HttpClient $httpClient
     ) {
-        $this->httpClient = $httpClient;
     }
 
     /**

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -94,30 +94,35 @@ final class Auth0 implements Auth0Interface
         ?string $redirectUrl = null,
         ?array $params = null
     ): string {
-        if (! $this->configuration()->usingStatefulness()) {
+        $this->deferStateSaving();
+
+        $store = $this->getTransientStore(true);
+
+        if (! $this->configuration()->usingStatefulness() || ! $store instanceof TransientStoreHandler) {
             throw ConfigurationException::requiresStatefulness('Auth0->login()');
         }
 
-        $this->deferStateSaving();
-
-        $store = $this->getTransientStore();
-        $params = $params ?? [];
-        $state = $params['state'] ?? $store?->issue('state') ?? uniqid();
-        $params['nonce'] = $params['nonce'] ?? $store?->issue('nonce') ?? uniqid();
-        $params['max_age'] = $params['max_age'] ?? $this->configuration()->getTokenMaxAge();
-
-        unset($params['state']);
+        $params ??= [];
+        $state = $params['state'] ?? $store->getNonce();
+        $params['nonce'] ??= $store->getNonce();
+        $params['max_age'] ??= $this->configuration()->getTokenMaxAge();
 
         if ($this->configuration()->getUsePkce()) {
             $codeVerifier = PKCE::generateCodeVerifier(128);
             $params['code_challenge'] = PKCE::generateCodeChallenge($codeVerifier);
             $params['code_challenge_method'] = 'S256';
-            $store?->store('code_verifier', $codeVerifier);
+
+            $store->store('code_verifier', $codeVerifier);
         }
 
-        if ($params['max_age'] !== null) {
-            $store?->store('max_age', (string) $params['max_age']);
+        $store->store('state', (string) $state);
+        $store->store('nonce', (string) $params['nonce']);
+
+        if (null !== $params['max_age']) {
+            $store->store('max_age', (string) $params['max_age']);
         }
+
+        unset($params['state']);
 
         $this->deferStateSaving(false);
 
@@ -215,9 +220,10 @@ final class Auth0 implements Auth0Interface
         ?int $tokenType = null
     ): TokenInterface {
         $store = $this->getTransientStore();
-        $tokenType = $tokenType ?? Token::TYPE_ID_TOKEN;
-        $tokenNonce = $tokenNonce ?? $store?->getOnce('nonce') ?? null;
-        $tokenMaxAge = $tokenMaxAge ?? $store?->getOnce('max_age') ?? null;
+
+        $tokenType ??= Token::TYPE_ID_TOKEN;
+        $tokenNonce ??= $store?->getOnce('nonce') ?? null;
+        $tokenMaxAge ??= $store?->getOnce('max_age') ?? null;
         $tokenIssuer = null;
 
         $token = new Token($this->configuration, $token, $tokenType);
@@ -239,9 +245,9 @@ final class Auth0 implements Auth0Interface
         );
 
         // Ensure transient-stored values are cleared, even if overriding values were passed to the  method.
-        if ($this->configuration()->usingStatefulness()) {
-            $store?->delete('max_age');
-            $store?->delete('nonce');
+        if ($this->configuration()->usingStatefulness() && $store instanceof TransientStoreHandler) {
+            $store->delete('max_age');
+            $store->delete('nonce');
         }
 
         return $token;
@@ -252,45 +258,41 @@ final class Auth0 implements Auth0Interface
         ?string $code = null,
         ?string $state = null
     ): bool {
-        if (! $this->configuration()->usingStatefulness()) {
+        $store = $this->getTransientStore();
+
+        if (! $this->configuration()->usingStatefulness() || ! $store instanceof TransientStoreHandler) {
             throw ConfigurationException::requiresStatefulness('Auth0->exchange()');
         }
 
         [$redirectUri, $code, $state] = Toolkit::filter([$redirectUri, $code, $state])->string()->trim();
 
-        $code = $code ?? $this->getRequestParameter('code');
-        $state = $state ?? $this->getRequestParameter('state');
-
-        $store = $this->getTransientStore();
-        $codeVerifier = $store?->getOnce('code_verifier');
-        $nonce = $store?->isset('nonce');
-        $stateVerified = null;
-
-        if (null !== $state) {
-            $stateVerified = $store?->verify('state', $state) ?? false;
-        }
+        $code ??= $this->getRequestParameter('code');
+        $state ??= $this->getRequestParameter('state');
+        $pkce = $store->getOnce('code_verifier');
+        $nonce = $store->isset('nonce');
+        $verified = (null !== $state ? $store->verify('state', $state) : false);
 
         $user = null;
 
         $this->clear(false);
         $this->deferStateSaving();
 
-        if ($code === null) {
+        if (null === $code) {
             $this->clear();
             throw \Auth0\SDK\Exception\StateException::missingCode();
         }
 
-        if ($state === null || ! $stateVerified) {
+        if (null === $state || ! $verified) {
             $this->clear();
             throw \Auth0\SDK\Exception\StateException::invalidState();
         }
 
-        if ($this->configuration()->getUsePkce() && $codeVerifier === null) {
+        if (null === $pkce && $this->configuration()->getUsePkce()) {
             $this->clear();
             throw \Auth0\SDK\Exception\StateException::missingCodeVerifier();
         }
 
-        $response = $this->authentication()->codeExchange($code, $redirectUri, $codeVerifier);
+        $response = $this->authentication()->codeExchange($code, $redirectUri, $pkce);
 
         if (! HttpResponse::wasSuccessful($response)) {
             $this->clear();
@@ -300,6 +302,21 @@ final class Auth0 implements Auth0Interface
         $response = HttpResponse::decodeContent($response);
 
         /** @var array{access_token?: string, scope?: string, refresh_token?: string, id_token?: string, expires_in?: int|string} $response */
+
+        if (isset($response['id_token'])) {
+            if (! $nonce) {
+                $this->clear();
+                throw \Auth0\SDK\Exception\StateException::missingNonce();
+            }
+
+            try {
+                $user = $this->decode($response['id_token'])->toArray();
+                $this->setIdToken($response['id_token']);
+            } catch (\Throwable $tokenException) {
+                $this->clear();
+                throw $tokenException;
+            }
+        }
 
         if (! isset($response['access_token']) || trim($response['access_token']) === '') {
             $this->clear();
@@ -314,16 +331,6 @@ final class Auth0 implements Auth0Interface
 
         if (isset($response['refresh_token'])) {
             $this->setRefreshToken($response['refresh_token']);
-        }
-
-        if (isset($response['id_token'])) {
-            if (null === $nonce || ! $nonce) {
-                $this->clear();
-                throw \Auth0\SDK\Exception\StateException::missingNonce();
-            }
-
-            $this->setIdToken($response['id_token']);
-            $user = $this->decode($response['id_token'])->toArray();
         }
 
         if (isset($response['expires_in']) && is_numeric($response['expires_in'])) {

--- a/src/Contract/TokenInterface.php
+++ b/src/Contract/TokenInterface.php
@@ -14,12 +14,9 @@ interface TokenInterface
     /**
      * Parses a provided JWT string and prepare for verification and validation.
      *
-     * @param string $jwt The JWT string to process.
-     *
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token parsing fails. See the exception message for further details.
      */
     public function parse(
-        string $jwt
     ): self;
 
     /**

--- a/src/Event/HttpRequestBuilt.php
+++ b/src/Event/HttpRequestBuilt.php
@@ -9,12 +9,9 @@ use Psr\Http\Message\RequestInterface;
 
 final class HttpRequestBuilt implements Auth0Event
 {
-    private RequestInterface $httpRequest;
-
     public function __construct(
-        RequestInterface $httpRequest
+        private RequestInterface $httpRequest
     ) {
-        $this->httpRequest = $httpRequest;
     }
 
     public function get(): RequestInterface

--- a/src/Event/HttpResponseReceived.php
+++ b/src/Event/HttpResponseReceived.php
@@ -10,15 +10,10 @@ use Psr\Http\Message\ResponseInterface;
 
 final class HttpResponseReceived implements Auth0Event
 {
-    private ResponseInterface $httpResponse;
-    private RequestInterface $httpRequest;
-
     public function __construct(
-        ResponseInterface $httpResponse,
-        RequestInterface $httpRequest
+        private ResponseInterface $httpResponse,
+        private RequestInterface $httpRequest
     ) {
-        $this->httpResponse = $httpResponse;
-        $this->httpRequest = $httpRequest;
     }
 
     public function get(): ResponseInterface

--- a/src/Event/Psr14Store/Boot.php
+++ b/src/Event/Psr14Store/Boot.php
@@ -9,15 +9,10 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Boot implements Auth0Event
 {
-    private StoreInterface $store;
-    private string $prefix;
-
     public function __construct(
-        StoreInterface $store,
-        string $prefix
+        private StoreInterface $store,
+        private string $prefix
     ) {
-        $this->store = $store;
-        $this->prefix = $prefix;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Clear.php
+++ b/src/Event/Psr14Store/Clear.php
@@ -9,13 +9,11 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Clear implements Auth0Event
 {
-    private StoreInterface $store;
     private ?bool $success = null;
 
     public function __construct(
-        StoreInterface $store
+        private StoreInterface $store
     ) {
-        $this->store = $store;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Defer.php
+++ b/src/Event/Psr14Store/Defer.php
@@ -9,15 +9,10 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Defer implements Auth0Event
 {
-    private StoreInterface $store;
-    private bool $state;
-
     public function __construct(
-        StoreInterface $store,
-        bool $state
+        private StoreInterface $store,
+        private bool $state
     ) {
-        $this->store = $store;
-        $this->state = $state;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Delete.php
+++ b/src/Event/Psr14Store/Delete.php
@@ -9,16 +9,12 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Delete implements Auth0Event
 {
-    private StoreInterface $store;
-    private string $key;
     private ?bool $success = null;
 
     public function __construct(
-        StoreInterface $store,
-        string $key
+        private StoreInterface $store,
+        private string $key
     ) {
-        $this->store = $store;
-        $this->key = $key;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Destruct.php
+++ b/src/Event/Psr14Store/Destruct.php
@@ -9,12 +9,9 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Destruct implements Auth0Event
 {
-    private StoreInterface $store;
-
     public function __construct(
-        StoreInterface $store
+        private StoreInterface $store
     ) {
-        $this->store = $store;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Get.php
+++ b/src/Event/Psr14Store/Get.php
@@ -9,10 +9,8 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Get implements Auth0Event
 {
-    private StoreInterface $store;
     private ?bool $missed = null;
     private ?bool $success = null;
-    private string $key;
 
     /**
      * @var mixed
@@ -20,11 +18,9 @@ final class Get implements Auth0Event
     private $value;
 
     public function __construct(
-        StoreInterface $store,
-        string $key
+        private StoreInterface $store,
+        private string $key
     ) {
-        $this->store = $store;
-        $this->key = $key;
     }
 
     public function getStore(): StoreInterface

--- a/src/Event/Psr14Store/Set.php
+++ b/src/Event/Psr14Store/Set.php
@@ -9,14 +9,7 @@ use Auth0\SDK\Contract\StoreInterface;
 
 final class Set implements Auth0Event
 {
-    private StoreInterface $store;
-    private string $key;
     private ?bool $success = null;
-
-    /**
-     * @var mixed
-     */
-    private $value;
 
     /**
      * @param StoreInterface $store
@@ -24,13 +17,10 @@ final class Set implements Auth0Event
      * @param mixed $value
      */
     public function __construct(
-        StoreInterface $store,
-        string $key,
-        $value
+        private StoreInterface $store,
+        private string $key,
+        private mixed $value
     ) {
-        $this->store = $store;
-        $this->key = $key;
-        $this->value = $value;
     }
 
     public function getStore(): StoreInterface

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -20,17 +20,6 @@ final class CookieStore implements StoreInterface
     public const VAL_CRYPTO_ALGO = 'aes-128-gcm';
 
     /**
-     * Instance of SdkConfiguration, for shared configuration across classes.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Cookie base name.
-     * Use 'namespace' argument to set this during instantiation.
-     */
-    private string $namespace;
-
-    /**
      * The threshold (in bytes) in which chunking/splitting occurs.
      */
     private int $threshold;
@@ -66,17 +55,9 @@ final class CookieStore implements StoreInterface
      * @psalm-suppress RedundantCondition
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        string $namespace = 'auth0'
+        private SdkConfiguration $configuration,
+        private string $namespace = 'auth0'
     ) {
-        [$namespace] = Toolkit::filter([$namespace])->string()->trim();
-
-        Toolkit::assert([
-            [$namespace, \Auth0\SDK\Exception\ArgumentException::missing('namespace')],
-        ])->isString();
-
-        $this->configuration = $configuration;
-        $this->namespace = (string) $namespace;
         $this->threshold = self::KEY_CHUNKING_THRESHOLD - strlen($this->namespace);
 
         $this->getState();
@@ -373,7 +354,7 @@ final class CookieStore implements StoreInterface
     public function getCookieOptions(
         ?int $expires = null
     ): array {
-        $expires = $expires ?? $this->configuration->getCookieExpires();
+        $expires ??= $this->configuration->getCookieExpires();
 
         if ($expires !== 0) {
             $expires = time() + $expires;

--- a/src/Store/Psr14Store.php
+++ b/src/Store/Psr14Store.php
@@ -13,7 +13,6 @@ use Auth0\SDK\Event\Psr14Store\Delete;
 use Auth0\SDK\Event\Psr14Store\Destruct;
 use Auth0\SDK\Event\Psr14Store\Get;
 use Auth0\SDK\Event\Psr14Store\Set;
-use Auth0\SDK\Utility\Toolkit;
 
 /**
  * Class Psr14Store
@@ -21,16 +20,6 @@ use Auth0\SDK\Utility\Toolkit;
  */
 final class Psr14Store implements StoreInterface
 {
-    /**
-     * Instance of SdkConfiguration, for shared configuration across classes.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Session base name, configurable on instantiation.
-     */
-    private string $sessionPrefix;
-
     /**
      * Track if a bootup event has been sent out yet.
      */
@@ -43,17 +32,9 @@ final class Psr14Store implements StoreInterface
      * @param string           $sessionPrefix A string to prefix session keys with.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        string $sessionPrefix = 'auth0'
+        private SdkConfiguration $configuration,
+        private string $sessionPrefix = 'auth0'
     ) {
-        [$sessionPrefix] = Toolkit::filter([$sessionPrefix])->string()->trim();
-
-        Toolkit::assert([
-            [$sessionPrefix, \Auth0\SDK\Exception\ArgumentException::missing('sessionPrefix')],
-        ])->isString();
-
-        $this->configuration = $configuration;
-        $this->sessionPrefix = $sessionPrefix ?? 'auth0';
     }
 
     /**

--- a/src/Store/Psr6Store.php
+++ b/src/Store/Psr6Store.php
@@ -17,21 +17,6 @@ use Psr\Cache\CacheItemPoolInterface;
 final class Psr6Store implements StoreInterface
 {
     /**
-     * The storage key to store data under.
-     */
-    private string $storageKey;
-
-    /**
-     * An instance of StoreInterface to use for 'public' storage.
-     */
-    private StoreInterface $publicStore;
-
-    /**
-     * An instance of CacheItemPoolInterface to use for 'private' storage.
-     */
-    private CacheItemPoolInterface $privateStore;
-
-    /**
      * Psr6Store constructor.
      *
      * @param StoreInterface         $publicStore  An instance of StoreInterface to use for 'public' storage.
@@ -39,13 +24,10 @@ final class Psr6Store implements StoreInterface
      * @param string                 $storageKey   A string representing the key/namespace under which to store values.
      */
     public function __construct(
-        StoreInterface $publicStore,
-        CacheItemPoolInterface $privateStore,
-        string $storageKey = 'storage_key'
+        private StoreInterface $publicStore,
+        private CacheItemPoolInterface $privateStore,
+        private string $storageKey = 'storage_key'
     ) {
-        $this->publicStore = $publicStore;
-        $this->privateStore = $privateStore;
-        $this->storageKey = $storageKey;
     }
 
     /**

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -15,35 +15,15 @@ use Auth0\SDK\Utility\Toolkit;
 final class SessionStore implements StoreInterface
 {
     /**
-     * Instance of SdkConfiguration, for shared configuration across classes.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Session base name, configurable on instantiation.
-     */
-    private string $sessionPrefix;
-
-    /**
      * SessionStore constructor.
      *
      * @param SdkConfiguration $configuration Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      * @param string           $sessionPrefix A string to prefix session keys with.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        string $sessionPrefix = 'auth0'
+        private SdkConfiguration $configuration,
+        private string $sessionPrefix = 'auth0'
     ) {
-        [$sessionPrefix] = Toolkit::filter([$sessionPrefix])->string()->trim();
-
-        Toolkit::assert([
-            [$sessionPrefix, \Auth0\SDK\Exception\ArgumentException::missing('sessionPrefix')],
-        ])->isString();
-
-        $this->configuration = $configuration;
-        $this->sessionPrefix = $sessionPrefix ?? 'auth0';
-
-        $this->start();
     }
 
     /**
@@ -69,6 +49,8 @@ final class SessionStore implements StoreInterface
         string $key,
         $value
     ): void {
+        $this->start();
+
         $_SESSION[$this->getSessionName($key)] = $value;
     }
 
@@ -85,6 +67,8 @@ final class SessionStore implements StoreInterface
         string $key,
         $default = null
     ) {
+        $this->start();
+
         $keyName = $this->getSessionName($key);
 
         if (isset($_SESSION[$keyName])) {
@@ -99,6 +83,8 @@ final class SessionStore implements StoreInterface
      */
     public function purge(): void
     {
+        $this->start();
+
         $session = $_SESSION ?? [];
         $prefix = $this->sessionPrefix . '_';
 
@@ -121,6 +107,8 @@ final class SessionStore implements StoreInterface
     public function delete(
         string $key
     ): void {
+        $this->start();
+
         unset($_SESSION[$this->getSessionName($key)]);
     }
 
@@ -144,7 +132,7 @@ final class SessionStore implements StoreInterface
     /**
      * This basic implementation of BaseAuth0 SDK uses PHP Sessions to store volatile data.
      */
-    private function start(): void
+    public function start(): void
     {
         $sessionId = session_id();
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -20,20 +20,7 @@ final class Token implements TokenInterface
     public const ALGO_RS256 = 'RS256';
     public const ALGO_HS256 = 'HS256';
 
-    /**
-     * A representation of the type of Token, to customize claim validations. See TYPE_ consts for options.
-     */
-    private int $type;
-
-    /**
-     * A unique, internal instance of \Auth0\SDK\Token\Parser
-     */
-    private Parser $parser;
-
-    /**
-     * Instance of SdkConfiguration
-     */
-    private SdkConfiguration $configuration;
+    private ?Parser $parser = null;
 
     /**
      * Constructor for Token handling class.
@@ -45,24 +32,15 @@ final class Token implements TokenInterface
      * @throws \Auth0\SDK\Exception\InvalidTokenException When Token parsing fails. See the exception message for further details.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        string $jwt,
-        int $type = self::TYPE_ID_TOKEN
+        private SdkConfiguration $configuration,
+        private string $jwt,
+        private int $type = self::TYPE_ID_TOKEN
     ) {
-        // Store the type of token we're working with.
-        $this->type = $type;
-
-        // Store the configuration internally.
-        $this->configuration = $configuration;
-
-        // Begin parsing the token.
-        $this->parse($jwt);
     }
 
     public function parse(
-        string $jwt
     ): self {
-        $this->parser = new Parser($jwt, $this->configuration);
+        $this->getParser();
         return $this;
     }
 
@@ -73,17 +51,17 @@ final class Token implements TokenInterface
         ?int $tokenCacheTtl = null,
         ?CacheItemPoolInterface $tokenCache = null
     ): self {
-        $tokenAlgorithm = $tokenAlgorithm ?? $this->configuration->getTokenAlgorithm();
-        $tokenJwksUri = $tokenJwksUri ?? $this->configuration->getTokenJwksUri() ?? null;
-        $clientSecret = $clientSecret ?? $this->configuration->getClientSecret() ?? null;
-        $tokenCacheTtl = $tokenCacheTtl ?? $this->configuration->getTokenCacheTtl();
-        $tokenCache = $tokenCache ?? $this->configuration->getTokenCache() ?? null;
+        $tokenAlgorithm ??= $this->configuration->getTokenAlgorithm();
+        $tokenJwksUri ??= $this->configuration->getTokenJwksUri() ?? null;
+        $clientSecret ??= $this->configuration->getClientSecret() ?? null;
+        $tokenCacheTtl ??= $this->configuration->getTokenCacheTtl();
+        $tokenCache ??= $this->configuration->getTokenCache() ?? null;
 
         if ($tokenJwksUri === null) {
             $tokenJwksUri = $this->configuration->formatDomain() . '/.well-known/jwks.json';
         }
 
-        $this->parser->verify(
+        $this->getParser()->verify(
             $tokenAlgorithm,
             $tokenJwksUri,
             $clientSecret,
@@ -103,22 +81,21 @@ final class Token implements TokenInterface
         ?int $tokenLeeway = null,
         ?int $tokenNow = null
     ): self {
-        $tokenIssuer = $tokenIssuer ?? $this->configuration->formatDomain() . '/';
-        $tokenAudience = $tokenAudience ?? $this->configuration->getAudience() ?? [];
-        $tokenOrganization = $tokenOrganization ?? $this->configuration->getOrganization() ?? null;
-        $tokenNonce = $tokenNonce ?? null;
-        $tokenMaxAge = $tokenMaxAge ?? $this->configuration->getTokenMaxAge() ?? null;
-        $tokenLeeway = $tokenLeeway ?? $this->configuration->getTokenLeeway() ?? 60;
+        $tokenIssuer ??= $this->configuration->formatDomain() . '/';
+        $tokenAudience ??= $this->configuration->getAudience() ?? [];
+        $tokenOrganization ??= $this->configuration->getOrganization() ?? null;
+        $tokenMaxAge ??= $this->configuration->getTokenMaxAge() ?? null;
+        $tokenLeeway ??= $this->configuration->getTokenLeeway() ?? 60;
         $tokenAudience[] = (string) $this->configuration->getClientId();
         $tokenAudience = array_unique($tokenAudience);
 
-        $validator = $this->parser->validate();
-        $now = $tokenNow ?? time();
+        $validator = $this->getParser()->validate();
+        $tokenNow ??= time();
 
         $validator
             ->issuer($tokenIssuer)
             ->audience($tokenAudience)
-            ->expiration($tokenLeeway, $now);
+            ->expiration($tokenLeeway, $tokenNow);
 
         if ($this->type === self::TYPE_ID_TOKEN) {
             $validator
@@ -132,7 +109,7 @@ final class Token implements TokenInterface
         }
 
         if ($tokenMaxAge !== null) {
-            $validator->authTime($tokenMaxAge, $tokenLeeway, $now);
+            $validator->authTime($tokenMaxAge, $tokenLeeway, $tokenNow);
         }
 
         if ($tokenOrganization !== null) {
@@ -144,7 +121,7 @@ final class Token implements TokenInterface
 
     public function getAudience(): ?array
     {
-        $claim = $this->parser->getClaim('aud');
+        $claim = $this->getParser()->getClaim('aud');
 
         if (is_string($claim)) {
             $claim = [ $claim ];
@@ -156,7 +133,7 @@ final class Token implements TokenInterface
 
     public function getAuthorizedParty(): ?string
     {
-        $claim = $this->parser->getClaim('azp');
+        $claim = $this->getParser()->getClaim('azp');
 
         /** @var string|null $claim */
         return $claim;
@@ -165,27 +142,27 @@ final class Token implements TokenInterface
     public function getAuthTime(): ?int
     {
         /** @var int|string|null $response */
-        $response = $this->parser->getClaim('auth_time');
+        $response = $this->getParser()->getClaim('auth_time');
         return $response === null ? null : (int) $response;
     }
 
     public function getExpiration(): ?int
     {
         /** @var int|string|null $response */
-        $response = $this->parser->getClaim('exp');
+        $response = $this->getParser()->getClaim('exp');
         return $response === null ? null : (int) $response;
     }
 
     public function getIssued(): ?int
     {
         /** @var int|string|null $response */
-        $response = $this->parser->getClaim('iat');
+        $response = $this->getParser()->getClaim('iat');
         return $response === null ? null : (int) $response;
     }
 
     public function getIssuer(): ?string
     {
-        $claim = $this->parser->getClaim('iss');
+        $claim = $this->getParser()->getClaim('iss');
 
         /** @var string|null $claim */
         return $claim;
@@ -193,7 +170,7 @@ final class Token implements TokenInterface
 
     public function getNonce(): ?string
     {
-        $claim = $this->parser->getClaim('nonce');
+        $claim = $this->getParser()->getClaim('nonce');
 
         /** @var string|null $claim */
         return $claim;
@@ -201,7 +178,7 @@ final class Token implements TokenInterface
 
     public function getOrganization(): ?string
     {
-        $claim = $this->parser->getClaim('org_id');
+        $claim = $this->getParser()->getClaim('org_id');
 
         /** @var string|null $claim */
         return $claim;
@@ -209,7 +186,7 @@ final class Token implements TokenInterface
 
     public function getSubject(): ?string
     {
-        $claim = $this->parser->getClaim('sub');
+        $claim = $this->getParser()->getClaim('sub');
 
         /** @var string|null $claim */
         return $claim;
@@ -217,11 +194,20 @@ final class Token implements TokenInterface
 
     public function toArray(): array
     {
-        return $this->parser->export();
+        return $this->getParser()->export();
     }
 
     public function toJson(): string
     {
         return json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+    }
+
+    private function getParser(): Parser
+    {
+        if (null === $this->parser) {
+            $this->parser = new Parser($this->configuration, $this->jwt);
+        }
+
+        return $this->parser;
     }
 }

--- a/src/Token/Validator.php
+++ b/src/Token/Validator.php
@@ -12,21 +12,13 @@ use Auth0\SDK\Contract\Token\ValidatorInterface;
 final class Validator implements ValidatorInterface
 {
     /**
-     * Array representing the claims of a JWT.
-     *
-     * @var array<string,array<int|string>|int|string>
-     */
-    private array $claims;
-
-    /**
      * Constructor for the Token Validator class.
      *
      * @param array<string,array<int|string>|int|string> $claims Array representing the claims of a JWT.
      */
     public function __construct(
-        array $claims
+        private array $claims
     ) {
-        $this->claims = $claims;
     }
 
     /**
@@ -71,7 +63,7 @@ final class Validator implements ValidatorInterface
         ?int $now = null
     ): self {
         $authTime = $this->getClaim('auth_time');
-        $now = $now ?? time();
+        $now ??= time();
 
         if ($authTime === null || ! is_numeric($authTime)) {
             throw \Auth0\SDK\Exception\InvalidTokenException::missingAuthTimeClaim();

--- a/src/Token/Verifier.php
+++ b/src/Token/Verifier.php
@@ -17,60 +17,6 @@ use Psr\Cache\CacheItemPoolInterface;
 final class Verifier
 {
     /**
-     * A string representing the headers and claims portions of a JWT.
-     */
-    private string $payload;
-
-    /**
-     * A string representing the signature portion of a JWT.
-     */
-    private string $signature;
-
-    /**
-     * An array of the headers for the JWT. Expects an 'alg' header, and in the case of RS256, a 'kid' header.
-     *
-     * @var array<int|string>
-     */
-    private array $headers;
-
-    /**
-     * Client Secret found in the Application settings for verifying HS256 tokens.
-     */
-    private ?string $clientSecret = null;
-
-    /**
-     * Algorithm to use for verification. Expects either RS256 or HS256. Defaults to RS256.
-     */
-    private ?string $algorithm = null;
-
-    /**
-     * URI to the JWKS when verifying RS256 tokens.
-     */
-    private ?string $jwksUri = null;
-
-    /**
-     * Time in seconds to keep JWKS records cached. Defaults to 60.
-     */
-    private ?int $cacheExpires = null;
-
-    /**
-     * An PSR-6 CacheItemPoolInterface instance to cache JWKS results within.
-     */
-    private ?CacheItemPoolInterface $cache = null;
-
-    /**
-     * Instance of SdkConfiguration, for shared configuration across classes.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Mocked responses for HTTP requests; only used in unit tests.
-     *
-     * @var array<object>
-     */
-    private ?array $mockedHttpResponses = null;
-
-    /**
      * Constructor for the Token Verifier class.
      *
      * @param string                      $payload             A string representing the headers and claims portions of a JWT.
@@ -84,28 +30,17 @@ final class Verifier
      * @param array<object>|null          $mockedHttpResponses Optional. Only intended for unit testing purposes.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        string $payload,
-        string $signature,
-        array $headers,
-        ?string $algorithm = null,
-        ?string $jwksUri = null,
-        ?string $clientSecret = null,
-        ?int $cacheExpires = null,
-        ?CacheItemPoolInterface $cache = null,
-        ?array & $mockedHttpResponses = null
+        private SdkConfiguration $configuration,
+        private string $payload,
+        private string $signature,
+        private array $headers,
+        private ?string $algorithm = null,
+        private ?string $jwksUri = null,
+        private ?string $clientSecret = null,
+        private ?int $cacheExpires = null,
+        private ?CacheItemPoolInterface $cache = null,
+        private ?array & $mockedHttpResponses = null
     ) {
-        $this->configuration = $configuration;
-        $this->payload = $payload;
-        $this->signature = $signature;
-        $this->headers = $headers;
-        $this->algorithm = $algorithm;
-        $this->jwksUri = $jwksUri;
-        $this->clientSecret = $clientSecret;
-        $this->cacheExpires = $cacheExpires;
-        $this->cache = $cache;
-        $this->mockedHttpResponses = & $mockedHttpResponses;
-
         $this->verify();
     }
 

--- a/src/Utility/EventDispatcher.php
+++ b/src/Utility/EventDispatcher.php
@@ -15,19 +15,13 @@ use Psr\EventDispatcher\StoppableEventInterface;
 final class EventDispatcher implements EventDispatcherInterface
 {
     /**
-     * Shared configuration data.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
      * EventDispatcher constructor.
      *
      * @param SdkConfiguration   $configuration   Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      */
     public function __construct(
-        SdkConfiguration $configuration
+        private SdkConfiguration $configuration
     ) {
-        $this->configuration = $configuration;
     }
 
     public function getListenerProvider(): ?ListenerProviderInterface

--- a/src/Utility/HttpClient.php
+++ b/src/Utility/HttpClient.php
@@ -22,33 +22,11 @@ final class HttpClient
     private ?HttpRequest $lastRequest = null;
 
     /**
-     * Shared configuration data.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Base API path.
-     */
-    private string $basePath;
-
-    /**
-     * Headers to set for all calls.
-     *
-     * @var array<string,int|string>
-     */
-    private array $headers = [];
-
-    /**
      * Mocked responses to pass to HttpRequest instances for testing.
      *
      * @var array<object>
      */
     private array $mockedResponses = [];
-
-    /**
-     * The context in which this client was created, for defining special behaviors.
-     */
-    private int $context = self::CONTEXT_AUTHENTICATION_CLIENT;
 
     /**
      * HttpClient constructor.
@@ -59,15 +37,11 @@ final class HttpClient
      * @param array<int|string> $headers         Optional. Additional headers to send with the HTTP request.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        int $context = self::CONTEXT_AUTHENTICATION_CLIENT,
-        string $basePath = '/',
-        array $headers = []
+        private SdkConfiguration $configuration,
+        private int $context = self::CONTEXT_AUTHENTICATION_CLIENT,
+        private string $basePath = '/',
+        private array $headers = []
     ) {
-        $this->configuration = $configuration;
-        $this->basePath = $basePath;
-        $this->headers = $headers;
-        $this->context = $context;
     }
 
     /**

--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -27,38 +27,11 @@ final class HttpRequest
     public const MIN_REQUEST_RETRY_DELAY = 100;
 
     /**
-     * Shared configuration data.
-     */
-    private SdkConfiguration $configuration;
-
-    /**
-     * Base API path for the request.
-     */
-    private string $basePath = '/';
-
-    /**
      * Path to request.
      *
      * @var array<string>
      */
     private array $path = [];
-
-    /**
-     * HTTP method to use for the request.
-     */
-    private string $method = '';
-
-    /**
-     * Headers to include for the request.
-     *
-     * @var array<string,mixed>
-     */
-    private array $headers = [];
-
-    /**
-     * Domain to use for request.
-     */
-    private ?string $domain = null;
 
     /**
      * URL parameters for the request.
@@ -109,18 +82,6 @@ final class HttpRequest
     private ?ResponseInterface $lastResponse = null;
 
     /**
-     * Mocked response.
-     *
-     * @var array<object>
-     */
-    private ?array $mockedResponses = null;
-
-    /**
-     * The context in which this client was created, for defining special behaviors.
-     */
-    private int $context = HttpClient::CONTEXT_AUTHENTICATION_CLIENT;
-
-    /**
      * HttpRequest constructor.
      *
      * @param SdkConfiguration   $configuration   Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
@@ -132,21 +93,14 @@ final class HttpRequest
      * @param array<object>|null $mockedResponses Optional. Only intended for unit testing purposes.
      */
     public function __construct(
-        SdkConfiguration $configuration,
-        int $context,
-        string $method,
-        string $basePath = '/',
-        array $headers = [],
-        ?string $domain = null,
-        ?array & $mockedResponses = null
+        private SdkConfiguration $configuration,
+        private int $context,
+        private string $method,
+        private string $basePath = '/',
+        private array $headers = [],
+        private ?string $domain = null,
+        private ?array & $mockedResponses = null
     ) {
-        $this->configuration = $configuration;
-        $this->context = $context;
-        $this->method = mb_strtoupper($method);
-        $this->basePath = $basePath;
-        $this->headers = $headers;
-        $this->domain = $domain;
-        $this->mockedResponses = & $mockedResponses;
     }
 
     /**
@@ -288,7 +242,7 @@ final class HttpRequest
         $httpRequestFactory = $this->configuration->getHttpRequestFactory();
         $httpClient = $this->configuration->getHttpClient();
         $configuredRetries = $this->configuration->getHttpMaxRetries();
-        $httpRequest = $httpRequestFactory->createRequest($this->method, $uri);
+        $httpRequest = $httpRequestFactory->createRequest(mb_strtoupper($this->method), $uri);
         $headers = $this->headers;
         $mockedResponse = null;
 
@@ -313,7 +267,6 @@ final class HttpRequest
 
         // Add headers to request payload.
         foreach ($headers as $headerName => $headerValue) {
-            /** @var string|int $headerValue */
             $httpRequest = $httpRequest->withHeader($headerName, (string) $headerValue);
         }
 

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -25,11 +25,6 @@ final class HttpResponsePaginator implements \Countable, \Iterator
     ];
 
     /**
-     * An instance of the current HttpClient to use for network requests.
-     */
-    private HttpClient $httpClient;
-
-    /**
      * The current position in use by the Iterator, for tracking our index while looping.
      */
     private int $position = 0;
@@ -74,9 +69,8 @@ final class HttpResponsePaginator implements \Countable, \Iterator
      * @throws \Auth0\SDK\Exception\PaginatorException When an unsupported request type is provided.
      */
     public function __construct(
-        HttpClient $httpClient
+        private HttpClient $httpClient
     ) {
-        $this->httpClient = $httpClient;
         $lastRequest = $this->lastRequest();
         $lastResponse = $this->lastResponse();
 

--- a/src/Utility/Request/FilteredRequest.php
+++ b/src/Utility/Request/FilteredRequest.php
@@ -10,29 +10,15 @@ namespace Auth0\SDK\Utility\Request;
 final class FilteredRequest
 {
     /**
-     * Fields to include or exclude from API responses.
-     *
-     * @var array<string>
-     */
-    private ?array $fields = null;
-
-    /**
-     * True to include $fields, false to exclude $fields.
-     */
-    private ?bool $includeFields = null;
-
-    /**
      * FilteredRequest constructor
      *
      * @param array<string>|null $fields        Fields to include or exclude from API responses.
      * @param bool|null          $includeFields True to include $fields, false to exclude $fields.
      */
     public function __construct(
-        ?array $fields = null,
-        ?bool $includeFields = null
+        private ?array $fields = null,
+        private ?bool $includeFields = null
     ) {
-        $this->fields = $fields;
-        $this->includeFields = $includeFields;
     }
 
     /**

--- a/src/Utility/Request/PaginatedRequest.php
+++ b/src/Utility/Request/PaginatedRequest.php
@@ -10,29 +10,9 @@ namespace Auth0\SDK\Utility\Request;
 final class PaginatedRequest
 {
     /**
-     * Page index of the results to return. First page is 0.
-     */
-    private ?int $page = null;
-
-    /**
-     * Number of results per page. Paging is disabled if parameter not set.
-     */
-    private ?int $perPage = null;
-
-    /**
-     * Optional ID from which to start selection. If not specified, checkpoint pagination is disabled.
-     */
-    private ?string $from = null;
-
-    /**
      * Number of results per page for checkpoint pagination.
      */
     private ?int $take = null;
-
-    /**
-     * Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
-     */
-    private ?bool $includeTotals = null;
 
     /**
      * PaginatedRequest constructor.
@@ -42,15 +22,11 @@ final class PaginatedRequest
      * @param bool|null $includeTotals Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
      */
     public function __construct(
-        ?int $page = null,
-        ?int $perPage = null,
-        ?bool $includeTotals = null,
-        ?string $from = null
+        private ?int $page = null,
+        private ?int $perPage = null,
+        private ?bool $includeTotals = null,
+        private ?string $from = null
     ) {
-        $this->page = $page;
-        $this->perPage = $perPage;
-        $this->includeTotals = $includeTotals;
-        $this->from = $from;
     }
 
     /**

--- a/src/Utility/Request/RequestOptions.php
+++ b/src/Utility/Request/RequestOptions.php
@@ -10,27 +10,15 @@ namespace Auth0\SDK\Utility\Request;
 final class RequestOptions
 {
     /**
-     * An instance of FilteredRequest or null, for managing field-filtered requests.
-     */
-    private ?FilteredRequest $fields = null;
-
-    /**
-     * An instance of PaginatedRequest or null, for managing paginated requests.
-     */
-    private ?PaginatedRequest $pagination = null;
-
-    /**
      * RequestOptions constructor
      *
      * @param FilteredRequest|null  $fields     An instance of FilteredRequest, for managing field-filtered requests.
      * @param PaginatedRequest|null $pagination An instance of PaginatedRequest, for managing paginated requests.
      */
     public function __construct(
-        ?FilteredRequest $fields = null,
-        ?PaginatedRequest $pagination = null
+        private ?FilteredRequest $fields = null,
+        private ?PaginatedRequest $pagination = null
     ) {
-        $this->fields = $fields;
-        $this->pagination = $pagination;
     }
 
     /**

--- a/src/Utility/Toolkit/Assert.php
+++ b/src/Utility/Toolkit/Assert.php
@@ -10,21 +10,13 @@ namespace Auth0\SDK\Utility\Toolkit;
 final class Assert
 {
     /**
-     * Values to process.
-     *
-     * @var array<array{0: mixed, 1: \Throwable}>
-     */
-    private array $subjects;
-
-    /**
      * ArrayProcessor Constructor
      *
      * @param array<array{0: mixed, 1: \Throwable}> $subjects Values to process.
      */
     public function __construct(
-        array $subjects
+        private array $subjects
     ) {
-        $this->subjects = $subjects;
     }
 
     /**

--- a/src/Utility/Toolkit/Filter.php
+++ b/src/Utility/Toolkit/Filter.php
@@ -13,21 +13,13 @@ use Auth0\SDK\Utility\Toolkit\Filter\StringFilter;
 final class Filter
 {
     /**
-     * Values to process.
-     *
-     * @var array<mixed>
-     */
-    private array $subjects;
-
-    /**
      * Filter Constructor
      *
      * @param array<mixed> $subjects An array of values to process.
      */
     public function __construct(
-        array $subjects
+        private array $subjects
     ) {
-        $this->subjects = $subjects;
     }
 
     /**

--- a/src/Utility/Toolkit/Filter/ArrayFilter.php
+++ b/src/Utility/Toolkit/Filter/ArrayFilter.php
@@ -12,21 +12,13 @@ use Auth0\SDK\Utility\Toolkit;
 final class ArrayFilter
 {
     /**
-     * Values to process.
-     *
-     * @var array<array<mixed>>
-     */
-    private array $subjects;
-
-    /**
      * StringFilter constructor.
      *
      * @param array<array<mixed>> $subjects An array of arrays to filter.
      */
     public function __construct(
-        array $subjects
+        private array $subjects
     ) {
-        $this->subjects = $subjects;
     }
 
     /**

--- a/src/Utility/Toolkit/Filter/StringFilter.php
+++ b/src/Utility/Toolkit/Filter/StringFilter.php
@@ -10,21 +10,13 @@ namespace Auth0\SDK\Utility\Toolkit\Filter;
 final class StringFilter
 {
     /**
-     * Values to process.
-     *
-     * @var array<string|null>
-     */
-    private array $subjects;
-
-    /**
      * StringFilter constructor.
      *
      * @param array<string|null> $subjects An array of string or null values.
      */
     public function __construct(
-        array $subjects
+        private array $subjects
     ) {
-        $this->subjects = $subjects;
     }
 
     /**

--- a/src/Utility/TransientStoreHandler.php
+++ b/src/Utility/TransientStoreHandler.php
@@ -12,19 +12,13 @@ use Auth0\SDK\Contract\StoreInterface;
 final class TransientStoreHandler
 {
     /**
-     * Storage method to use.
-     */
-    private StoreInterface $store;
-
-    /**
      * TransientStoreHandler constructor.
      *
      * @param StoreInterface $store Storage method to use.
      */
     public function __construct(
-        StoreInterface $store
+        private StoreInterface $store
     ) {
-        $this->store = $store;
     }
 
     /**

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -24,10 +24,6 @@ beforeEach(function(): void {
     $this->sdk = new Auth0($this->configuration);
 });
 
-test('__construct() fails without a configuration', function(): void {
-    new Authentication(null);
-})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
-
 test('__construct() accepts a configuration as an array', function(): void {
     $auth = new Authentication([
         'strategy' => SdkConfiguration::STRATEGY_API,

--- a/tests/Unit/API/ManagementTest.php
+++ b/tests/Unit/API/ManagementTest.php
@@ -29,10 +29,6 @@ beforeEach(function(): void {
     $this->sdk = new Auth0($this->configuration);
 });
 
-test('__construct() fails without a configuration', function(): void {
-    new Management(null);
-})->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_CONFIGURATION_REQUIRED);
-
 test('getHttpClient() fails without a managementToken, if client id and secret are not configured', function(): void {
     $this->configuration->setManagementToken(null);
     $this->sdk->management()->blacklists();

--- a/tests/Unit/Configuration/SdkConfigurationTest.php
+++ b/tests/Unit/Configuration/SdkConfigurationTest.php
@@ -214,12 +214,15 @@ test('a `webapp` strategy is used by default', function(): void
 
 test('a `webapp` strategy requires a domain', function(): void
 {
-    $sdk = new SdkConfiguration();
+    $sdk = new SdkConfiguration([
+        'cookieSecret' => uniqid(),
+    ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_DOMAIN);
 
 test('a `webapp` strategy requires a client id', function(): void
 {
     $sdk = new SdkConfiguration([
+        'cookieSecret' => uniqid(),
         'domain' => MockDomain::valid()
     ]);
 })->throws(\Auth0\SDK\Exception\ConfigurationException::class, \Auth0\SDK\Exception\ConfigurationException::MSG_REQUIRES_CLIENT_ID);
@@ -227,6 +230,7 @@ test('a `webapp` strategy requires a client id', function(): void
 test('a `webapp` strategy requires a client secret when HS256 is used', function(): void
 {
     $sdk = new SdkConfiguration([
+        'cookieSecret' => uniqid(),
         'domain' => MockDomain::valid(),
         'clientId' => uniqid(),
         'tokenAlgorithm' => 'HS256'

--- a/tests/Unit/Store/SessionStoreTest.php
+++ b/tests/Unit/Store/SessionStoreTest.php
@@ -9,7 +9,7 @@ use Auth0\Tests\Utilities\MockDomain;
 uses()->group('storage', 'storage.session');
 
 beforeEach(function(): void {
-    $_SESSION = [];
+    session_destroy();
 
     $this->configuration = new SdkConfiguration([
         'domain' => MockDomain::valid(),
@@ -22,6 +22,7 @@ beforeEach(function(): void {
     $this->namespace = uniqid();
 
     $this->store = new SessionStore($this->configuration, $this->namespace);
+    $this->store->start();
 });
 
 test('set() assigns values as expected', function(string $key, string $value): void {

--- a/tests/Unit/Token/ParserTest.php
+++ b/tests/Unit/Token/ParserTest.php
@@ -22,9 +22,7 @@ beforeEach(function() {
 it('throws an exception with json error on decoding headers', function(
     SdkConfiguration $configuration
 ): void {
-    $jwt = sprintf('1234567879.%s.%s', uniqid(), uniqid());
-
-    $token = new Parser($jwt, $configuration);
+    new Parser($configuration, sprintf('1234567879.%s.%s', uniqid(), uniqid()));
 })->with(['mocked configured' => [
     fn() => $this->configuration
 ]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, 'Malformed UTF-8 characters, possibly incorrectly encoded');
@@ -32,9 +30,7 @@ it('throws an exception with json error on decoding headers', function(
 it('throws an exception with json error on decoding claims', function(
     SdkConfiguration $configuration
 ): void {
-    $jwt = sprintf('%s.1234567879.%s', uniqid(), uniqid());
-
-    $token = new Parser($jwt, $configuration);
+     new Parser($configuration, sprintf('%s.1234567879.%s', uniqid(), uniqid()));
 })->with(['mocked configured' => [
     fn() => $this->configuration
 ]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, 'Malformed UTF-8 characters, possibly incorrectly encoded');
@@ -42,9 +38,7 @@ it('throws an exception with json error on decoding claims', function(
 it('throws an exception with malformed token separators', function(
     SdkConfiguration $configuration
 ): void {
-    $jwt = uniqid() . uniqid();
-
-    $token = new Parser($jwt, $configuration);
+    $token = new Parser($configuration, uniqid() . uniqid());
 })->with(['mocked configured' => [
     fn() => $this->configuration
 ]])->throws(\Auth0\SDK\Exception\InvalidTokenException::class, \Auth0\SDK\Exception\InvalidTokenException::MSG_BAD_SEPARATORS);
@@ -53,7 +47,7 @@ it('accepts and successfully parses a valid RS256 ID Token', function(
     SdkConfiguration $configuration,
     TokenGeneratorResponse $jwt
 ): void {
-    $token = new Parser($jwt->token, $configuration);
+    $token = new Parser($configuration, $jwt->token);
 
     expect($token)
         ->toBeObject()
@@ -80,7 +74,7 @@ it('defaults to a `jwt` `typ` header if none was present', function(
     SdkConfiguration $configuration,
     TokenGeneratorResponse $jwt
 ): void {
-    $token = new Parser($jwt->token, $configuration);
+    $token = new Parser($configuration, $jwt->token);
 
     expect($token)
         ->toBeObject()
@@ -95,7 +89,7 @@ test('hasClaim() returns expected values', function(
     SdkConfiguration $configuration,
     TokenGeneratorResponse $jwt
 ): void {
-    $token = new Parser($jwt->token, $configuration);
+    $token = new Parser($configuration, $jwt->token);
     expect($token->hasClaim('aud'))->toBeTrue();
     expect($token->hasClaim('xyz'))->toBeFalse();
 })->with(['mocked rs256 id token' => [
@@ -107,7 +101,7 @@ test('hasHeader() returns expected values', function(
     SdkConfiguration $configuration,
     TokenGeneratorResponse $jwt
 ): void {
-    $token = new Parser($jwt->token, $configuration);
+    $token = new Parser($configuration, $jwt->token);
     expect($token->hasHeader('typ'))->toBeTrue();
     expect($token->hasHeader('xyz'))->toBeFalse();
 })->with(['mocked rs256 id token' => [
@@ -119,7 +113,7 @@ test('getRaw() returns a raw token string', function(
     SdkConfiguration $configuration,
     TokenGeneratorResponse $jwt
 ): void {
-    $token = new Parser($jwt->token, $configuration);
+    $token = new Parser($configuration, $jwt->token);
     expect($token->getRaw())->toEqual($jwt->token);
 })->with(['mocked rs256 id token' => [
     fn() => $this->configuration,

--- a/tests/Unit/Token/VerifierTest.php
+++ b/tests/Unit/Token/VerifierTest.php
@@ -59,7 +59,7 @@ test('verify() throws an error when token alg claim is not supported', function(
     new Verifier($this->configuration, '', '', ['alg' => uniqid()]);
 })->throws(\Auth0\SDK\Exception\InvalidTokenException::class);
 
-test('verify() throws an exception signature is incorrect', function($keyPair, $token, $payload, $signature, $headers, $jwksUri, $jwksCacheKey): void {
+test('verify() throws an exception when signature is incorrect', function($keyPair, $token, $payload, $signature, $headers, $jwksUri, $jwksCacheKey): void {
     $headers = TokenGenerator::decodePart($headers);
     $cache = new ArrayAdapter();
     $item = $cache->getItem($jwksCacheKey);

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -70,7 +70,7 @@ class TokenGenerator
 
         $privateKeyResource = openssl_pkey_new($config);
 
-        $export = openssl_pkey_export($privateKeyResource, $privateKey, null, $config);
+        $export = openssl_pkey_export($privateKeyResource, $privateKey);
 
         if ($export === false) {
             throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());
@@ -98,7 +98,7 @@ class TokenGenerator
 
         $privateKeyResource = openssl_pkey_new($config);
 
-        $export = openssl_pkey_export($privateKeyResource, $privateKey, null, $config);
+        $export = openssl_pkey_export($privateKeyResource, $privateKey);
 
         if ($export === false) {
             throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\Tests\Utilities;
 
 use Firebase\JWT\JWT;
+use RuntimeException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -49,14 +50,32 @@ class TokenGenerator
         return array_merge($defaults, $overrides);
     }
 
+    public static function getOpenSslError(): string
+    {
+		$errors = [];
+
+		while ($error = openssl_error_string()) {
+			$errors[] = $error;
+		}
+
+        return implode(', ', $errors);
+    }
+
     public static function generateRsaKeyPair(): array
     {
-        $privateKeyResource = openssl_pkey_new([
+        $config = [
             'digest_alg' => 'sha256',
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
+        ];
 
-        openssl_pkey_export($privateKeyResource, $privateKey);
+        $privateKeyResource = openssl_pkey_new($config);
+
+        $export = openssl_pkey_export($privateKeyResource, $privateKey, null, $config);
+
+        if ($export === false) {
+            throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());
+        }
+
         $publicKey = openssl_pkey_get_details($privateKeyResource);
 
         $resCsr = openssl_csr_new([], $privateKeyResource);
@@ -72,12 +91,19 @@ class TokenGenerator
 
     public static function generateDsaKeyPair(): array
     {
-        $privateKeyResource = openssl_pkey_new([
+        $config = [
             'digest_alg' => 'sha256',
             'private_key_type' => OPENSSL_KEYTYPE_DSA,
-        ]);
+        ];
 
-        openssl_pkey_export($privateKeyResource, $privateKey);
+        $privateKeyResource = openssl_pkey_new($config);
+
+        $export = openssl_pkey_export($privateKeyResource, $privateKey, null, $config);
+
+        if ($export === false) {
+            throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());
+        }
+
         $publicKey = openssl_pkey_get_details($privateKeyResource);
 
         $resCsr = openssl_csr_new([], $privateKeyResource);

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -70,6 +70,10 @@ class TokenGenerator
 
         $privateKeyResource = openssl_pkey_new($config);
 
+        if ($privateKeyResource === false) {
+            throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());
+        }
+
         $export = openssl_pkey_export($privateKeyResource, $privateKey);
 
         if ($export === false) {
@@ -97,6 +101,10 @@ class TokenGenerator
         ];
 
         $privateKeyResource = openssl_pkey_new($config);
+
+        if ($privateKeyResource === false) {
+            throw new RuntimeException("OpenSSL reported an error: " . self::getOpenSslError());
+        }
 
         $export = openssl_pkey_export($privateKeyResource, $privateKey);
 


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there before committing work.
-->

### Changes

This PR addresses a bug reported in #673 by @winstoncl in which: if a `state` value is provided by the host applications upon calling `login()`, it was not being properly stored within the given transient medium for comparison later (upon calling `exchange()` on the return trip.) This caused an `Invalid State` exception to be raised.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #673 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Run `composer test` or see GitHub status checks on this PR.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
