### PR TITLE
Release 8.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [8.3.8](https://github.com/auth0/auth0-PHP/tree/8.3.8) (2022-11-28)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.7...8.3.8)
+
+**Fixed**
+- fix: Always store provided state in transient medium [\#674](https://github.com/auth0/auth0-PHP/pull/674) ([evansims](https://github.com/evansims))
+
 ## [8.3.7](https://github.com/auth0/auth0-PHP/tree/8.3.7) (2022-11-07)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.3.6...8.3.7)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -23,7 +23,7 @@ use Auth0\SDK\Utility\TransientStoreHandler;
  */
 final class Auth0 implements Auth0Interface
 {
-    public const VERSION = '8.3.7';
+    public const VERSION = '8.3.8';
 
     /**
      * Instance of SdkConfiguration, for shared configuration across classes.


### PR DESCRIPTION
**Fixed**
- fix: Always store provided state in transient medium [\#674](https://github.com/auth0/auth0-PHP/pull/674) ([evansims](https://github.com/evansims))