### PR TITLE
feat: Add Token generator support

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,10 @@
     <include>
       <directory suffix=".php">./src/</directory>
     </include>
+    <exclude>
+      <directory suffix=".php">./src/Contract/</directory>
+      <directory suffix=".php">./src/Exception/</directory>
+    </exclude>
   </coverage>
   <testsuites>
     <testsuite name="unit">

--- a/src/Contract/Token/GeneratorInterface.php
+++ b/src/Contract/Token/GeneratorInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Contract\Token;
+
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token;
+use OpenSSLAsymmetricKey;
+
+/**
+ * @codeCoverageIgnore
+ */
+interface GeneratorInterface
+{
+    /**
+     * Create a new token generator instance.
+     *
+     * @param OpenSSLAsymmetricKey|string $signingKey Signing key to use for signing the token. This MUST be a string for HS256. MUST be either a string or OpenSSLAsymmetricKey for RS256.
+     * @param string $algorithm Algorithm to use for signing the token. Defaults to RS256.
+     * @param array $claims Claims to include in the token. Defaults to an empty array.
+     * @param array $headers Headers to include in the token. Defaults to an empty array. The the "alg" header will be set to represent $algorithm appropriately.
+     * @param null|string $signingKeyPassphrase Optional. Passphrase to use for signing key if it is encrypted. Defaults to null.
+     *
+     * @throws TokenException When an unsupported algorithm is provided.
+     * @throws TokenException When a non-string $signingKey is provided for HS256.
+     * @throws TokenException When a string $signingKey is used with RS256.
+     * @throws TokenException When using RS256 and openssl_pkey_get_private() is unable to load the provided signing key.
+     */
+    public static function create(
+        OpenSSLAsymmetricKey|string $signingKey,
+        string $algorithm = Token::ALGO_RS256,
+        array $claims = [],
+        array $headers = [],
+        null|string $signingKeyPassphrase = null
+    ): static;
+
+    /**
+     * Generate a new token and return it as an array.
+     *
+     * @param bool $encodeSegments Whether to encode the segments or not. Defaults to true.
+     *
+     * @throws TokenException If an error occurs while generating the token.
+     */
+    public function toArray(
+        $encodeSegments = true
+    ): array;
+
+    /**
+     * Generate a new token and return it as a string.
+     *
+     * @throws TokenException
+     */
+    public function toString(): string;
+
+    /**
+     * Generate a new token and return it as a string.
+     *
+     * @throws TokenException
+     */
+    public function __toString(): string;
+}

--- a/src/Contract/Token/GeneratorInterface.php
+++ b/src/Contract/Token/GeneratorInterface.php
@@ -8,9 +8,6 @@ use Auth0\SDK\Exception\TokenException;
 use Auth0\SDK\Token;
 use OpenSSLAsymmetricKey;
 
-/**
- * @codeCoverageIgnore
- */
 interface GeneratorInterface
 {
     /**
@@ -18,8 +15,8 @@ interface GeneratorInterface
      *
      * @param OpenSSLAsymmetricKey|string $signingKey Signing key to use for signing the token. This MUST be a string for HS256. MUST be either a string or OpenSSLAsymmetricKey for RS256.
      * @param string $algorithm Algorithm to use for signing the token. Defaults to RS256.
-     * @param array $claims Claims to include in the token. Defaults to an empty array.
-     * @param array $headers Headers to include in the token. Defaults to an empty array. The the "alg" header will be set to represent $algorithm appropriately.
+     * @param array<mixed> $claims Claims to include in the token. Defaults to an empty array.
+     * @param array<string> $headers Headers to include in the token. Defaults to an empty array. The the "alg" header will be set to represent $algorithm appropriately.
      * @param null|string $signingKeyPassphrase Optional. Passphrase to use for signing key if it is encrypted. Defaults to null.
      *
      * @throws TokenException When an unsupported algorithm is provided.
@@ -39,6 +36,8 @@ interface GeneratorInterface
      * Generate a new token and return it as an array.
      *
      * @param bool $encodeSegments Whether to encode the segments or not. Defaults to true.
+     *
+     * @return array<mixed>
      *
      * @throws TokenException If an error occurs while generating the token.
      */

--- a/src/Contract/TokenInterface.php
+++ b/src/Contract/TokenInterface.php
@@ -7,7 +7,9 @@ namespace Auth0\SDK\Contract;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
- * Interface TokenInterface.
+ *
+ * @codeCoverageIgnore
+ *
  */
 interface TokenInterface
 {

--- a/src/Exception/TokenException.php
+++ b/src/Exception/TokenException.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Exception;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class TokenException extends \Exception implements Auth0Exception
+{
+    const MSG_UNKNOWN_ERROR = 'An unknown error occurred.';
+    const MSG_KEY_TYPE_UNKNOWN = 'Key type could not be determined';
+    const MSG_KEY_TYPE_NOT_SUPPORTED = 'Key type "%s" is not supported for the $s algorithm';
+    const MSG_SIGNING_KEY_PROCESSING_ERROR = 'An exception occurred while attempting to process the configured signing key: %s';
+    const MSG_UNABLE_TO_ENCODE_SEGMENT = 'An exception occurred while attempting to encode segment "%s" during token generation: %s';
+    const MSG_UNABLE_TO_SIGN_DATA = 'An exception occurred while attempting to produce signature during token generation: %s';
+    const MSG_UNSUPPORTED_ALGORITHM = 'Unsupported algorithm "%s". Supported algorithms are: %s';
+    const MSG_HS256_REQUIRES_KEY_AS_STRING = 'HS256 algorithm requires a key in string format.';
+    const MSG_LIB_OPENSSL_MISSING = 'The OpenSSL extension is required to generate tokens';
+    const MSG_LIB_OPENSSL_MISSING_ALGO = 'The OpenSSL extension must support %s algorithm to generate tokens';
+
+    public static function unableToProcessSigningKey(
+        string $message,
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(sprintf(static::MSG_SIGNING_KEY_PROCESSING_ERROR, $message), 0, $previous);
+    }
+
+    public static function unableToEncodeSegment(
+        string $segment,
+        string $message,
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(sprintf(static::MSG_UNABLE_TO_ENCODE_SEGMENT, $segment, $message), 0, $previous);
+    }
+
+    public static function unableToSignData(
+        string $message,
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(sprintf(static::MSG_UNABLE_TO_SIGN_DATA, $message), 0, $previous);
+    }
+
+    public static function unsupportedAlgorithm (
+        string $algorithm,
+        string $supported,
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(sprintf(static::MSG_UNSUPPORTED_ALGORITHM, $algorithm, $supported), 0, $previous);
+    }
+
+    public static function requireKeyAsStringHs256 (
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(static::MSG_HS256_REQUIRES_KEY_AS_STRING, 0, $previous);
+    }
+
+    public static function openSslMissing (
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(static::MSG_LIB_OPENSSL_MISSING, 0, $previous);
+    }
+
+    public static function openSslMissingAlgo (
+        string $algorithm,
+        ?\Throwable $previous = null,
+    ): static {
+        return new static(sprintf(static::MSG_LIB_OPENSSL_MISSING_ALGO, $algorithm), 0, $previous);
+    }
+}

--- a/src/Exception/TokenException.php
+++ b/src/Exception/TokenException.php
@@ -9,16 +9,16 @@ namespace Auth0\SDK\Exception;
  */
 final class TokenException extends \Exception implements Auth0Exception
 {
-    const MSG_UNKNOWN_ERROR = 'An unknown error occurred.';
-    const MSG_KEY_TYPE_UNKNOWN = 'Key type could not be determined';
-    const MSG_KEY_TYPE_NOT_SUPPORTED = 'Key type "%s" is not supported for the $s algorithm';
-    const MSG_SIGNING_KEY_PROCESSING_ERROR = 'An exception occurred while attempting to process the configured signing key: %s';
-    const MSG_UNABLE_TO_ENCODE_SEGMENT = 'An exception occurred while attempting to encode segment "%s" during token generation: %s';
-    const MSG_UNABLE_TO_SIGN_DATA = 'An exception occurred while attempting to produce signature during token generation: %s';
-    const MSG_UNSUPPORTED_ALGORITHM = 'Unsupported algorithm "%s". Supported algorithms are: %s';
-    const MSG_HS256_REQUIRES_KEY_AS_STRING = 'HS256 algorithm requires a key in string format.';
-    const MSG_LIB_OPENSSL_MISSING = 'The OpenSSL extension is required to generate tokens';
-    const MSG_LIB_OPENSSL_MISSING_ALGO = 'The OpenSSL extension must support %s algorithm to generate tokens';
+    public const MSG_UNKNOWN_ERROR = 'An unknown error occurred.';
+    public const MSG_KEY_TYPE_UNKNOWN = 'Key type could not be determined';
+    public const MSG_KEY_TYPE_NOT_SUPPORTED = 'Key type "%s" is not supported for the $s algorithm';
+    public const MSG_SIGNING_KEY_PROCESSING_ERROR = 'An exception occurred while attempting to process the configured signing key: %s';
+    public const MSG_UNABLE_TO_ENCODE_SEGMENT = 'An exception occurred while attempting to encode segment "%s" during token generation: %s';
+    public const MSG_UNABLE_TO_SIGN_DATA = 'An exception occurred while attempting to produce signature during token generation: %s';
+    public const MSG_UNSUPPORTED_ALGORITHM = 'Unsupported algorithm "%s". Supported algorithms are: %s';
+    public const MSG_HS256_REQUIRES_KEY_AS_STRING = 'HS256 algorithm requires a key in string format.';
+    public const MSG_LIB_OPENSSL_MISSING = 'The OpenSSL extension is required to generate tokens';
+    public const MSG_LIB_OPENSSL_MISSING_ALGO = 'The OpenSSL extension must support %s algorithm to generate tokens';
 
     public static function unableToProcessSigningKey(
         string $message,
@@ -42,7 +42,7 @@ final class TokenException extends \Exception implements Auth0Exception
         return new static(sprintf(static::MSG_UNABLE_TO_SIGN_DATA, $message), 0, $previous);
     }
 
-    public static function unsupportedAlgorithm (
+    public static function unsupportedAlgorithm(
         string $algorithm,
         string $supported,
         ?\Throwable $previous = null,
@@ -50,19 +50,19 @@ final class TokenException extends \Exception implements Auth0Exception
         return new static(sprintf(static::MSG_UNSUPPORTED_ALGORITHM, $algorithm, $supported), 0, $previous);
     }
 
-    public static function requireKeyAsStringHs256 (
+    public static function requireKeyAsStringHs256(
         ?\Throwable $previous = null,
     ): static {
         return new static(static::MSG_HS256_REQUIRES_KEY_AS_STRING, 0, $previous);
     }
 
-    public static function openSslMissing (
+    public static function openSslMissing(
         ?\Throwable $previous = null,
     ): static {
         return new static(static::MSG_LIB_OPENSSL_MISSING, 0, $previous);
     }
 
-    public static function openSslMissingAlgo (
+    public static function openSslMissingAlgo(
         string $algorithm,
         ?\Throwable $previous = null,
     ): static {

--- a/src/Exception/TokenException.php
+++ b/src/Exception/TokenException.php
@@ -23,49 +23,49 @@ final class TokenException extends \Exception implements Auth0Exception
     public static function unableToProcessSigningKey(
         string $message,
         ?\Throwable $previous = null,
-    ): static {
-        return new static(sprintf(static::MSG_SIGNING_KEY_PROCESSING_ERROR, $message), 0, $previous);
+    ): self {
+        return new self(sprintf(static::MSG_SIGNING_KEY_PROCESSING_ERROR, $message), 0, $previous);
     }
 
     public static function unableToEncodeSegment(
         string $segment,
         string $message,
         ?\Throwable $previous = null,
-    ): static {
-        return new static(sprintf(static::MSG_UNABLE_TO_ENCODE_SEGMENT, $segment, $message), 0, $previous);
+    ): self {
+        return new self(sprintf(static::MSG_UNABLE_TO_ENCODE_SEGMENT, $segment, $message), 0, $previous);
     }
 
     public static function unableToSignData(
         string $message,
         ?\Throwable $previous = null,
-    ): static {
-        return new static(sprintf(static::MSG_UNABLE_TO_SIGN_DATA, $message), 0, $previous);
+    ): self {
+        return new self(sprintf(static::MSG_UNABLE_TO_SIGN_DATA, $message), 0, $previous);
     }
 
     public static function unsupportedAlgorithm(
         string $algorithm,
         string $supported,
         ?\Throwable $previous = null,
-    ): static {
-        return new static(sprintf(static::MSG_UNSUPPORTED_ALGORITHM, $algorithm, $supported), 0, $previous);
+    ): self {
+        return new self(sprintf(static::MSG_UNSUPPORTED_ALGORITHM, $algorithm, $supported), 0, $previous);
     }
 
     public static function requireKeyAsStringHs256(
         ?\Throwable $previous = null,
-    ): static {
-        return new static(static::MSG_HS256_REQUIRES_KEY_AS_STRING, 0, $previous);
+    ): self {
+        return new self(static::MSG_HS256_REQUIRES_KEY_AS_STRING, 0, $previous);
     }
 
     public static function openSslMissing(
         ?\Throwable $previous = null,
-    ): static {
-        return new static(static::MSG_LIB_OPENSSL_MISSING, 0, $previous);
+    ): self {
+        return new self(static::MSG_LIB_OPENSSL_MISSING, 0, $previous);
     }
 
     public static function openSslMissingAlgo(
         string $algorithm,
         ?\Throwable $previous = null,
-    ): static {
-        return new static(sprintf(static::MSG_LIB_OPENSSL_MISSING_ALGO, $algorithm), 0, $previous);
+    ): self {
+        return new self(sprintf(static::MSG_LIB_OPENSSL_MISSING_ALGO, $algorithm), 0, $previous);
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -16,6 +16,7 @@ final class Token implements TokenInterface
 {
     public const TYPE_ID_TOKEN = 1;
 
+    public const TYPE_ACCESS_TOKEN = 2;
     public const TYPE_TOKEN = 2;
 
     public const ALGO_RS256 = 'RS256';

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -47,8 +47,7 @@ final class Generator implements GeneratorInterface
 
     public function toArray(
         $encodeSegments = true
-    ): array
-    {
+    ): array {
         // Build token from headers and claims.
         $segments = [
             static::encode(data: $this->headers, segment: 'headers', skip: !$encodeSegments),
@@ -122,7 +121,8 @@ final class Generator implements GeneratorInterface
      *
      * @throws TokenException When a configuration issue in the host environment is detected.
      */
-    private function checkEnvironment(): void {
+    private function checkEnvironment(): void
+    {
         if (! extension_loaded('openssl')) {
             throw TokenException::openSslMissing();
         }
@@ -151,7 +151,8 @@ final class Generator implements GeneratorInterface
      * @throws TokenException When a string $signingKey is used with RS256.
      * @throws TokenException When using RS256 and openssl_pkey_get_private() is unable to load the provided signing key.
      */
-    private function loadSigningKey(OpenSSLAsymmetricKey|string $signingKey, null|string $signingKeyPassphrase = null): OpenSSLAsymmetricKey|string {
+    private function loadSigningKey(OpenSSLAsymmetricKey|string $signingKey, null|string $signingKeyPassphrase = null): OpenSSLAsymmetricKey|string
+    {
         // Ensure the provided algorithm is supported.
         if (! \in_array($this->algorithm, static::CONST_SUPPORTED_ALGOS, true)) {
             throw TokenException::unsupportedAlgorithm($this->algorithm, implode(',', static::CONST_SUPPORTED_ALGOS));
@@ -233,7 +234,7 @@ final class Generator implements GeneratorInterface
                     value: $data,
                     flags: \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR
                 );
-            // @codeCoverageIgnoreStart
+                // @codeCoverageIgnoreStart
             } catch (\Throwable $th) {
                 throw TokenException::unableToEncodeSegment($segment, $th->getMessage());
             }
@@ -289,7 +290,7 @@ final class Generator implements GeneratorInterface
                 private_key: $this->signingKey,
                 algorithm: \OPENSSL_ALGO_SHA256
             );
-        // @codeCoverageIgnoreStart
+            // @codeCoverageIgnoreStart
         } catch (\Throwable $th) {
             $failure = $th;
         }
@@ -314,7 +315,8 @@ final class Generator implements GeneratorInterface
      *
      * @return array<string> The OpenSSL error stack.
      */
-    private function getOpenSslErrorStack(): array {
+    private function getOpenSslErrorStack(): array
+    {
         $openSslErrorStack = [];
 
         while ($error = openssl_error_string()) {

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Token;
+
+use Auth0\SDK\Contract\Token\GeneratorInterface;
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token;
+use OpenSSLAsymmetricKey;
+
+final class Generator implements GeneratorInterface
+{
+    /**
+     * Supported algorithms for token generation.
+     */
+    public const CONST_SUPPORTED_ALGOS = [
+        Token::ALGO_RS256,
+        Token::ALGO_HS256,
+    ];
+
+    /**
+     * Supported key types for token generation.
+     */
+    public const CONST_SUPPORTED_KEY_TYPES = [
+        OPENSSL_KEYTYPE_RSA => 'RSA',
+        OPENSSL_KEYTYPE_DSA => 'DSA',
+        OPENSSL_KEYTYPE_DH => 'DH',
+        OPENSSL_KEYTYPE_EC => 'EC',
+    ];
+
+    public static function create(
+        OpenSSLAsymmetricKey|string $signingKey,
+        string $algorithm = Token::ALGO_RS256,
+        array $claims = [],
+        array $headers = [],
+        null|string $signingKeyPassphrase = null
+    ): static {
+        return new static(
+            signingKey: $signingKey,
+            algorithm: $algorithm,
+            claims: $claims,
+            headers: $headers,
+            signingKeyPassphrase: $signingKeyPassphrase
+        );
+    }
+
+    public function toArray(
+        $encodeSegments = true
+    ): array
+    {
+        // Build token from headers and claims.
+        $segments = [
+            static::encode(data: $this->headers, segment: 'headers', skip: !$encodeSegments),
+            static::encode(data: $this->claims, segment: 'claims', skip: !$encodeSegments)
+        ];
+
+        // Sign the token.
+        $signature = $this->sign(
+            data: $this->glue($segments)
+        );
+
+        // Attach the signature to the token.
+        $segments[] = $signature;
+
+        if (! $encodeSegments) {
+            return [
+                'headers' => $this->headers,
+                'claims' => $this->claims,
+                'signature' => $signature
+            ];
+        }
+
+        // Return the token with encoded segments.
+        return $segments;
+    }
+
+    public function toString(): string
+    {
+        return $this->glue(array_values($this->toArray()));
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Create a new token generator instance.
+     *
+     * @param OpenSSLAsymmetricKey|string $signingKey Signing key to use for signing the token. This MUST be a string for HS256. MUST be either a string or OpenSSLAsymmetricKey for RS256.
+     * @param string $algorithm Algorithm to use for signing the token. Defaults to RS256.
+     * @param array $claims Claims to include in the token. Defaults to an empty array.
+     * @param array $headers Headers to include in the token. Defaults to an empty array. The the "alg" header will be set to represent $algorithm appropriately.
+     * @param null|string $signingKeyPassphrase Optional. Passphrase to use for signing key if it is encrypted. Defaults to null.
+     *
+     * @throws TokenException When an unsupported algorithm is provided.
+     * @throws TokenException When a non-string $signingKey is provided for HS256.
+     * @throws TokenException When a string $signingKey is used with RS256.
+     * @throws TokenException When using RS256 and openssl_pkey_get_private() is unable to load the provided signing key.
+     */
+    private function __construct(
+        private OpenSSLAsymmetricKey|string $signingKey,
+        private string $algorithm = Token::ALGO_RS256,
+        private array $claims = [],
+        private array $headers = [],
+        private null|string $signingKeyPassphrase = null
+    ) {
+        // Ensure the environment is configured with the necessary OpenSSL extension support.
+        $this->checkEnvironment();
+
+        // Merge any provided headers with the defaults.
+        $this->headers = array_merge($this->headers, ['type' => 'JWT', 'alg' => $this->algorithm]);
+
+        // Convert the provided signing key to the appropriate type.
+        $this->signingKey = $this->loadSigningKey($signingKey, $signingKeyPassphrase);
+    }
+
+    // @codeCoverageIgnoreStart
+    /**
+     * Ensure the environment is configured with the necessary OpenSSL extension support.
+     *
+     * @throws TokenException When a configuration issue in the host environment is detected.
+     */
+    private function checkEnvironment(): void {
+        if (! extension_loaded('openssl')) {
+            throw TokenException::openSslMissing();
+        }
+
+        $envSupportsDigestMethods = openssl_get_md_methods(true);
+        $sdkRequiredDigestMethods = ['sha256', 'sha384', 'sha512'];
+
+        foreach ($sdkRequiredDigestMethods as $method) {
+            if (! in_array($method, $envSupportsDigestMethods, true)) {
+                throw TokenException::openSslMissingAlgo($method);
+            }
+        }
+
+        // $envSupportsCurveMethods = openssl_get_curve_names();
+    }
+    // @codeCoverageIgnoreEnd
+
+    /**
+     * Load the provided signing key and return as an appropriate object type.
+     *
+     * @param OpenSSLAsymmetricKey|string $signingKey Signing key to use for signing the token. This MUST be a string for HS256. MUST be either a string or OpenSSLAsymmetricKey for RS256.
+     * @param null|string $signingKeyPassphrase Optional. Passphrase to use for signing key if it is encrypted. Defaults to null.
+     *
+     * @throws TokenException When an unsupported algorithm is provided.
+     * @throws TokenException When a non-string $signingKey is provided for HS256.
+     * @throws TokenException When a string $signingKey is used with RS256.
+     * @throws TokenException When using RS256 and openssl_pkey_get_private() is unable to load the provided signing key.
+     */
+    private function loadSigningKey(OpenSSLAsymmetricKey|string $signingKey, null|string $signingKeyPassphrase = null): OpenSSLAsymmetricKey|string {
+        // Ensure the provided algorithm is supported.
+        if (! \in_array($this->algorithm, static::CONST_SUPPORTED_ALGOS, true)) {
+            throw TokenException::unsupportedAlgorithm($this->algorithm, implode(',', static::CONST_SUPPORTED_ALGOS));
+        }
+
+        // For HS256, if signing key is a string, use it.
+        if ($this->algorithm === Token::ALGO_HS256) {
+            if (! is_string($signingKey)) {
+                throw TokenException::requireKeyAsStringHs256();
+            }
+
+            return $signingKey;
+        }
+
+        // Otherwise, process as the default RS256 algorithm...
+        $failure = null;
+        $details = null;
+
+        try {
+            // Attempt to load it with openssl_pkey_get_private() and return an OpenSSLAsymmetricKey.
+            $signingKey = openssl_pkey_get_private(
+                private_key: $signingKey,
+                passphrase: $signingKeyPassphrase
+            );
+
+            // Get the details of the key.
+            $details = openssl_pkey_get_details($signingKey);
+        } catch (\Throwable $th) {
+            $failure = $th;
+        }
+
+        // If we were unable to load the key, throw an exception.
+        if (! $signingKey || ! $details) {
+            $message = implode(', ', $this->getOpenSslErrorStack());
+            $message = (($failure instanceof \Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) .  ' (' . $message . ')';
+            throw TokenException::unableToProcessSigningKey($message, $failure);
+        }
+
+        // If the key is not an RSA key, throw an exception.
+        if (! isset($details['type']) || $details['type'] !== OPENSSL_KEYTYPE_RSA || ! isset($details['rsa'])) {
+            throw TokenException::unableToProcessSigningKey(sprintf(TokenException::MSG_KEY_TYPE_NOT_SUPPORTED, $details['type'] ?? 'unknown'));
+        }
+
+        return $signingKey;
+    }
+
+    /**
+     * Glue the provided data segments together with a period, to produce a formatted token.
+     */
+    private function glue(array $data): string
+    {
+        return implode(
+            separator: '.',
+            array: $data
+        );
+    }
+
+    /**
+     * Encode the provided data segment as a base64-encoded string. Optionally, encode the data as JSON.
+     *
+     * @param string|array $data Data to encode.
+     * @param string $segment Segment name to use for error messages.
+     * @param bool $json Whether to encode the data as JSON. Defaults to true.
+     * @param bool $skip Whether to skip encoding the data. Defaults to false.
+     *
+     * @throws TokenException When unable to encode the data segment.
+     */
+    private function encode(string|array $data, string $segment, bool $json = true, bool $skip = false): string
+    {
+        // If $skip is true, return the data as-is.
+        if ($skip) {
+            return json_encode($data) ?? 'JSON_ENCODING_ERROR';
+        }
+
+        // If the data is an array, or $json is true, encode it as JSON.
+        if ($json === true || ! is_string($data)) {
+            try {
+                $data = json_encode(
+                    value: $data,
+                    flags: \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR
+                );
+            // @codeCoverageIgnoreStart
+            } catch (\Throwable $th) {
+                throw TokenException::unableToEncodeSegment($segment, $th->getMessage());
+            }
+            // @codeCoverageIgnoreEnd
+        }
+
+        // Return the sanitized base64-encoded data.
+        return str_replace(
+            search: '=',
+            replace: '',
+            subject: strtr(
+                string: base64_encode($data),
+                from: '+/',
+                to: '-_'
+            )
+        );
+    }
+
+    /**
+     * Sign the provided data with the provided signing key.
+     *
+     * @param string $data Data to sign.
+     *
+     * @throws TokenException When an unsupported algorithm is provided.
+     * @throws TokenException When a signature is unable to be generated.
+     * @throws TokenException When unable to encode the data segment.
+     */
+    private function sign(string $data): string
+    {
+        // For HS256, use hash_hmac() to sign the data.
+        if ($this->algorithm === Token::ALGO_HS256) {
+            return $this->encode(
+                data: hash_hmac(
+                    algo: 'sha256',
+                    data: $data,
+                    key: $this->signingKey,
+                    binary: true
+                ),
+                json: false,
+                segment: 'signature',
+            );
+        }
+
+        // Otherwise, default to RS256, and use openssl_sign() to sign the data.
+        $signature = '';
+        $success = false;
+        $failure = null;
+
+        try {
+            $success = openssl_sign(
+                data: $data,
+                signature: $signature,
+                private_key: $this->signingKey,
+                algorithm: \OPENSSL_ALGO_SHA256
+            );
+        // @codeCoverageIgnoreStart
+        } catch (\Throwable $th) {
+            $failure = $th;
+        }
+
+        // If we were unable to sign the data, throw an exception.
+        if (! $success) {
+            $message = implode(', ', $this->getOpenSslErrorStack());
+            $message = (($failure instanceof \Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) .  ' (' . $message . ')';
+            throw TokenException::unableToSignData($message, $failure);
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $this->encode(
+            data: $signature,
+            segment: 'signature',
+            json: false
+        );
+    }
+
+    /**
+     * Get the OpenSSL error stack.
+     *
+     * @return array<string> The OpenSSL error stack.
+     */
+    private function getOpenSslErrorStack(): array {
+        $openSslErrorStack = [];
+
+        while ($error = openssl_error_string()) {
+            $openSslErrorStack[] = $error;
+        }
+
+        return $openSslErrorStack;
+    }
+}

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Token\Generator;
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token;
+use Auth0\Tests\Utilities\Chaos;
+use Auth0\Tests\Utilities\TokenGenerator;
+
+uses()->group('token', 'token.generator');
+
+it('throws an error when instantiated directly', function(): void {
+    new Generator(uniqid());
+})->throws(Error::class);
+
+it('throws an error when a signing key is provided as a string with RS256', function(): void {
+    Generator::create(uniqid());
+})->throws(TokenException::class);
+
+it('throws an error when an incompatible signing key is used with RS256', function(): void {
+    $mockSigningKey = TokenGenerator::generateDsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+})->throws(TokenException::class);
+
+it('throws an error when an incompatible signing key is used with HS256', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_HS256
+    );
+})->throws(TokenException::class);
+
+it('throws an error when an malformed signing key is used with RS256', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair()['private'];
+    $corruptedSigningKey = Chaos::corruptString($mockSigningKey, 12);
+
+    Generator::create(
+        signingKey: $corruptedSigningKey,
+        algorithm: Token::ALGO_RS256
+    );
+})->throws(TokenException::class);
+
+it('throws an error when an incompatible algorithm is specified', function(): void {
+    Generator::create(
+        signingKey: uniqid(),
+        algorithm: uniqid()
+    );
+})->throws(TokenException::class);
+
+it('returns an instance of the Generator class', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+
+    expect($token)->toBeInstanceOf(Generator::class);
+});
+
+test('toArray(false) returns the segments as a key pair with a valid RS256 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid RS256 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid RS256 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid RS256 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = (string) Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+
+    expect($token)->toBeString();
+});
+
+test('toArray(false) returns the segments as a key pair with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+    $token = (string) Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    );
+
+    expect($token)->toBeString();
+});
+
+it('assigns a correct `type` header value', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()->toHaveKeys(['headers'])
+        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->type->toBeString()->toEqual('JWT');
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private'],
+        headers: [
+            'type' => null
+        ]
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()->toHaveKeys(['headers'])
+        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->type->toBeString()->toEqual('JWT');
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private'],
+        headers: [
+            'type' => uniqid()
+        ]
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()->toHaveKeys(['headers'])
+        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->type->toBeString()->toEqual('JWT');
+});
+
+it('assigns the correct `alg` header value', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature'])
+        ->headers->toBeArray()->toHaveKeys(['alg'])
+        ->headers->alg->toBeString()->toEqual(Token::ALGO_RS256);
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private'],
+        headers: [
+            'alg' => Token::ALGO_HS256
+        ]
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature'])
+        ->headers->toBeArray()->toHaveKeys(['alg'])
+        ->headers->alg->toBeString()->toEqual(Token::ALGO_RS256);
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private'],
+        headers: [
+            'alg' => 'none'
+        ]
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature'])
+        ->headers->toBeArray()->toHaveKeys(['alg'])
+        ->headers->alg->toBeString()->toEqual(Token::ALGO_RS256);
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private'],
+        headers: [
+            'alg' => 'none'
+        ]
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature'])
+        ->headers->toBeArray()->toHaveKeys(['alg'])
+        ->headers->alg->toBeString()->toEqual(Token::ALGO_RS256);
+});

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -37,12 +37,14 @@ it('throws an error when an incompatible signing key is used with HS256', functi
 
 it('throws an error when an malformed signing key is used with RS256', function(): void {
     $mockSigningKey = TokenGenerator::generateRsaKeyPair()['private'];
-    $corruptedSigningKey = Chaos::corruptString($mockSigningKey, 12);
 
-    Generator::create(
-        signingKey: $corruptedSigningKey,
-        algorithm: Token::ALGO_RS256
-    );
+    for ($i = 0; $i < 128; $i++) {
+        $corruptedSigningKey = Chaos::corruptString($mockSigningKey, random_int(0, 256));
+
+        Generator::create(
+            signingKey: $corruptedSigningKey
+        );
+    }
 })->throws(TokenException::class);
 
 it('throws an error when an incompatible algorithm is specified', function(): void {

--- a/tests/Utilities/Chaos.php
+++ b/tests/Utilities/Chaos.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Tests\Utilities;
+
+class Chaos
+{
+    public static function corruptString(
+        string $original,
+        int $iterations = 1
+    ): string {
+        $len = strlen($original);
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $random = random_int(0, $len - 1);
+            $corrupted = substr_replace($original, chr(random_int(0, 255)), $random, 1);
+        }
+
+        if ($original === $corrupted) {
+            return self::corruptString($original, $iterations);
+        }
+
+        return $corrupted;
+    }
+}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a new utility class, `Auth0\SDK\Token\Generator`. This class may be used to generate JSON Web Tokens signed using RS256 or HS256.

The class is invoked with the static method, `Auth0\SDK\Token\Generator::create()`. It accepts a `signingKey` parameter, which in the case of RS256, must either by a `OpenSSLAsymmetricKey` or a compatible string representation of one using PEM, DER, CRT, and X.509 format.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist

<!-- This checklist MUST be completed for your pull request to be considered. -->

- [x] My code follows the [contributing guidelines of this repo](./CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
