### PR TITLE
feat(Authentication): Add support for Client Assertion

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -6,6 +6,9 @@ namespace Auth0\SDK\API;
 
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Contract\API\AuthenticationInterface;
+use Auth0\SDK\Exception\ConfigurationException;
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token\ClientAssertionGenerator;
 use Auth0\SDK\Utility\HttpClient;
 use Auth0\SDK\Utility\Toolkit;
 use Psr\Http\Message\ResponseInterface;
@@ -15,6 +18,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class Authentication implements AuthenticationInterface
 {
+    public const CONST_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
     /**
      * Instance of Auth0\SDK\API\Utility\HttpClient.
      */
@@ -30,7 +35,7 @@ final class Authentication implements AuthenticationInterface
      *
      * @param  array<mixed>|SdkConfiguration  $configuration  Required. Base configuration options for the SDK. See the SdkConfiguration class constructor for options.
      *
-     * @throws \Auth0\SDK\Exception\ConfigurationException when an invalidation `configuration` is provided
+     * @throws ConfigurationException when an invalidation `configuration` is provided
      *
      * @psalm-suppress DocblockTypeContradiction
      */
@@ -71,7 +76,7 @@ final class Authentication implements AuthenticationInterface
         /** @var string $clientId */
         [$clientId] = Toolkit::filter([
             [$clientId, $this->getConfiguration()->getClientId()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresClientId());
+        ])->array()->first(ConfigurationException::requiresClientId());
 
         /** @var array<string> $query */
         $query = Toolkit::filter([
@@ -94,7 +99,7 @@ final class Authentication implements AuthenticationInterface
         /** @var string $clientId */
         [$clientId] = Toolkit::filter([
             [$clientId, $this->getConfiguration()->getClientId()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresClientId());
+        ])->array()->first(ConfigurationException::requiresClientId());
 
         return sprintf(
             '%s/samlp/metadata/%s',
@@ -115,7 +120,7 @@ final class Authentication implements AuthenticationInterface
         /** @var string $clientId */
         [$clientId] = Toolkit::filter([
             [$clientId, $this->getConfiguration()->getClientId()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresClientId());
+        ])->array()->first(ConfigurationException::requiresClientId());
 
         return sprintf(
             '%s/wsfed/%s?%s',
@@ -149,14 +154,14 @@ final class Authentication implements AuthenticationInterface
 
         [$redirectUri] = Toolkit::filter([
             [$redirectUri, isset($params['redirect_uri']) ? (string) $params['redirect_uri'] : null, $this->getConfiguration()->getRedirectUri()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresRedirectUri());
+        ])->array()->first(ConfigurationException::requiresRedirectUri());
 
         return sprintf(
             '%s/authorize?%s',
             $this->getConfiguration()->formatDomain(),
             http_build_query(Toolkit::merge([
                 'state'         => $state,
-                'client_id'     => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
+                'client_id'     => $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()),
                 'audience'      => $this->getConfiguration()->defaultAudience(),
                 'organization'  => $this->getConfiguration()->defaultOrganization(),
                 'redirect_uri'  => $redirectUri,
@@ -179,14 +184,14 @@ final class Authentication implements AuthenticationInterface
         /** @var string $returnTo */
         [$returnTo] = Toolkit::filter([
             [$returnTo, isset($params['returnTo']) ? (string) $params['returnTo'] : null, $this->getConfiguration()->getRedirectUri()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresRedirectUri());
+        ])->array()->first(ConfigurationException::requiresRedirectUri());
 
         return sprintf(
             '%s/v2/logout?%s',
             $this->getConfiguration()->formatDomain(),
             http_build_query(Toolkit::merge([
                 'returnTo'  => $returnTo,
-                'client_id' => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
+                'client_id' => $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()),
             ], $params), '', '&', PHP_QUERY_RFC3986),
         );
     }
@@ -195,18 +200,17 @@ final class Authentication implements AuthenticationInterface
         ?array $body = null,
         ?array $headers = null,
     ): ResponseInterface {
+        /** @var array<int|string> $headers */
+        /** @var array<string> $body */
+
         [$body, $headers] = Toolkit::filter([$body, $headers])->array()->trim();
 
-        /** @var array<mixed> $body */
-        /** @var array<int|string> $headers */
+        $body = $this->addClientAuthentication($body);
 
         return $this->getHttpClient()->
             method('post')->
             addPath('passwordless', 'start')->
-            withBody((object) Toolkit::merge([
-                'client_id'     => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
-                'client_secret' => $this->getConfiguration()->getClientSecret(\Auth0\SDK\Exception\ConfigurationException::requiresClientSecret()),
-            ], $body))->
+            withBody((object) $body)->
             withHeaders($headers)->
             call();
     }
@@ -299,27 +303,29 @@ final class Authentication implements AuthenticationInterface
         ?array $headers = null,
     ): ResponseInterface {
         [$grantType] = Toolkit::filter([$grantType])->string()->trim();
+
+        /** @var array<int|string> $headers */
+        /** @var array<bool|int|string> $params */
+
         [$params, $headers] = Toolkit::filter([$params, $headers])->array()->trim();
 
         Toolkit::assert([
             [$grantType, \Auth0\SDK\Exception\ArgumentException::missing('grantType')],
         ])->isString();
 
-        /** @var array<bool|int|string> $params */
-        $parameters = Toolkit::merge([
-            'grant_type'    => $grantType,
-            'client_id'     => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
-            'client_secret' => $this->getConfiguration()->getClientSecret(\Auth0\SDK\Exception\ConfigurationException::requiresClientSecret()),
+        $params = Toolkit::merge([
+            'grant_type' => $grantType,
         ], $params);
 
-        /** @var array<bool|int|string> $parameters */
-        /** @var array<int|string> $headers */
+        $params = $this->addClientAuthentication($params);
+
+        /** @var array<bool|int|string> $params */
 
         return $this->getHttpClient()->
             method('post')->
             addPath('oauth', 'token')->
             withHeaders($headers)->
-            withFormParams($parameters)->
+            withFormParams($params)->
             call();
     }
 
@@ -336,7 +342,7 @@ final class Authentication implements AuthenticationInterface
 
         [$redirectUri] = Toolkit::filter([
             [$redirectUri, $this->getConfiguration()->getRedirectUri()],
-        ])->array()->first(\Auth0\SDK\Exception\ConfigurationException::requiresRedirectUri());
+        ])->array()->first(ConfigurationException::requiresRedirectUri());
 
         $params = Toolkit::filter([
             [
@@ -469,7 +475,7 @@ final class Authentication implements AuthenticationInterface
             method('post')->
             addPath('dbconnections', 'signup')->
             withBody(Toolkit::merge([
-                'client_id'  => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
+                'client_id'  => $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()),
                 'email'      => $email,
                 'password'   => $password,
                 'connection' => $connection,
@@ -499,11 +505,46 @@ final class Authentication implements AuthenticationInterface
             method('post')->
             addPath('dbconnections', 'change_password')->
             withBody(Toolkit::merge([
-                'client_id'  => $this->getConfiguration()->getClientId(\Auth0\SDK\Exception\ConfigurationException::requiresClientId()),
+                'client_id'  => $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()),
                 'email'      => $email,
                 'connection' => $connection,
             ], $body))->
             withHeaders($headers)->
             call();
+    }
+
+    /**
+     * Add client authentication to a request body.
+     *
+     * @param array<mixed> $requestBody Request body being sent to the endpoint.
+     *
+     * @return array<mixed> Request body with client authentication added.
+     *
+     * @throws TokenException If client assertion signing key or algorithm is invalid.
+     * @throws ConfigurationException If client ID or secret are invalid.
+     */
+    private function addClientAuthentication(array $requestBody): array
+    {
+        $clientAssertionSigningKey = $this->getConfiguration()->getClientAssertionSigningKey();
+        $clientAssertionSigningAlgorithm = $this->getConfiguration()->getClientAssertionSigningAlgorithm();
+
+        $requestBody['client_id'] = $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()) ?? '';
+
+        if (null !== $clientAssertionSigningKey) {
+            $requestBody['client_assertion_type'] = self::CONST_CLIENT_ASSERTION_TYPE;
+            $requestBody['client_assertion'] = ClientAssertionGenerator::create(
+                domain: $this->getConfiguration()->formatDomain(true) . '/',
+                clientId: $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()) ?? '',
+                signingKey: $clientAssertionSigningKey,
+                signingAlgorithm: $clientAssertionSigningAlgorithm
+            );
+
+            return $requestBody;
+        }
+
+        $clientSecret = $this->getConfiguration()->getClientSecret(ConfigurationException::requiresClientSecret()) ?? '';
+        $requestBody['client_secret'] = $clientSecret;
+
+        return $requestBody;
     }
 }

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -525,16 +525,17 @@ final class Authentication implements AuthenticationInterface
      */
     private function addClientAuthentication(array $requestBody): array
     {
+        $clientId = $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()) ?? '';
         $clientAssertionSigningKey = $this->getConfiguration()->getClientAssertionSigningKey();
         $clientAssertionSigningAlgorithm = $this->getConfiguration()->getClientAssertionSigningAlgorithm();
 
-        $requestBody['client_id'] = $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()) ?? '';
+        $requestBody['client_id'] = $clientId;
 
         if (null !== $clientAssertionSigningKey) {
             $requestBody['client_assertion_type'] = self::CONST_CLIENT_ASSERTION_TYPE;
-            $requestBody['client_assertion'] = ClientAssertionGenerator::create(
+            $requestBody['client_assertion'] = (string) ClientAssertionGenerator::create(
                 domain: $this->getConfiguration()->formatDomain(true) . '/',
-                clientId: $this->getConfiguration()->getClientId(ConfigurationException::requiresClientId()) ?? '',
+                clientId: $clientId,
                 signingKey: $clientAssertionSigningKey,
                 signingAlgorithm: $clientAssertionSigningAlgorithm
             );
@@ -542,8 +543,7 @@ final class Authentication implements AuthenticationInterface
             return $requestBody;
         }
 
-        $clientSecret = $this->getConfiguration()->getClientSecret(ConfigurationException::requiresClientSecret()) ?? '';
-        $requestBody['client_secret'] = $clientSecret;
+        $requestBody['client_secret'] = $this->getConfiguration()->getClientSecret(ConfigurationException::requiresClientSecret()) ?? '';
 
         return $requestBody;
     }

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -47,9 +47,11 @@ final class ConfigurationException extends \Exception implements Auth0Exception
 
     public const MSG_INVALID_TOKEN_ALGORITHM = 'Invalid token algorithm; must be "HS256" or "RS256"';
 
-    public const MSG_NO_PSR18_LIBRARY = 'No compatible PSR-18 library was configured, and one could not be auto-discovered.';
+    public const MSG_NO_PSR18_LIBRARY = 'No compatible PSR-18 library was configured, and one could not be auto-discovered';
 
-    public const MSG_NO_PSR17_LIBRARY = 'No compatible PSR-17 library was configured, and one could not be auto-discovered.';
+    public const MSG_NO_PSR17_LIBRARY = 'No compatible PSR-17 library was configured, and one could not be auto-discovered';
+
+    public const MSG_INCOMPATIBLE_SIGNING_ALGORITHM = '%s it not a compatible signing algorithm';
 
     public static function requiresConfiguration(
         ?\Throwable $previous = null,
@@ -186,5 +188,12 @@ final class ConfigurationException extends \Exception implements Auth0Exception
         ?\Throwable $previous = null,
     ): self {
         return new self(self::MSG_NO_PSR17_LIBRARY, 0, $previous);
+    }
+
+    public static function incompatibleClientAssertionSigningAlgorithm(
+        string $algorithm,
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(sprintf(self::MSG_INCOMPATIBLE_SIGNING_ALGORITHM, $algorithm), 0, $previous);
     }
 }

--- a/src/Exception/TokenException.php
+++ b/src/Exception/TokenException.php
@@ -19,6 +19,7 @@ final class TokenException extends \Exception implements Auth0Exception
     public const MSG_HS256_REQUIRES_KEY_AS_STRING = 'HS256 algorithm requires a key in string format.';
     public const MSG_LIB_OPENSSL_MISSING = 'The OpenSSL extension is required to generate tokens';
     public const MSG_LIB_OPENSSL_MISSING_ALGO = 'The OpenSSL extension must support %s algorithm to generate tokens';
+    public const MSG_KEY_LENGTH_NOT_SUPPORTED = 'Key length "%s" is not supported for the %s algorithm';
 
     public static function unableToProcessSigningKey(
         string $message,
@@ -67,5 +68,13 @@ final class TokenException extends \Exception implements Auth0Exception
         ?\Throwable $previous = null,
     ): self {
         return new self(sprintf(static::MSG_LIB_OPENSSL_MISSING_ALGO, $algorithm), 0, $previous);
+    }
+
+    public static function keyLengthNotSupported(
+        string $length,
+        string $algorithm,
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(sprintf(static::MSG_KEY_LENGTH_NOT_SUPPORTED, $length, $algorithm), 0, $previous);
     }
 }

--- a/src/Exception/TokenException.php
+++ b/src/Exception/TokenException.php
@@ -11,7 +11,7 @@ final class TokenException extends \Exception implements Auth0Exception
 {
     public const MSG_UNKNOWN_ERROR = 'An unknown error occurred.';
     public const MSG_KEY_TYPE_UNKNOWN = 'Key type could not be determined';
-    public const MSG_KEY_TYPE_NOT_SUPPORTED = 'Key type "%s" is not supported for the $s algorithm';
+    public const MSG_KEY_TYPE_NOT_SUPPORTED = 'Key type "%s" is not supported for the %s algorithm';
     public const MSG_SIGNING_KEY_PROCESSING_ERROR = 'An exception occurred while attempting to process the configured signing key: %s';
     public const MSG_UNABLE_TO_ENCODE_SEGMENT = 'An exception occurred while attempting to encode segment "%s" during token generation: %s';
     public const MSG_UNABLE_TO_SIGN_DATA = 'An exception occurred while attempting to produce signature during token generation: %s';
@@ -19,7 +19,26 @@ final class TokenException extends \Exception implements Auth0Exception
     public const MSG_HS256_REQUIRES_KEY_AS_STRING = 'HS256 algorithm requires a key in string format.';
     public const MSG_LIB_OPENSSL_MISSING = 'The OpenSSL extension is required to generate tokens';
     public const MSG_LIB_OPENSSL_MISSING_ALGO = 'The OpenSSL extension must support %s algorithm to generate tokens';
-    public const MSG_KEY_LENGTH_NOT_SUPPORTED = 'Key length "%s" is not supported for the %s algorithm';
+
+    public static function unknown(
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(static::MSG_UNKNOWN_ERROR, 0, $previous);
+    }
+
+    public static function unidentifiableKeyType(
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(static::MSG_KEY_TYPE_UNKNOWN, 0, $previous);
+    }
+
+    public static function keyTypeMismatch(
+        string $keyType,
+        string $algorithm,
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(sprintf(static::MSG_KEY_TYPE_NOT_SUPPORTED, $keyType, $algorithm), 0, $previous);
+    }
 
     public static function unableToProcessSigningKey(
         string $message,
@@ -68,13 +87,5 @@ final class TokenException extends \Exception implements Auth0Exception
         ?\Throwable $previous = null,
     ): self {
         return new self(sprintf(static::MSG_LIB_OPENSSL_MISSING_ALGO, $algorithm), 0, $previous);
-    }
-
-    public static function keyLengthNotSupported(
-        string $length,
-        string $algorithm,
-        ?\Throwable $previous = null,
-    ): self {
-        return new self(sprintf(static::MSG_KEY_LENGTH_NOT_SUPPORTED, $length, $algorithm), 0, $previous);
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -14,14 +14,18 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 final class Token implements TokenInterface
 {
+    // TODO: Replace these with an enum when PHP 8.1 is our min supported version.
     public const TYPE_ID_TOKEN = 1;
-
     public const TYPE_ACCESS_TOKEN = 2;
     public const TYPE_TOKEN = 2;
 
-    public const ALGO_RS256 = 'RS256';
-
+    // TODO: Replace these with an enum when PHP 8.1 is our min supported version.
     public const ALGO_HS256 = 'HS256';
+    public const ALGO_RS256 = 'RS256';
+    public const ALGO_HS384 = 'HS384';
+    public const ALGO_RS384 = 'RS384';
+    public const ALGO_HS512 = 'HS512';
+    public const ALGO_RS512 = 'RS512';
 
     private ?Parser $parser = null;
 

--- a/src/Token/ClientAssertionGenerator.php
+++ b/src/Token/ClientAssertionGenerator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Token;
+
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token;
+use InvalidArgumentException;
+use OpenSSLAsymmetricKey;
+
+final class ClientAssertionGenerator
+{
+    /**
+     * Supported signing algorithms.
+     *
+     * @var array<string>
+     */
+    public const CONST_SUPPORTED_ALGORITHMS = [
+        Token::ALGO_RS256,
+    ];
+
+    /**
+     * Create a JWT client assertion.
+     *
+     * @param string $domain The Auth0 domain to use.
+     * @param string $clientId The Auth0 client ID to use.
+     * @param OpenSSLAsymmetricKey|string $signingKey The signing key to use.
+     * @param string $signingAlgorithm The signing algorithm to use.
+     *
+     * @return string The generated JWT.
+     *
+     * @throws InvalidArgumentException If an invalid signing algorithm is provided.
+     * @throws TokenException If an error occurs during signing.
+     */
+    public static function create(
+        string $domain,
+        string $clientId,
+        OpenSSLAsymmetricKey|string $signingKey,
+        string $signingAlgorithm = Token::ALGO_RS256,
+    ): string {
+        if (! in_array($signingAlgorithm, self::CONST_SUPPORTED_ALGORITHMS, true)) {
+            throw TokenException::unsupportedAlgorithm($signingAlgorithm, implode(',', self::CONST_SUPPORTED_ALGORITHMS));
+        }
+
+        $now = time();
+
+        $claims = [
+            'iss' => $clientId,
+            'sub' => $clientId,
+            'aud' => $domain,
+            'iat' => $now,
+            'exp' => $now + 180,
+            'jti' => hash('sha256', implode(':', [uniqid(microtime(), true), bin2hex(random_bytes(32))]))
+        ];
+
+        return (string) Generator::create(
+            signingKey: $signingKey,
+            algorithm: $signingAlgorithm,
+            claims: $claims,
+        );
+    }
+}

--- a/src/Token/ClientAssertionGenerator.php
+++ b/src/Token/ClientAssertionGenerator.php
@@ -18,6 +18,7 @@ final class ClientAssertionGenerator
      */
     public const CONST_SUPPORTED_ALGORITHMS = [
         Token::ALGO_RS256,
+        Token::ALGO_RS384
     ];
 
     /**
@@ -28,7 +29,7 @@ final class ClientAssertionGenerator
      * @param OpenSSLAsymmetricKey|string $signingKey The signing key to use.
      * @param string $signingAlgorithm The signing algorithm to use.
      *
-     * @return string The generated JWT.
+     * @return Generator A configured instance of the Token Generator.
      *
      * @throws InvalidArgumentException If an invalid signing algorithm is provided.
      * @throws TokenException If an error occurs during signing.
@@ -38,7 +39,7 @@ final class ClientAssertionGenerator
         string $clientId,
         OpenSSLAsymmetricKey|string $signingKey,
         string $signingAlgorithm = Token::ALGO_RS256,
-    ): string {
+    ): Generator {
         if (! in_array($signingAlgorithm, self::CONST_SUPPORTED_ALGORITHMS, true)) {
             throw TokenException::unsupportedAlgorithm($signingAlgorithm, implode(',', self::CONST_SUPPORTED_ALGORITHMS));
         }
@@ -54,7 +55,7 @@ final class ClientAssertionGenerator
             'jti' => hash('sha256', implode(':', [uniqid(microtime(), true), bin2hex(random_bytes(32))]))
         ];
 
-        return (string) Generator::create(
+        return Generator::create(
             signingKey: $signingKey,
             algorithm: $signingAlgorithm,
             claims: $claims,

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -21,6 +21,22 @@ final class Generator implements GeneratorInterface
     ];
 
     /**
+     * Minimum signing key lengths for token generation.
+     */
+    public const CONST_ALGO_MIN_LENGTHS = [
+        Token::ALGO_RS256 => 2048,
+        Token::ALGO_HS256 => 2048
+    ];
+
+    /**
+     * Maximum signing key lengths for token generation.
+     */
+    public const CONST_ALGO_MAX_LENGTHS = [
+        Token::ALGO_RS256 => 4096,
+        Token::ALGO_HS256 => 4096
+    ];
+
+    /**
      * Supported key types for token generation.
      */
     public const CONST_SUPPORTED_KEY_TYPES = [
@@ -199,6 +215,10 @@ final class Generator implements GeneratorInterface
         // If the key is not an RSA key, throw an exception.
         if (! isset($details['type']) || $details['type'] !== OPENSSL_KEYTYPE_RSA || ! isset($details['rsa'])) {
             throw TokenException::unableToProcessSigningKey(sprintf(TokenException::MSG_KEY_TYPE_NOT_SUPPORTED, $details['type'] ?? 'unknown'));
+        }
+
+        if (! isset($details['bits']) || intval($details['bits']) < self::CONST_ALGO_MIN_LENGTHS[$this->algorithm] || intval($details['bits']) > self::CONST_ALGO_MAX_LENGTHS[$this->algorithm]) {
+            throw TokenException::keyLengthNotSupported((string) $details['bits'] ?? 'unknown', $this->algorithm);
         }
 
         return $signingKey;

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -12,38 +12,26 @@ use Throwable;
 
 final class Generator implements GeneratorInterface
 {
-    /**
-     * Supported algorithms for token generation.
-     */
-    public const CONST_SUPPORTED_ALGOS = [
-        Token::ALGO_RS256,
+    // Lookup table for supported digest algorithms as strings.
+    public const CONST_DIGEST_STRING = [
+        \OPENSSL_ALGO_SHA256 => 'sha256',
+        \OPENSSL_ALGO_SHA384 => 'sha384',
+        \OPENSSL_ALGO_SHA512 => 'sha512',
+    ];
+
+    // Lookup table for supported key types as strings.
+    public const CONST_KEYTYPE_STRING = [
+        \OPENSSL_KEYTYPE_RSA => 'RSA',
+    ];
+
+    // Supported algorithms for token generation.
+    public const CONST_SUPPORTED_ALGORITHMS = [
         Token::ALGO_HS256,
-    ];
-
-    /**
-     * Minimum signing key lengths for token generation.
-     */
-    public const CONST_ALGO_MIN_LENGTHS = [
-        Token::ALGO_RS256 => 2048,
-        Token::ALGO_HS256 => 2048
-    ];
-
-    /**
-     * Maximum signing key lengths for token generation.
-     */
-    public const CONST_ALGO_MAX_LENGTHS = [
-        Token::ALGO_RS256 => 4096,
-        Token::ALGO_HS256 => 4096
-    ];
-
-    /**
-     * Supported key types for token generation.
-     */
-    public const CONST_SUPPORTED_KEY_TYPES = [
-        OPENSSL_KEYTYPE_RSA => 'RSA',
-        OPENSSL_KEYTYPE_DSA => 'DSA',
-        OPENSSL_KEYTYPE_DH => 'DH',
-        OPENSSL_KEYTYPE_EC => 'EC',
+        Token::ALGO_HS384,
+        Token::ALGO_HS512,
+        Token::ALGO_RS256,
+        Token::ALGO_RS384,
+        Token::ALGO_RS512,
     ];
 
     public static function create(
@@ -122,8 +110,16 @@ final class Generator implements GeneratorInterface
         private array $headers = [],
         private null|string $signingKeyPassphrase = null
     ) {
-        // Ensure the environment is configured with the necessary OpenSSL extension support.
-        $this->checkEnvironment();
+        // @codeCoverageIgnoreStart
+        if (! extension_loaded('openssl')) {
+            throw TokenException::openSslMissing();
+        }
+        // @codeCoverageIgnoreEnd
+
+        // Ensure the provided algorithm is supported.
+        if (! \in_array($this->algorithm, static::CONST_SUPPORTED_ALGORITHMS, true)) {
+            throw TokenException::unsupportedAlgorithm($this->algorithm, implode(',', static::CONST_SUPPORTED_ALGORITHMS));
+        }
 
         // Merge any provided headers with the defaults.
         $this->headers = array_merge($this->headers, ['type' => 'JWT', 'alg' => $this->algorithm]);
@@ -132,51 +128,19 @@ final class Generator implements GeneratorInterface
         $this->signingKey = $this->loadSigningKey($this->signingKey, $this->signingKeyPassphrase);
     }
 
-    // @codeCoverageIgnoreStart
-    /**
-     * Ensure the environment is configured with the necessary OpenSSL extension support.
-     *
-     * @throws TokenException When a configuration issue in the host environment is detected.
-     */
-    private function checkEnvironment(): void
-    {
-        if (! extension_loaded('openssl')) {
-            throw TokenException::openSslMissing();
-        }
-
-        $envSupportsDigestMethods = openssl_get_md_methods(true);
-        $sdkRequiredDigestMethods = ['sha256', 'sha384', 'sha512'];
-
-        foreach ($sdkRequiredDigestMethods as $method) {
-            if (! in_array($method, $envSupportsDigestMethods, true)) {
-                throw TokenException::openSslMissingAlgo($method);
-            }
-        }
-
-        // $envSupportsCurveMethods = openssl_get_curve_names();
-    }
-    // @codeCoverageIgnoreEnd
-
     /**
      * Load the provided signing key and return as an appropriate object type.
      *
      * @param OpenSSLAsymmetricKey|string $signingKey Signing key to use for signing the token. This MUST be a string for HS256. MUST be either a string or OpenSSLAsymmetricKey for RS256.
      * @param null|string $signingKeyPassphrase Optional. Passphrase to use for signing key if it is encrypted. Defaults to null.
      *
-     * @throws TokenException When an unsupported algorithm is provided.
      * @throws TokenException When a non-string $signingKey is provided for HS256.
      * @throws TokenException When a string $signingKey is used with RS256.
      * @throws TokenException When using RS256 and openssl_pkey_get_private() is unable to load the provided signing key.
      */
     private function loadSigningKey(OpenSSLAsymmetricKey|string $signingKey, null|string $signingKeyPassphrase = null): OpenSSLAsymmetricKey|string
     {
-        // Ensure the provided algorithm is supported.
-        if (! \in_array($this->algorithm, static::CONST_SUPPORTED_ALGOS, true)) {
-            throw TokenException::unsupportedAlgorithm($this->algorithm, implode(',', static::CONST_SUPPORTED_ALGOS));
-        }
-
-        // For HS256, if signing key is a string, use it.
-        if ($this->algorithm === Token::ALGO_HS256) {
+        if (null === $this->getOpenSslKeyType()) {
             if (! is_string($signingKey)) {
                 throw TokenException::requireKeyAsStringHs256();
             }
@@ -184,18 +148,18 @@ final class Generator implements GeneratorInterface
             return $signingKey;
         }
 
-        // Otherwise, process as the default RS256 algorithm...
+        // Otherwise, process with OpenSSL...
         $failure = null;
         $details = null;
 
         try {
-            // Attempt to load it with openssl_pkey_get_private() and return an OpenSSLAsymmetricKey.
+            // Attempt to load signing key with openssl_pkey_get_private(). This returns an OpenSSLAsymmetricKey.
             $signingKey = openssl_pkey_get_private(
                 private_key: $signingKey,
                 passphrase: $signingKeyPassphrase
             );
 
-            // Get the details of the key.
+            // Get the key details from the OpenSSLAsymmetricKey.
             if ($signingKey instanceof OpenSSLAsymmetricKey) {
                 $details = openssl_pkey_get_details($signingKey);
             }
@@ -206,20 +170,26 @@ final class Generator implements GeneratorInterface
 
         // If we were unable to load the key, throw an exception.
         if (! $signingKey instanceof OpenSSLAsymmetricKey || $details === false) {
-            $message = implode(', ', $this->openSslErrors());
-            $message = (($failure instanceof Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) .  ' (' . $message . ')';
+            $message = (($failure instanceof Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) . $this->openSslErrors();
             throw TokenException::unableToProcessSigningKey($message, $failure);
+        }
+
+        if (! is_array($details) || ! isset($details['type'])) {
+            throw TokenException::unidentifiableKeyType();
         }
         // @codeCoverageIgnoreEnd
 
-        // If the key is not an RSA key, throw an exception.
-        if (! isset($details['type']) || $details['type'] !== OPENSSL_KEYTYPE_RSA || ! isset($details['rsa'])) {
-            throw TokenException::unableToProcessSigningKey(sprintf(TokenException::MSG_KEY_TYPE_NOT_SUPPORTED, $details['type'] ?? 'unknown'));
+        $keyType = $details['type'];
+
+        if ($keyType !== $this->getOpenSslKeyType()) {
+            throw TokenException::keyTypeMismatch((string) $keyType, $this->algorithm);
         }
 
-        if (! isset($details['bits']) || intval($details['bits']) < self::CONST_ALGO_MIN_LENGTHS[$this->algorithm] || intval($details['bits']) > self::CONST_ALGO_MAX_LENGTHS[$this->algorithm]) {
-            throw TokenException::keyLengthNotSupported((string) $details['bits'] ?? 'unknown', $this->algorithm);
+        // @codeCoverageIgnoreStart
+        if ($keyType === OPENSSL_KEYTYPE_RSA && ! isset($details['rsa'])) {
+            throw TokenException::unidentifiableKeyType();
         }
+        // @codeCoverageIgnoreEnd
 
         return $signingKey;
     }
@@ -295,8 +265,7 @@ final class Generator implements GeneratorInterface
      */
     private function sign(string $data): string
     {
-        // For HS256, use hash_hmac() to sign the data.
-        if ($this->algorithm === Token::ALGO_HS256) {
+        if (null === $this->getOpenSslKeyType()) {
             // @codeCoverageIgnoreStart
             if (! is_string($this->signingKey)) {
                 throw TokenException::unableToSignData(TokenException::MSG_UNKNOWN_ERROR);
@@ -305,7 +274,7 @@ final class Generator implements GeneratorInterface
 
             return $this->encode(
                 data: hash_hmac(
-                    algo: 'sha256',
+                    algo: self::CONST_DIGEST_STRING[$this->getDigestAlgorithm()],
                     data: $data,
                     key: $this->signingKey,
                     binary: true
@@ -321,7 +290,7 @@ final class Generator implements GeneratorInterface
         $failure = null;
 
         try {
-            $success = openssl_sign($data, $signature, $this->signingKey, OPENSSL_ALGO_SHA256);
+            $success = openssl_sign($data, $signature, $this->signingKey, $this->getDigestAlgorithm());
             // @codeCoverageIgnoreStart
         } catch (Throwable $th) {
             $failure = $th;
@@ -329,8 +298,8 @@ final class Generator implements GeneratorInterface
 
         // If we were unable to sign the data, throw an exception.
         if (! $success) {
-            $message = implode(', ', $this->openSslErrors());
-            $message = (($failure instanceof Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) .  ' (' . $message . ')';
+            $message = $this->openSslErrors();
+            $message = (($failure instanceof Throwable) ? $failure->getMessage() : TokenException::MSG_UNKNOWN_ERROR) .  $message;
             throw TokenException::unableToSignData($message, $failure);
         }
         // @codeCoverageIgnoreEnd
@@ -343,18 +312,52 @@ final class Generator implements GeneratorInterface
     }
 
     /**
-     * Get the OpenSSL error stack.
+     * Get the OpenSSL key type to use for the provided algorithm.
      *
-     * @return array<string> The OpenSSL error stack.
+     * @return int|null The OpenSSL key type to use.
      */
-    private function openSslErrors(): array
+    private function getOpenSslKeyType(): ?int
     {
-        $openSslErrorStack = [];
+        return match ($this->algorithm) {
+            Token::ALGO_RS256, Token::ALGO_RS384, Token::ALGO_RS512 => \OPENSSL_KEYTYPE_RSA,
+            default => null
+        };
+    }
+
+    /**
+     * Get the digest algorithm to use for the provided algorithm.
+     *
+     * @return int The digest algorithm to use.
+     */
+    private function getDigestAlgorithm(): int
+    {
+        return match ($this->algorithm) {
+            Token::ALGO_HS256, Token::ALGO_RS256 => \OPENSSL_ALGO_SHA256,
+            Token::ALGO_HS384, Token::ALGO_RS384 => \OPENSSL_ALGO_SHA384,
+            Token::ALGO_HS512, Token::ALGO_RS512 => \OPENSSL_ALGO_SHA512,
+            default => throw TokenException::unsupportedAlgorithm($this->algorithm, implode(', ', self::CONST_SUPPORTED_ALGORITHMS))
+        };
+    }
+
+    /**
+     * Retrieve and format the OpenSSL error stack as a string suitable for logging.
+     *
+     * @return string The OpenSSL error stack.
+     *
+     * @codeCoverageIgnore
+     */
+    private function openSslErrors(): string
+    {
+        $errors = [];
 
         while ($error = openssl_error_string()) {
-            $openSslErrorStack[] = $error;
+            $errors[] = $error;
         }
 
-        return $openSslErrorStack;
+        if ([] !== $errors) {
+            return "\n" . implode("\n* ", $errors);
+        }
+
+        return '';
     }
 }

--- a/tests/Unit/Token/ClientAssertionGeneratorTest.php
+++ b/tests/Unit/Token/ClientAssertionGeneratorTest.php
@@ -3,18 +3,33 @@
 declare(strict_types=1);
 
 use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token;
 use Auth0\SDK\Token\ClientAssertionGenerator;
+use Auth0\SDK\Token\Generator;
 use Auth0\Tests\Utilities\TokenGenerator;
 
 uses()->group('token', 'token.generator');
 
 it('throws an error when an incompatible signing algorithm is provided', function(): void {
-    $mockSigningKey = TokenGenerator::generateDsaKeyPair();
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
 
     ClientAssertionGenerator::create(
         domain: uniqid(),
         clientId: uniqid(),
         signingKey: $mockSigningKey['private'],
-        signingAlgorithm: uniqid()
+        signingAlgorithm: Token::ALGO_HS256
     );
 })->throws(TokenException::class);
+
+it('returns a properly configured of Generator instance', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = ClientAssertionGenerator::create(
+        domain: uniqid(),
+        clientId: uniqid(),
+        signingKey: $mockSigningKey['private'],
+        signingAlgorithm: Token::ALGO_RS256
+    );
+
+    expect($token)->toBeInstanceOf(Generator::class);
+});

--- a/tests/Unit/Token/ClientAssertionGeneratorTest.php
+++ b/tests/Unit/Token/ClientAssertionGeneratorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Exception\TokenException;
+use Auth0\SDK\Token\ClientAssertionGenerator;
+use Auth0\Tests\Utilities\TokenGenerator;
+
+uses()->group('token', 'token.generator');
+
+it('throws an error when an incompatible signing algorithm is provided', function(): void {
+    $mockSigningKey = TokenGenerator::generateDsaKeyPair();
+
+    ClientAssertionGenerator::create(
+        domain: uniqid(),
+        clientId: uniqid(),
+        signingKey: $mockSigningKey['private'],
+        signingAlgorithm: uniqid()
+    );
+})->throws(TokenException::class);

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Auth0\SDK\Token\Generator;
 use Auth0\SDK\Exception\TokenException;
 use Auth0\SDK\Token;
+use Auth0\SDK\Token\Generator;
 use Auth0\Tests\Utilities\Chaos;
 use Auth0\Tests\Utilities\TokenGenerator;
 
@@ -13,6 +13,257 @@ uses()->group('token', 'token.generator');
 it('throws an error when instantiated directly', function(): void {
     new Generator(uniqid());
 })->throws(Error::class);
+
+it('throws an error when an incompatible algorithm is specified', function(): void {
+    Generator::create(
+        signingKey: uniqid(),
+        algorithm: uniqid()
+    );
+})->throws(TokenException::class);
+
+it('returns an instance of the Generator class', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+
+    expect($token)->toBeInstanceOf(Generator::class);
+});
+
+/**
+ * HS256 tests.
+ */
+
+it('throws an error when an incompatible signing key is used with HS256', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_HS256
+    );
+})->throws(TokenException::class);
+
+test('toArray(false) returns the segments as a key pair with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS256
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+    $key = uniqid();
+
+    $token = (string) Generator::create(
+        signingKey: $key,
+        algorithm: TOKEN::ALGO_HS256
+    );
+
+    expect($token)->toBeString();
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+
+    $hash = hash_hmac('sha256', $payload, $key, true);
+    $hash = str_replace(search: '=', replace: '', subject: strtr(base64_encode($hash), '+/', '-_'));
+    $valid = hash_equals($hash, $signature);
+
+    expect($valid)->toBeTrue();
+});
+
+test('a valid signature is produced for HS256 configurations', function(): void {
+    $key = uniqid();
+
+    $token = (string) Generator::create(
+        signingKey: $key,
+        algorithm: TOKEN::ALGO_HS256
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+
+    $hash = hash_hmac('sha256', $payload, $key, true);
+    $hash = str_replace(search: '=', replace: '', subject: strtr(base64_encode($hash), '+/', '-_'));
+    $valid = hash_equals($hash, $signature);
+
+    expect($valid)->toBeTrue();
+});
+
+/**
+ * HS384 tests.
+ */
+
+ it('throws an error when an incompatible signing key is used with HS384', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_HS384
+    );
+})->throws(TokenException::class);
+
+test('toArray(false) returns the segments as a key pair with a valid HS384 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS384
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid HS384 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS384
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid HS384 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS384
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid HS384 configuration', function(): void {
+    $token = (string) Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS384
+    );
+
+    expect($token)->toBeString();
+});
+
+test('a valid signature is produced for HS384 configurations', function(): void {
+    $key = uniqid();
+
+    $token = (string) Generator::create(
+        signingKey: $key,
+        algorithm: TOKEN::ALGO_HS384
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+
+    $hash = hash_hmac('sha384', $payload, $key, true);
+    $hash = str_replace(search: '=', replace: '', subject: strtr(base64_encode($hash), '+/', '-_'));
+    $valid = hash_equals($hash, $signature);
+
+    expect($valid)->toBeTrue();
+});
+
+/**
+ * HS512 tests.
+ */
+
+ it('throws an error when an incompatible signing key is used with HS512', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_HS512
+    );
+})->throws(TokenException::class);
+
+test('toArray(false) returns the segments as a key pair with a valid HS512 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS512
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid HS512 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS512
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid HS512 configuration', function(): void {
+    $token = Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS512
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid HS512 configuration', function(): void {
+    $token = (string) Generator::create(
+        signingKey: uniqid(),
+        algorithm: TOKEN::ALGO_HS512
+    );
+
+    expect($token)->toBeString();
+});
+
+test('a valid signature is produced for HS512 configurations', function(): void {
+    $key = uniqid();
+
+    $token = (string) Generator::create(
+        signingKey: $key,
+        algorithm: TOKEN::ALGO_HS512
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+
+    $hash = hash_hmac('sha512', $payload, $key, true);
+    $hash = str_replace(search: '=', replace: '', subject: strtr(base64_encode($hash), '+/', '-_'));
+    $valid = hash_equals($hash, $signature);
+
+    expect($valid)->toBeTrue();
+});
+
+/**
+ * RS256 tests.
+ */
 
 it('throws an error when a signing key is provided as a string with RS256', function(): void {
     Generator::create(uniqid());
@@ -23,15 +274,6 @@ it('throws an error when an incompatible signing key is used with RS256', functi
 
     Generator::create(
         signingKey: $mockSigningKey['private']
-    );
-})->throws(TokenException::class);
-
-it('throws an error when an incompatible signing key is used with HS256', function(): void {
-    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
-
-    Generator::create(
-        signingKey: $mockSigningKey['resource'],
-        algorithm: Token::ALGO_HS256
     );
 })->throws(TokenException::class);
 
@@ -46,45 +288,6 @@ it('throws an error when an malformed signing key is used with RS256', function(
         );
     }
 })->throws(TokenException::class);
-
-it('throws an error when an incompatible algorithm is specified', function(): void {
-    Generator::create(
-        signingKey: uniqid(),
-        algorithm: uniqid()
-    );
-})->throws(TokenException::class);
-
-it('throws an error when too small a bit length is used by a configured signing key', function(): void {
-    $mockSigningKey = TokenGenerator::generateRsaKeyPair(
-        bitLength: 1024 / 2
-    );
-
-    Generator::create(
-        signingKey: $mockSigningKey['resource'],
-        algorithm: Token::ALGO_RS256
-    );
-})->throws(TokenException::class);
-
-it('throws an error when too large bit length is used by a configured signing key', function(): void {
-    $mockSigningKey = TokenGenerator::generateRsaKeyPair(
-        bitLength: 1024 * 5
-    );
-
-    Generator::create(
-        signingKey: $mockSigningKey['resource'],
-        algorithm: Token::ALGO_RS256
-    );
-})->throws(TokenException::class);
-
-it('returns an instance of the Generator class', function(): void {
-    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
-
-    $token = Generator::create(
-        signingKey: $mockSigningKey['private']
-    );
-
-    expect($token)->toBeInstanceOf(Generator::class);
-});
 
 test('toArray(false) returns the segments as a key pair with a valid RS256 configuration', function(): void {
     $mockSigningKey = TokenGenerator::generateRsaKeyPair();
@@ -132,10 +335,56 @@ test('type casting a Generator to a string returns the segments formatted as a s
     expect($token)->toBeString();
 });
 
-test('toArray(false) returns the segments as a key pair with a valid HS256 configuration', function(): void {
+test('a valid signature is produced for RS256 configurations', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = (string) Generator::create(
+        signingKey: $mockSigningKey['private'],
+        algorithm: TOKEN::ALGO_RS256
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+    $signature = base64_decode(strtr($signature, '-_', '+/'), true);
+
+    $valid = openssl_verify($payload, $signature, $mockSigningKey['public'], OPENSSL_ALGO_SHA256);
+
+    expect($valid)->toEqual(1);
+});
+
+/**
+ * RS384 tests.
+ */
+
+ it('throws an error when a signing key is provided as a string with RS384', function(): void {
+    Generator::create(uniqid());
+})->throws(TokenException::class);
+
+it('throws an error when an incompatible signing key is used with RS384', function(): void {
+    $mockSigningKey = TokenGenerator::generateDsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+})->throws(TokenException::class);
+
+it('throws an error when an malformed signing key is used with RS384', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair()['private'];
+
+    for ($i = 0; $i < 128; $i++) {
+        $corruptedSigningKey = Chaos::corruptString($mockSigningKey, random_int(0, 384));
+
+        Generator::create(
+            signingKey: $corruptedSigningKey
+        );
+    }
+})->throws(TokenException::class);
+
+test('toArray(false) returns the segments as a key pair with a valid RS384 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
     $token = Generator::create(
-        signingKey: uniqid(),
-        algorithm: TOKEN::ALGO_HS256
+        signingKey: $mockSigningKey['private']
     )->toArray(false);
 
     expect($token)
@@ -144,10 +393,11 @@ test('toArray(false) returns the segments as a key pair with a valid HS256 confi
         ->toHaveKeys(['headers', 'claims', 'signature']);
 });
 
-test('toArray(true) returns the segments without keys with a valid HS256 configuration', function(): void {
+test('toArray(true) returns the segments without keys with a valid RS384 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
     $token = Generator::create(
-        signingKey: uniqid(),
-        algorithm: TOKEN::ALGO_HS256
+        signingKey: $mockSigningKey['private']
     )->toArray();
 
     expect($token)
@@ -156,23 +406,137 @@ test('toArray(true) returns the segments without keys with a valid HS256 configu
         ->not()->toHaveKeys(['headers', 'claims', 'signature']);
 });
 
-test('toString() returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+test('toString() returns the segments formatted as a string with a valid RS384 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
     $token = Generator::create(
-        signingKey: uniqid(),
-        algorithm: TOKEN::ALGO_HS256
+        signingKey: $mockSigningKey['private']
     )->toString();
 
     expect($token)->toBeString();
 });
 
-test('type casting a Generator to a string returns the segments formatted as a string with a valid HS256 configuration', function(): void {
+test('type casting a Generator to a string returns the segments formatted as a string with a valid RS384 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
     $token = (string) Generator::create(
-        signingKey: uniqid(),
-        algorithm: TOKEN::ALGO_HS256
+        signingKey: $mockSigningKey['private']
     );
 
     expect($token)->toBeString();
 });
+
+test('a valid signature is produced for RS384 configurations', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = (string) Generator::create(
+        signingKey: $mockSigningKey['private'],
+        algorithm: TOKEN::ALGO_RS384
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+    $signature = base64_decode(strtr($signature, '-_', '+/'), true);
+
+    $valid = openssl_verify($payload, $signature, $mockSigningKey['public'], OPENSSL_ALGO_SHA384);
+
+    expect($valid)->toEqual(1);
+});
+
+/**
+ * RS512 tests.
+ */
+
+ it('throws an error when a signing key is provided as a string with RS512', function(): void {
+    Generator::create(uniqid());
+})->throws(TokenException::class);
+
+it('throws an error when an incompatible signing key is used with RS512', function(): void {
+    $mockSigningKey = TokenGenerator::generateDsaKeyPair();
+
+    Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+})->throws(TokenException::class);
+
+it('throws an error when an malformed signing key is used with RS512', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair()['private'];
+
+    for ($i = 0; $i < 128; $i++) {
+        $corruptedSigningKey = Chaos::corruptString($mockSigningKey, random_int(0, 512));
+
+        Generator::create(
+            signingKey: $corruptedSigningKey
+        );
+    }
+})->throws(TokenException::class);
+
+test('toArray(false) returns the segments as a key pair with a valid RS512 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray(false);
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toArray(true) returns the segments without keys with a valid RS512 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toArray();
+
+    expect($token)
+        ->toBeArray()
+        ->toHaveCount(3)
+        ->not()->toHaveKeys(['headers', 'claims', 'signature']);
+});
+
+test('toString() returns the segments formatted as a string with a valid RS512 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = Generator::create(
+        signingKey: $mockSigningKey['private']
+    )->toString();
+
+    expect($token)->toBeString();
+});
+
+test('type casting a Generator to a string returns the segments formatted as a string with a valid RS512 configuration', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = (string) Generator::create(
+        signingKey: $mockSigningKey['private']
+    );
+
+    expect($token)->toBeString();
+});
+
+test('a valid signature is produced for RS512 configurations', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair();
+
+    $token = (string) Generator::create(
+        signingKey: $mockSigningKey['private'],
+        algorithm: TOKEN::ALGO_RS512
+    );
+
+    [$headers, $claims, $signature] = explode('.', $token);
+    $payload = implode('.', [$headers, $claims]);
+    $signature = base64_decode(strtr($signature, '-_', '+/'), true);
+
+    $valid = openssl_verify($payload, $signature, $mockSigningKey['public'], OPENSSL_ALGO_SHA512);
+
+    expect($valid)->toEqual(1);
+});
+
+/**
+ * Header tests.
+ */
 
 it('assigns a correct `type` header value', function(): void {
     $mockSigningKey = TokenGenerator::generateRsaKeyPair();

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -54,6 +54,28 @@ it('throws an error when an incompatible algorithm is specified', function(): vo
     );
 })->throws(TokenException::class);
 
+it('throws an error when too small a bit length is used by a configured signing key', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair(
+        bitLength: 1024 / 2
+    );
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_RS256
+    );
+})->throws(TokenException::class);
+
+it('throws an error when too large bit length is used by a configured signing key', function(): void {
+    $mockSigningKey = TokenGenerator::generateRsaKeyPair(
+        bitLength: 1024 * 5
+    );
+
+    Generator::create(
+        signingKey: $mockSigningKey['resource'],
+        algorithm: Token::ALGO_RS256
+    );
+})->throws(TokenException::class);
+
 it('returns an instance of the Generator class', function(): void {
     $mockSigningKey = TokenGenerator::generateRsaKeyPair();
 

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -6,7 +6,6 @@ namespace Auth0\Tests\Utilities;
 
 use Auth0\SDK\Token;
 use Auth0\SDK\Token\Generator;
-use Firebase\JWT\JWT;
 use RuntimeException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 

--- a/tests/Utilities/TokenGenerator.php
+++ b/tests/Utilities/TokenGenerator.php
@@ -65,12 +65,14 @@ class TokenGenerator
 
     public static function generateRsaKeyPair(
         string $digestAlg = 'sha256',
-        int $keyType = OPENSSL_KEYTYPE_RSA
+        int $keyType = OPENSSL_KEYTYPE_RSA,
+        int $bitLength = 2048
     ): array
     {
         $config = [
             'digest_alg' => $digestAlg,
-            'private_key_type' => $keyType
+            'private_key_type' => $keyType,
+            'private_key_bits' => $bitLength,
         ];
 
         $privateKeyResource = openssl_pkey_new($config);
@@ -101,12 +103,14 @@ class TokenGenerator
 
     public static function generateDsaKeyPair(
         string $digestAlg = 'sha256',
-        int $keyType = OPENSSL_KEYTYPE_DSA
+        int $keyType = OPENSSL_KEYTYPE_DSA,
+        int $bitLength = 2048
     ): array
     {
         $config = [
             'digest_alg' => $digestAlg,
-            'private_key_type' => $keyType
+            'private_key_type' => $keyType,
+            'private_key_bits' => $bitLength,
         ];
 
         $privateKeyResource = openssl_pkey_new($config);


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds support for Client Assertion, as an alternative to using Client Secrets, when making requests against the Authentication API.

Changes include the introduction of two new SDK configuration properties:

- `clientAssertionSigningKey`, which accepts an `OpenSSLAsymmetricKey` object, a PEM formatted private key as a `string`, a file path to a PEM certificate (e.g. `file://path/to/file.pem`), or `null` to disable the feature. Defaults to `null`.
- `clientAssertionSigningAlgorithm`, which accepts a string. Defaults to `RS256`.

When configured, the `clientAssertionSigningKey` will take precedence over any configured `clientSecret`, where appropriate.

When passing a string as the value to `clientAssertionSigningKey`, the format can be anything the OpenSSL `openssl_pkey_get_private()` 

Changes also include a new class, `Auth0\SDK\Token\ClientAssertionGenerator`. This is a template interstitial for `Auth0\SDK\Token\Generator` that will apply the necessary configuration to create a JSON Web Token appropriate for use with the Client Assertion feature.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist

<!-- This checklist MUST be completed for your pull request to be considered. -->

- [x] My code follows the [contributing guidelines of this repo](./CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
