### PR TITLE
feat(Management): Add support for client credentials endpoints

### DIFF
--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -112,4 +112,86 @@ final class Clients extends ManagementEndpoint implements ClientsInterface
             withOptions($options)->
             call();
     }
+
+    public function createCredentials(
+        string $clientId,
+        array $body,
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        [$clientId] = Toolkit::filter([$clientId])->string()->trim();
+        [$body] = Toolkit::filter([$body])->array()->trim();
+
+        Toolkit::assert([
+            [$clientId, \Auth0\SDK\Exception\ArgumentException::missing('clientId')],
+        ])->isString();
+
+        /** @var array<mixed> $body */
+
+        return $this->getHttpClient()->
+            method('post')->
+            addPath('clients', $clientId, 'credentials')->
+            withBody((object) $body)->
+            withOptions($options)->
+            call();
+    }
+
+    public function getCredentials(
+        string $clientId,
+        ?array $parameters = null,
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        [$clientId] = Toolkit::filter([$clientId])->string()->trim();
+        [$parameters] = Toolkit::filter([$parameters])->array()->trim();
+
+        Toolkit::assert([
+            [$clientId, \Auth0\SDK\Exception\ArgumentException::missing('clientId')],
+        ])->isString();
+
+        /** @var array<int|string|null> $parameters */
+
+        return $this->getHttpClient()->
+            method('get')->
+            addPath('clients', $clientId, 'credentials')->
+            withParams($parameters)->
+            withOptions($options)->
+            call();
+    }
+
+    public function getCredential(
+        string $clientId,
+        string $credentialId,
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        [$clientId, $credentialId] = Toolkit::filter([$clientId, $credentialId])->string()->trim();
+
+        Toolkit::assert([
+            [$clientId, \Auth0\SDK\Exception\ArgumentException::missing('clientId')],
+            [$credentialId, \Auth0\SDK\Exception\ArgumentException::missing('credentialId')],
+        ])->isString();
+
+        return $this->getHttpClient()->
+            method('get')->
+            addPath('clients', $clientId, 'credentials', $credentialId)->
+            withOptions($options)->
+            call();
+    }
+
+    public function deleteCredential(
+        string $clientId,
+        string $credentialId,
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        [$clientId, $credentialId] = Toolkit::filter([$clientId, $credentialId])->string()->trim();
+
+        Toolkit::assert([
+            [$clientId, \Auth0\SDK\Exception\ArgumentException::missing('clientId')],
+            [$credentialId, \Auth0\SDK\Exception\ArgumentException::missing('credentialId')],
+        ])->isString();
+
+        return $this->getHttpClient()->
+            method('delete')->
+            addPath('clients', $clientId, 'credentials', $credentialId)->
+            withOptions($options)->
+            call();
+    }
 }

--- a/src/Contract/API/Management/ClientsInterface.php
+++ b/src/Contract/API/Management/ClientsInterface.php
@@ -105,4 +105,81 @@ interface ClientsInterface
         string $id,
         ?RequestOptions $options = null,
     ): ResponseInterface;
+
+    /**
+     * Create a new Client.
+     * Required scope: `create:clients`.
+     *
+     * @param  string  $clientId  client  to create credentials for
+     * @param  array<mixed>  $body  Additional body content to pass with the API request. See @see for supported options.
+     * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `name` is provided
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Clients/post_clients
+     */
+    public function createCredentials(
+        string $clientId,
+        array $body,
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
+
+    /**
+     * Get all Clients.
+     * Required scopes:
+     * - `read:clients` for any call to this endpoint.
+     * - `read:client_keys` to retrieve "client_secret" and "encryption_key" attributes.
+     *
+     * @param  string  $clientId  client to retrieve credentials for
+     * @param  array<int|string|null>|null  $parameters  Optional. Additional query parameters to pass with the API request. See @see for supported options.
+     * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients
+     */
+    public function getCredentials(
+        string $clientId,
+        ?array $parameters = null,
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
+
+    /**
+     * Get a Client.
+     * Required scopes:
+     * - `read:clients` for any call to this endpoint.
+     * - `read:client_keys` to retrieve "client_secret" and "encryption_key" attributes.
+     *
+     * @param  string  $clientId  client to retrieve credential for
+     * @param  string  $credentialId  credential to retrieve
+     * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` is provided
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
+     */
+    public function getCredential(
+        string $clientId,
+        string $credentialId,
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
+
+    /**
+     * Delete a Client.
+     * Required scope: `delete:clients".
+     *
+     * @param  string  $clientId  client to delete credential for
+     * @param  string  $credentialId  credential to delete
+     * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` is provided
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     */
+    public function deleteCredential(
+        string $clientId,
+        string $credentialId,
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
 }

--- a/src/Contract/API/Management/ClientsInterface.php
+++ b/src/Contract/API/Management/ClientsInterface.php
@@ -107,17 +107,13 @@ interface ClientsInterface
     ): ResponseInterface;
 
     /**
-     * Create a new Client.
-     * Required scope: `create:clients`.
+     * Add new credentials to the specified Client.
      *
-     * @param  string  $clientId  client  to create credentials for
+     * @param  string  $clientId Client to add credentials to
      * @param  array<mixed>  $body  Additional body content to pass with the API request. See @see for supported options.
      * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `name` is provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
-     *
-     * @see https://auth0.com/docs/api/management/v2#!/Clients/post_clients
      */
     public function createCredentials(
         string $clientId,
@@ -126,18 +122,14 @@ interface ClientsInterface
     ): ResponseInterface;
 
     /**
-     * Get all Clients.
-     * Required scopes:
-     * - `read:clients` for any call to this endpoint.
-     * - `read:client_keys` to retrieve "client_secret" and "encryption_key" attributes.
+     * Get all credentials from the specified Client.
      *
-     * @param  string  $clientId  client to retrieve credentials for
+     * @param  string  $clientId  Client to retrieve credentials for
      * @param  array<int|string|null>|null  $parameters  Optional. Additional query parameters to pass with the API request. See @see for supported options.
      * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
      *
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` is provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
-     *
-     * @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients
      */
     public function getCredentials(
         string $clientId,
@@ -146,19 +138,14 @@ interface ClientsInterface
     ): ResponseInterface;
 
     /**
-     * Get a Client.
-     * Required scopes:
-     * - `read:clients` for any call to this endpoint.
-     * - `read:client_keys` to retrieve "client_secret" and "encryption_key" attributes.
+     * Get a specific credential from the specified Client.
      *
-     * @param  string  $clientId  client to retrieve credential for
+     * @param  string  $clientId  Client to retrieve credential for
      * @param  string  $credentialId  credential to retrieve
      * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` is provided
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` or `credentialId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
-     *
-     * @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
      */
     public function getCredential(
         string $clientId,
@@ -167,14 +154,13 @@ interface ClientsInterface
     ): ResponseInterface;
 
     /**
-     * Delete a Client.
-     * Required scope: `delete:clients".
+     * Delete a credential from the specified Client.
      *
      * @param  string  $clientId  client to delete credential for
      * @param  string  $credentialId  credential to delete
      * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
      *
-     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` is provided
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` or `credentialId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
      */
     public function deleteCredential(

--- a/src/Contract/API/Management/ClientsInterface.php
+++ b/src/Contract/API/Management/ClientsInterface.php
@@ -114,6 +114,8 @@ interface ClientsInterface
      * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
      *
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Client_Credentials/post_client_credentials
      */
     public function createCredentials(
         string $clientId,
@@ -130,6 +132,8 @@ interface ClientsInterface
      *
      * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` is provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Client_Credentials/get_client_credentials
      */
     public function getCredentials(
         string $clientId,
@@ -146,6 +150,8 @@ interface ClientsInterface
      *
      * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` or `credentialId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Client_Credentials/get_client_credentials_by_id
      */
     public function getCredential(
         string $clientId,
@@ -162,6 +168,8 @@ interface ClientsInterface
      *
      * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `clientId` or `credentialId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Client_Credentials/delete_client_credentials_by_id
      */
     public function deleteCredential(
         string $clientId,

--- a/tests/Unit/API/Management/ClientsTest.php
+++ b/tests/Unit/API/Management/ClientsTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Auth0\Tests\Utilities\TokenGenerator;
+
 uses()->group('management', 'management.clients');
 
 beforeEach(function(): void {
@@ -64,4 +66,66 @@ test('update() issues an appropriate request', function(): void {
     $body = $this->api->getRequestBody();
     $this->assertArrayHasKey('name', $body);
     expect($body['name'])->toEqual('__test_new_name__');
+});
+
+test('getCredentials() issues an appropriate request', function(): void {
+    $mockClientId = uniqid();
+    $this->endpoint->getCredentials($mockClientId, ['client_id' => '__test_client_id__', 'app_type' => '__test_app_type__']);
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/clients/' . $mockClientId . '/credentials');
+
+    $query = $this->api->getRequestQuery();
+    expect($query)->toContain('&client_id=__test_client_id__&app_type=__test_app_type__');
+});
+
+test('getCredential() issues an appropriate request', function(): void {
+    $mockClientId = uniqid();
+    $mockCredentialId = uniqid();
+    $this->endpoint->getCredential($mockClientId, $mockCredentialId);
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/clients/' . $mockClientId . '/credentials/' . $mockCredentialId);
+});
+
+test('deleteCredential() issues an appropriate request', function(): void {
+    $mockClientId = uniqid();
+    $mockCredentialId = uniqid();
+    $this->endpoint->deleteCredential($mockClientId, $mockCredentialId);
+
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/clients/' . $mockClientId . '/credentials/' . $mockCredentialId);
+});
+
+test('createCredentials() issues an appropriate request', function(): void {
+    $mockCertificate = TokenGenerator::generateRsaKeyPair();
+    $mockClientId = uniqid();
+    $mockRequestBody = [
+        [
+            'credential_type' => 'public_key',
+            'name' => 'my pub key',
+            'pem' => $mockCertificate['cert'],
+        ]
+    ];
+
+    $this->endpoint->createCredentials($mockClientId, $mockRequestBody);
+
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/clients/' . $mockClientId . '/credentials');
+
+    $body = $this->api->getRequestBody();
+
+    expect($body)
+        ->toBeArray()
+        ->toHaveCount(1);
+
+    expect($body[0])
+        ->toBeArray()
+        ->toHaveKeys(['credential_type', 'name', 'pem'])
+        ->credential_type->toEqual('public_key')
+        ->name->toEqual('my pub key')
+        ->pem->toEqual($mockCertificate['cert']);
+
+    $body = $this->api->getRequestBodyAsString();
+    expect($body)->toEqual(json_encode((object) $mockRequestBody));
 });


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds support to the `Auth0\SDK\API\Management\Clients` class for managing client credentials using the Management API. The following methods were added:

- `Auth0\SDK\API\Management\Clients::createCredentials($clientId, $body)` issues a `POST` request to `/api/v2/clients/:client_id/credentials` with the supplied data.
- `Auth0\SDK\API\Management\Clients::getCredentials($clientId)` issues a `GET` request to `/api/v2/clients/:client_id/credentials` to retrieve a list of registered credentials for the specified client.
- `Auth0\SDK\API\Management\Clients::getCredential($clientId, $credentialId)` issues a `GET` request to `/api/v2/clients/:client_id/credentials/:credential_id` to retrieve the specified client credential.
- `Auth0\SDK\API\Management\Clients::deleteCredential($clientId, $credentialId)` issues a `DELETE` request to `/api/v2/clients/:client_id/credentials/credential_id` to delete the specified client credential.

The `ClientsTest` unit tests have been expanded to provide coverage for these new methods.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist

<!-- This checklist MUST be completed for your pull request to be considered. -->

- [x] My code follows the [contributing guidelines of this repo](./CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
