### PR TITLE
chore(dependencies): Remove `firebase/php-jwt`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",
-    "firebase/php-jwt": "^6.3",
     "hyperf/event": "^2.2",
     "laravel/pint": "^1.2",
     "mockery/mockery": "^1.5",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes the `firebase/php-jwt` development dependency, as it was replaced by our own token generator in 8.4.0, and our tests were already updated to use the new class. Just overlooked removing it from the manifest before release.

### Type of change

- [x] Dependency cleanup

### Checklist

<!-- This checklist MUST be completed for your pull request to be considered. -->

- [x] My code follows the [contributing guidelines of this repo](./CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
