### PR TITLE
feat: Add method deleteAllAuthenticators to the users management api

### DIFF
--- a/src/API/Management/Users.php
+++ b/src/API/Management/Users.php
@@ -411,4 +411,21 @@ final class Users extends ManagementEndpoint implements UsersInterface
             withOptions($options)->
             call();
     }
+
+    public function deleteAllAuthenticators(
+        string $id,
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        [$id] = Toolkit::filter([$id])->string()->trim();
+
+        Toolkit::assert([
+            [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
+        ])->isString();
+
+        return $this->getHttpClient()->
+            method('delete')->
+            addPath('users', $id, 'authenticators')->
+            withOptions($options)->
+            call();
+    }
 }

--- a/src/Contract/API/Management/UsersInterface.php
+++ b/src/Contract/API/Management/UsersInterface.php
@@ -365,4 +365,22 @@ interface UsersInterface
         string $provider,
         ?RequestOptions $options = null,
     ): ResponseInterface;
+
+    /**
+     * Deletes all authenticators that are associated to the provided user.
+     *
+     * Required scope: `delete:guardian_enrollments`.
+     *
+     * @param  string  $id  user ID with the authenticators to delete
+     * @param  RequestOptions|null  $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` is provided
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators
+     */
+    public function deleteAllAuthenticators(
+        string $id,
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
 }

--- a/tests/Unit/API/Management/UsersTest.php
+++ b/tests/Unit/API/Management/UsersTest.php
@@ -161,6 +161,19 @@ test('deleteMultifactorProvider() issues an appropriate request', function(): vo
     expect($headers['Content-Type'][0])->toEqual('application/json');
 });
 
+test('deleteAllAuthenticators() issues an appropriate request', function(): void {
+    $id = uniqid();
+
+    $this->endpoint->deleteAllAuthenticators($id);
+
+    expect($this->api->getRequestMethod())->toEqual('DELETE');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/users/' . $id . '/authenticators');
+
+    $headers = $this->api->getRequestHeaders();
+    expect($headers['Content-Type'][0])->toEqual('application/json');
+});
+
+
 test('getRoles() issues an appropriate request', function(): void {
     $mockupId = uniqid();
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added the `deleteAllAuthenticators` method to the `UsersInterface`. This method calls the [management api endpoint](https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators) to delete all authenticators.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Checklist

<!-- This checklist MUST be completed for your pull request to be considered. -->

- [x] My code follows the [contributing guidelines of this repo](./CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
