### PR TITLE
Release 8.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,6 +34,7 @@ body:
       label: SDK Version
       description: What version of our SDK are you running? (`composer show | grep auth0/auth0-php`)
       options:
+        - 8.6
         - 8.5
         - 8.4
         - 8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [Unreleased]
+## [8.6.0](https://github.com/auth0/auth0-PHP/tree/8.6.0) - 2023-05-02
+
+**Added**
+
+- **[PAR (Pushed Authorization Request)](https://www.rfc-editor.org/rfc/rfc6749) support¹** ([#714](https://github.com/auth0/auth0-PHP/pull/714)):
+  - `Auth0\SDK\API\Authentication\PushedAuthorizationRequest` is a new class for issuing Pushed Authorization Requests and producing authorization links for them.
+  - `Auth0\SDK\API\Authentication::pushedAuthorizationRequest()` has been added as a shortcut method for returning a configured instantiation of the above class.
+  - `Auth0\SDK\Auth0::login()` has been updated to support issuing Pushed Authorization Requests and returning authorization links for them.
+  - `Auth0\SDK\Configuration\SdkConfiguration` has been updated to accept a `pushedAuthorizationRequest` boolean to enable this feature.
+- `Auth0\SDK\Auth0::isAuthenticated()` shortcut method (alias for `isCredentials() !== null`)
+
+¹ **Note:** To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
 
 ## [8.5.0](https://github.com/auth0/auth0-PHP/tree/8.5.0) - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - `Auth0\SDK\API\Authentication::pushedAuthorizationRequest()` has been added as a shortcut method for returning a configured instantiation of the above class.
   - `Auth0\SDK\Auth0::login()` has been updated to support issuing Pushed Authorization Requests and returning authorization links for them.
   - `Auth0\SDK\Configuration\SdkConfiguration` has been updated to accept a `pushedAuthorizationRequest` boolean to enable this feature.
-- `Auth0\SDK\Auth0::isAuthenticated()` shortcut method (alias for `isCredentials() !== null`)
+- `Auth0\SDK\Auth0::isAuthenticated()` has been added as a shortcut method. It is an alias for `getCredentials() !== null`.
 
 ¹ **Note:** To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
 

--- a/examples/features/authentication/pushed-authorization-request/composer.json
+++ b/examples/features/authentication/pushed-authorization-request/composer.json
@@ -1,18 +1,9 @@
 {
   "name": "auth0-samples/pushed-authorization-request",
   "description": "Example of using Pushed Authorization Requests with Auth0 PHP",
-  "repositories": [
-    {
-      "type": "path",
-      "url": "vendor/auth0/auth0-php",
-      "options": {
-        "symlink": true
-      }
-    }
-  ],
   "require": {
     "php": "^8.0",
-    "auth0/auth0-php": "@dev",
+    "auth0/auth0-php": "^8.6",
     "nyholm/psr7": "^1.5",
     "symfony/http-client": "^6.2"
   },
@@ -27,20 +18,14 @@
     }
   },
   "scripts": {
-    "start": [
-      "chmod +x setup.sh",
-      "bash setup.sh",
+    "serve": [
       "php -S 127.0.0.1:3000 src/index.php"
     ],
-    "pre-update-cmd": [
-      "@symlink-package",
+    "pre-install-cmd": [
       "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
     ],
-    "symlink-package": [
-      "mkdir -p vendor/auth0",
-      "rm -rf vendor/auth0/auth0-php",
-      "ln -s ./../../../../../../ vendor/auth0/auth0-php"
-    ],
-    "pre-install-cmd": "@symlink-package"
+    "pre-update-cmd": [
+      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+    ]
   }
 }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -21,7 +21,7 @@ final class Auth0 implements Auth0Interface
     /**
      * @var string
      */
-    public const VERSION = '8.5.0';
+    public const VERSION = '8.6.0';
 
     /**
      * Authentication Client.


### PR DESCRIPTION
**Added**

- **[PAR (Pushed Authorization Request)](https://www.rfc-editor.org/rfc/rfc6749) support¹** ([#714](https://github.com/auth0/auth0-PHP/pull/714)):
  - `Auth0\SDK\API\Authentication\PushedAuthorizationRequest` is a new class for issuing Pushed Authorization Requests and producing authorization links for them.
  - `Auth0\SDK\API\Authentication::pushedAuthorizationRequest()` has been added as a shortcut method for returning a configured instantiation of the above class.
  - `Auth0\SDK\Auth0::login()` has been updated to support issuing Pushed Authorization Requests and returning authorization links for them.
  - `Auth0\SDK\Configuration\SdkConfiguration` has been updated to accept a `pushedAuthorizationRequest` boolean to enable this feature.
- `Auth0\SDK\Auth0::isAuthenticated()` has been added as a shortcut method. It is an alias for `getCredentials() !== null`.

¹ **Note:** To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.