### PR TITLE
Remove and ignore pest.log file introduced in 02e6148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ TODO.txt
 composer.local.json
 .php-cs-fixer.cache
 composer.local.old
+pest.log


### PR DESCRIPTION
Noticed during an update that the package size increased by a few megs due to this new log file which looks like it was inadvertently committed during 02e61480a63d5881236e9ec767237fe54f100e3f. This change removes and ignores that file.