### PR TITLE
Release 8.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,6 +33,7 @@ body:
       label: SDK Version
       description: What version of our SDK are you running? (`composer show | grep auth0/auth0-php`)
       options:
+        - 8.7
         - 8.6
         - 8.5
         - 8.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Organization Name support added for Authentication API and token handling ¹ ([#719](https://github.com/auth0/auth0-PHP/pull/719))
 
-> **¹ Note**
-> To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
+> **Note**
+> ¹  To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
 
 ## [8.6.0](https://github.com/auth0/auth0-PHP/tree/8.6.0) - 2023-05-02
 
@@ -20,8 +20,8 @@
   - `Auth0\SDK\Configuration\SdkConfiguration` has been updated to accept a `pushedAuthorizationRequest` boolean to enable this feature.
 - `Auth0\SDK\Auth0::isAuthenticated()` has been added as a shortcut method. It is an alias for `getCredentials() !== null`.
 
-> **¹ Note**
-> To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
+> **Note**
+> ¹  To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
 
 ## [8.5.0](https://github.com/auth0/auth0-PHP/tree/8.5.0) - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [8.7.0](https://github.com/auth0/auth0-PHP/tree/8.7.0) - 2023-07-20
+
+**Added**
+
+- Organization Name support added for Authentication API and token handling ¹ ([#719](https://github.com/auth0/auth0-PHP/pull/719))
+
+> **¹ Note**
+> To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
+
 ## [8.6.0](https://github.com/auth0/auth0-PHP/tree/8.6.0) - 2023-05-02
 
 **Added**
@@ -11,7 +20,8 @@
   - `Auth0\SDK\Configuration\SdkConfiguration` has been updated to accept a `pushedAuthorizationRequest` boolean to enable this feature.
 - `Auth0\SDK\Auth0::isAuthenticated()` has been added as a shortcut method. It is an alias for `getCredentials() !== null`.
 
-¹ **Note:** To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
+> **¹ Note**
+> To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.
 
 ## [8.5.0](https://github.com/auth0/auth0-PHP/tree/8.5.0) - 2023-03-27
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -21,7 +21,7 @@ final class Auth0 implements Auth0Interface
     /**
      * @var string
      */
-    public const VERSION = '8.6.0';
+    public const VERSION = '8.7.0';
 
     /**
      * Authentication Client.


### PR DESCRIPTION
**Added**

- Organization Name support added for Authentication API and token handling ¹ ([#719](https://github.com/auth0/auth0-PHP/pull/719))

> **Note**
> ¹  To use this feature, an Auth0 tenant must have support for it enabled. This feature is not yet available to all tenants.