### PR TITLE
fix: Correct route for deploy action

### DIFF
--- a/src/API/Management/Actions.php
+++ b/src/API/Management/Actions.php
@@ -70,7 +70,7 @@ final class Actions extends ManagementEndpoint implements ActionsInterface
         ])->isString();
 
         return $this->getHttpClient()
-            ->method('post')->addPath(['actions', $id, 'deploy'])
+            ->method('post')->addPath(['actions', 'actions', $id, 'deploy'])
             ->withOptions($options)
             ->call();
     }


### PR DESCRIPTION
### Changes

Current route for deploy action returns a `404` error. This PR updates the route to match other routes and the documentation.

### References

https://auth0.com/docs/api/management/v2/actions/post-deploy-action

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
