### PR TITLE
fix: Typo in token generator claim

### DIFF
--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -284,12 +284,12 @@ final class Generator implements GeneratorInterface, Stringable
             throw TokenException::unableToProcessSigningKey($message, $failure);
         }
 
-        if (! is_array($details) || ! isset($details['typ'])) {
+        if (! is_array($details) || ! isset($details['type'])) {
             throw TokenException::unidentifiableKeyType();
         }
         // @codeCoverageIgnoreEnd
 
-        $keyType = $details['typ'];
+        $keyType = $details['type'];
 
         if ($keyType !== $this->getOpenSslKeyType()) {
             throw TokenException::keyTypeMismatch((string) $keyType, $this->algorithm);

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -284,12 +284,12 @@ final class Generator implements GeneratorInterface, Stringable
             throw TokenException::unableToProcessSigningKey($message, $failure);
         }
 
-        if (! is_array($details) || ! isset($details['type'])) {
+        if (! is_array($details) || ! isset($details['typ'])) {
             throw TokenException::unidentifiableKeyType();
         }
         // @codeCoverageIgnoreEnd
 
-        $keyType = $details['type'];
+        $keyType = $details['typ'];
 
         if ($keyType !== $this->getOpenSslKeyType()) {
             throw TokenException::keyTypeMismatch((string) $keyType, $this->algorithm);

--- a/src/Token/Generator.php
+++ b/src/Token/Generator.php
@@ -88,7 +88,7 @@ final class Generator implements GeneratorInterface, Stringable
         }
 
         // Merge any provided headers with the defaults.
-        $this->headers = array_merge($this->headers, ['type' => 'JWT', 'alg' => $this->algorithm]);
+        $this->headers = array_merge($this->headers, ['typ' => 'JWT', 'alg' => $this->algorithm]);
 
         // Convert the provided signing key to the appropriate type.
         $this->signingKey = $this->loadSigningKey($this->signingKey, $this->signingKeyPassphrase);

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -548,7 +548,7 @@ it('assigns a correct `type` header value', function(): void {
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
         ->headers->toBeArray()->toHaveKeys(['typ'])
-        ->headers->type->toBeString()->toEqual('JWT');
+        ->headers->typ->toBeString()->toEqual('JWT');
 
     $token = Generator::create(
         signingKey: $mockSigningKey['private'],

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -547,31 +547,31 @@ it('assigns a correct `type` header value', function(): void {
 
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
-        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->toBeArray()->toHaveKeys(['typ'])
         ->headers->type->toBeString()->toEqual('JWT');
 
     $token = Generator::create(
         signingKey: $mockSigningKey['private'],
         headers: [
-            'type' => null
+            'typ' => null
         ]
     )->toArray(false);
 
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
-        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->toBeArray()->toHaveKeys(['typ'])
         ->headers->type->toBeString()->toEqual('JWT');
 
     $token = Generator::create(
         signingKey: $mockSigningKey['private'],
         headers: [
-            'type' => uniqid()
+            'typ' => uniqid()
         ]
     )->toArray(false);
 
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
-        ->headers->toBeArray()->toHaveKeys(['type'])
+        ->headers->toBeArray()->toHaveKeys(['typ'])
         ->headers->type->toBeString()->toEqual('JWT');
 });
 

--- a/tests/Unit/Token/GeneratorTest.php
+++ b/tests/Unit/Token/GeneratorTest.php
@@ -560,7 +560,7 @@ it('assigns a correct `type` header value', function(): void {
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
         ->headers->toBeArray()->toHaveKeys(['typ'])
-        ->headers->type->toBeString()->toEqual('JWT');
+        ->headers->typ->toBeString()->toEqual('JWT');
 
     $token = Generator::create(
         signingKey: $mockSigningKey['private'],
@@ -572,7 +572,7 @@ it('assigns a correct `type` header value', function(): void {
     expect($token)
         ->toBeArray()->toHaveKeys(['headers'])
         ->headers->toBeArray()->toHaveKeys(['typ'])
-        ->headers->type->toBeString()->toEqual('JWT');
+        ->headers->typ->toBeString()->toEqual('JWT');
 });
 
 it('assigns the correct `alg` header value', function(): void {


### PR DESCRIPTION
### Changes

This PR fixes a typo in the JSON web token generator class.

### References

Closes #728

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
