### PR TITLE
fix: Added ext-mbstring to composer.json dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
+    "ext-mbstring": "*",
     "ext-openssl": "*",
     "php-http/multipart-stream-builder": "^1",
     "psr-discovery/all": "^1",


### PR DESCRIPTION
### Changes

Added ext-mbstring to composer.json dependencies. Some systems, such as Heroku, require PHP extension dependencies to be specified in composer.json. This pull request resolves that dependency. 

### References

https://github.com/auth0/symfony/issues/155#issuecomment-1732696166

### Testing



### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
