### PR TITLE
[SDK-4665] Support `initiate_login_uri` property being an empty string for PATCH /api/v2/clients/:id requests.

### DIFF
--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -9,6 +9,9 @@ use Auth0\SDK\Utility\Request\RequestOptions;
 use Auth0\SDK\Utility\Toolkit;
 use Psr\Http\Message\ResponseInterface;
 
+use function array_key_exists;
+use function is_array;
+
 /**
  * Handles requests to the Clients endpoint of the v2 Management API.
  *
@@ -179,6 +182,10 @@ final class Clients extends ManagementEndpoint implements ClientsInterface
         Toolkit::assert([
             [$id, \Auth0\SDK\Exception\ArgumentException::missing('id')],
         ])->isString();
+
+        if (is_array($body) && array_key_exists('initiate_login_uri', $body) && null === $body['initiate_login_uri']) {
+            $body['initiate_login_uri'] = '';
+        }
 
         return $this->getHttpClient()
             ->method('patch')->addPath(['clients', $id])

--- a/tests/Unit/API/Management/ClientsTest.php
+++ b/tests/Unit/API/Management/ClientsTest.php
@@ -68,6 +68,18 @@ test('update() issues an appropriate request', function(): void {
     expect($body['name'])->toEqual('__test_new_name__');
 });
 
+test('update() does NOT nullify empty `initiate_login_uri` values', function(): void {
+    $this->endpoint->update('__test_id__', ['name' => '__test_new_name__', 'initiate_login_uri' => '']);
+
+    expect($this->api->getRequestMethod())->toEqual('PATCH');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/clients/__test_id__');
+
+    $body = $this->api->getRequestBody();
+    $this->assertArrayHasKey('name', $body);
+    expect($body['name'])->toEqual('__test_new_name__');
+    expect($body['initiate_login_uri'])->toEqual('');
+});
+
 test('getCredentials() issues an appropriate request', function(): void {
     $mockClientId = uniqid();
     $this->endpoint->getCredentials($mockClientId, ['client_id' => '__test_client_id__', 'app_type' => '__test_app_type__']);


### PR DESCRIPTION
### Changes

This PR adds support for `initiate_login_uri` to be supplied as an empty string to the `/api/v2/clients/:id` endpoint for `PATCH` requests.

### References

Resolves #731 

### Testing

This PR adds a regression testing for the change.

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
