### PR TITLE
fix(SDK-4716): Resolve thrown exception when enumerating device cookies that include non-string keys/names

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -438,7 +438,7 @@ final class CookieStore implements StoreInterface
     /**
      * Push our storage state to the source for persistence.
      *
-     * @psalm-suppress UnusedFunctionCall
+     * @psalm-suppress UnusedFunctionCall,DocblockTypeContradiction
      *
      * @param bool $force
      */
@@ -457,6 +457,10 @@ final class CookieStore implements StoreInterface
         // Iterate through the host device cookies and collect a list of ones that belong to us.
         foreach (array_keys($_COOKIE) as $cookieName) {
             $cookieBeginsWith = $this->namespace . self::KEY_SEPARATOR;
+
+            if (is_int($cookieName)) {
+                $cookieName = (string) $cookieName;
+            }
 
             if (mb_strlen($cookieName) >= mb_strlen($cookieBeginsWith)
                 && mb_substr($cookieName, 0, mb_strlen($cookieBeginsWith)) === $cookieBeginsWith) {

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -249,3 +249,21 @@ test('encrypt() returns nothing with invalid crypto properties', function(): voi
     $this->store->setEncrypted(false);
     expect($this->store->encrypt($state, ['encoded1' => false]))->toEqual('');
 });
+
+it('enumerates $_COOKIE with non-string keys', function(array $state): void {
+    $cookieNamespace = $this->store->getNamespace() . '_0';
+
+    $encrypted = MockCrypto::cookieCompatibleEncrypt($this->cookieSecret, [$this->exampleKey => $state]);
+
+    $_COOKIE[$cookieNamespace] = $encrypted;
+    $_COOKIE['123'] = uniqid();
+    $_COOKIE[456] = uniqid();
+    $_COOKIE['abc'] = uniqid();
+
+    $this->store->getState();
+    $this->store->setState(true);
+
+    expect($this->store->get($this->exampleKey))->toEqual($state);
+})->with(['mocked state' => [
+    fn() => MockDataset::state()
+]]);


### PR DESCRIPTION
### Changes

This PR resolves an issue wherein the SDK erroneously throws an exception when enumerating cookies from a device with integer-type keys.

### References

See internal ticket SDK-4716.

### Testing

Tests have been added to cover the code changes. Coverage remains 100%.

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
