### PR TITLE
fix: Remove redundant token verification step

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -459,7 +459,7 @@ final class CookieStore implements StoreInterface
             $cookieBeginsWith = $this->namespace . self::KEY_SEPARATOR;
 
             if (is_int($cookieName)) {
-                $cookieName = strval($cookieName);
+                $cookieName = (string) $cookieName;
             }
 
             if (mb_strlen($cookieName) >= mb_strlen($cookieBeginsWith)

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -438,7 +438,7 @@ final class CookieStore implements StoreInterface
     /**
      * Push our storage state to the source for persistence.
      *
-     * @psalm-suppress UnusedFunctionCall,DocblockTypeContradiction,NoValue
+     * @psalm-suppress UnusedFunctionCall,DocblockTypeContradiction,NoValue,InvalidCast
      *
      * @param bool $force
      */

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -438,7 +438,7 @@ final class CookieStore implements StoreInterface
     /**
      * Push our storage state to the source for persistence.
      *
-     * @psalm-suppress UnusedFunctionCall,DocblockTypeContradiction
+     * @psalm-suppress UnusedFunctionCall,DocblockTypeContradiction,NoValue
      *
      * @param bool $force
      */
@@ -459,7 +459,7 @@ final class CookieStore implements StoreInterface
             $cookieBeginsWith = $this->namespace . self::KEY_SEPARATOR;
 
             if (is_int($cookieName)) {
-                $cookieName = (string) $cookieName;
+                $cookieName = strval($cookieName);
             }
 
             if (mb_strlen($cookieName) >= mb_strlen($cookieBeginsWith)

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -265,7 +265,7 @@ final class Parser
         $signature = $this->getSignature() ?? '';
         $headers = $this->getHeaders();
 
-        $verifier = new Verifier(
+        new Verifier(
             $this->configuration,
             implode('.', [$parts[0], $parts[1]]),
             $signature,
@@ -276,8 +276,6 @@ final class Parser
             $cacheExpires,
             $cache,
         );
-
-        $verifier->verify();
 
         return $this;
     }


### PR DESCRIPTION
### Changes

This PR removes a redundant JWT verification step identified in #741. Verification is already performed in the token verifier constructor, so calling its `verify()` method afterward is redundant and unnecessary.

### References

Closes #741.

### Testing

No changes to testing were necessary for this change.

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
