### PR TITLE
Release 8.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [8.9.2](https://github.com/auth0/auth0-PHP/tree/8.9.2) (2023-11-29)
+[Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.9.1...8.9.2)
+
+**Fixed**
+- fix: Remove redundant token verification step [\#742](https://github.com/auth0/auth0-PHP/pull/742) ([evansims](https://github.com/evansims))
+
 ## [8.9.1](https://github.com/auth0/auth0-PHP/tree/8.9.1) (2023-11-20)
 [Full Changelog](https://github.com/auth0/auth0-PHP/compare/8.9.0...8.9.1)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -21,7 +21,7 @@ final class Auth0 implements Auth0Interface
     /**
      * @var string
      */
-    public const VERSION = '8.9.1';
+    public const VERSION = '8.9.2';
 
     /**
      * Authentication Client.


### PR DESCRIPTION

**Fixed**
- fix: Remove redundant token verification step [\#742](https://github.com/auth0/auth0-PHP/pull/742) ([evansims](https://github.com/evansims))
