### PR TITLE
Validate token with tenant domain in case of custom domain

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -254,7 +254,7 @@ final class Token implements TokenInterface
         ?int $tokenLeeway = null,
         ?int $tokenNow = null,
     ): self {
-        $tenantDomain = $this->configuration->formatDomain(true) . "/";
+        $tenantDomain = $this->configuration->formatDomain(true) . '/';
         $tokenIssuer ??= $this->configuration->formatDomain() . '/';
         $tokenAudience ??= $this->configuration->getAudience() ?? [];
         $tokenOrganization ??= $this->configuration->getOrganization() ?? null;
@@ -279,9 +279,10 @@ final class Token implements TokenInterface
         try {
             $validator->issuer($tokenIssuer);
         } catch (InvalidTokenException $invalidTokenException) {
-            if($tenantDomain !== $tokenIssuer) {
+            if ($tenantDomain !== $tokenIssuer) {
                 $validator->issuer($tenantDomain);
             }
+
             throw $invalidTokenException;
         }
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -254,6 +254,7 @@ final class Token implements TokenInterface
         ?int $tokenLeeway = null,
         ?int $tokenNow = null,
     ): self {
+        $tenantDomain = $this->configuration->formatDomain(true) . "/";
         $tokenIssuer ??= $this->configuration->formatDomain() . '/';
         $tokenAudience ??= $this->configuration->getAudience() ?? [];
         $tokenOrganization ??= $this->configuration->getOrganization() ?? null;
@@ -275,8 +276,16 @@ final class Token implements TokenInterface
             }
         }
 
+        try {
+            $validator->issuer($tokenIssuer);
+        } catch (InvalidTokenException $invalidTokenException) {
+            if($tenantDomain !== $tokenIssuer) {
+                $validator->issuer($tenantDomain);
+            }
+            throw $invalidTokenException;
+        }
+
         $validator
-            ->issuer($tokenIssuer)
             ->audience($tokenAudience)
             ->expiration($tokenLeeway, $tokenNow);
 


### PR DESCRIPTION
When a token is issued, the token issuer is validated against the (tenant)domain within the configuration. However, when a custom domain is provided within the SDK configuration, the issuer is validated against that custom domain.

This fix will, in case of custom domain set in SDK configuration, validates the custom domain at first against the issuer within the token (same as previous behaviour). However in case of failure fallback to the tenant domain set in the SDK Configuration.

Use case:
- A tenant domain is set
- A custom domain is set

All auth0 requests (e.g. token and validation) are sent to custom domain. In certain situations, the custom domain acts as a proxy that actually does some extended validation on the client request and redirects the requests to the actual tenant domain. Therefor, the tenant domain is the origin issuer of the token, while the requests are proxied through the custom domain.

### Changes

<!--
  Please outline the changes made in this pull request.
-->

### References

<!--
  Link to any associated issues, pull requests, or other resources.
-->

### Testing

<!--
  Tests must be added for new functionality.
  Existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
