### PR TITLE
Added test coverage

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -281,9 +281,9 @@ final class Token implements TokenInterface
         } catch (InvalidTokenException $invalidTokenException) {
             if ($tenantDomain !== $tokenIssuer) {
                 $validator->issuer($tenantDomain);
+            } else {
+                throw $invalidTokenException;
             }
-
-            throw $invalidTokenException;
         }
 
         $validator


### PR DESCRIPTION
### Changes

Added test coverage for previous added issuer claim validation with custom domain.
- Added expecting failure scenario with invalid `domain` not matching token issuer
- Added expecting failure scenario with invalid `domain` AND invalid `custom domain` not matching token issuer
- Added scenario with custom domain matching token issuer, should validate.
- Added scenario with custom domain not matching token issuer, should validate with tenant domain

### References

Ref: https://github.com/auth0/auth0-PHP/pull/755

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
