### PR TITLE
Update: Authentication.php, Management.php remove unused imports

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -7,10 +7,9 @@ namespace Auth0\SDK\API;
 use Auth0\SDK\API\Authentication\PushedAuthorizationRequest;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Contract\API\AuthenticationInterface;
-use Auth0\SDK\Exception\Authentication\{ParRequestException, ParResponseException, ParUnexpectedResponseException};
-use Auth0\SDK\Exception\{ConfigurationException, NetworkException, TokenException};
+use Auth0\SDK\Exception\{ConfigurationException};
 use Auth0\SDK\Token\ClientAssertionGenerator;
-use Auth0\SDK\Utility\{HttpClient, HttpResponse, Toolkit};
+use Auth0\SDK\Utility\{HttpClient, Toolkit};
 use Psr\Http\Message\ResponseInterface;
 
 use function is_array;

--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -8,7 +8,7 @@ use Auth0\SDK\API\Management\{Actions, AttackProtection, Blacklists, ClientGrant
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Contract\API\Management\{ActionsInterface, AttackProtectionInterface, BlacklistsInterface, ClientGrantsInterface, ClientsInterface, ConnectionsInterface, DeviceCredentialsInterface, EmailTemplatesInterface, EmailsInterface, GrantsInterface, GuardianInterface, JobsInterface, LogStreamsInterface, LogsInterface, OrganizationsInterface, ResourceServersInterface, RolesInterface, RulesInterface, StatsInterface, TenantsInterface, TicketsInterface, UserBlocksInterface, UsersByEmailInterface, UsersInterface};
 use Auth0\SDK\Contract\API\{AuthenticationInterface, ManagementInterface};
-use Auth0\SDK\Utility\{HttpClient, HttpRequest, HttpResponse, HttpResponsePaginator};
+use Auth0\SDK\Utility\{HttpClient, HttpResponse, HttpResponsePaginator};
 use Psr\Cache\CacheItemPoolInterface;
 
 use function is_array;


### PR DESCRIPTION
### Changes

Running "__composer phpcs__" highlights unused imports in the below files.
1.  [src/API/Authentication.php](https://github.com/auth0/auth0-PHP/compare/main...vishwac09:auth0-PHP:main#diff-32ff4a80e75d34c9a99695eeb43f0282a44126c391aff05fd34c7a30adca5c67)
2. [src/API/Management.php](https://github.com/auth0/auth0-PHP/compare/main...vishwac09:auth0-PHP:main#diff-60ca405803c26cf6dfc33e9ca7cd9e393b2055e1710bc9b9b6e290ab065bb0a0)

### References

N/A

### Testing

N/A