### PR TITLE
Decode HTML Entities on CookieStore Decrypt

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -113,7 +113,8 @@ final class CookieStore implements StoreInterface
 
         $decoded = rawurldecode((string) $data);
         $stripped = stripslashes($decoded);
-        $data = json_decode($stripped, true, 512);
+        $htmldecoded = html_entity_decode($stripped);
+        $data = json_decode($htmldecoded, true, 512);
 
         /** @var array{iv?: null|int|string, tag?: null|int|string, data: string} $data */
         if (! isset($data['iv']) || ! isset($data['tag']) || ! is_string($data['iv']) || ! is_string($data['tag'])) {


### PR DESCRIPTION
Decode HTML Entities on CookieStore Decrypt as some security frameworks add HTML Entity Encoding to received data.

### Changes

Decoding of HTML Entities performed from received cookie data , where a security framework has encoded them.

### References

Resolves #764

### Testing

Tested and running this in a production environment.

### Contributor Checklist

- [X] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [X] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
