### PR TITLE
Update callback verification in HttpRequest. 

### DIFF
--- a/src/Utility/HttpRequest.php
+++ b/src/Utility/HttpRequest.php
@@ -227,7 +227,7 @@ final class HttpRequest
 
             // Used for unit testing: if we're mocking responses and have a callback assigned, invoke that callback with our request and response.
             // @codeCoverageIgnoreStart
-            if ($mockedResponse && method_exists($mockedResponse, 'callback') && is_callable($mockedResponse->callback)) { // @phpstan-ignore-line
+            if ($mockedResponse && property_exists($mockedResponse, 'callback') && is_callable($mockedResponse->callback)) { // @phpstan-ignore-line
                 ($mockedResponse->callback)($httpRequest, $httpResponse);
             }
             // @codeCoverageIgnoreEnd

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -11,7 +11,7 @@ use Auth0\Tests\Utilities\MockDomain;
 
 uses()->group('utility', 'utility.http_client', 'networking');
 
-beforeEach(function (): void {
+beforeEach(function(): void {
     $this->config = new SdkConfiguration([
         'domain' => MockDomain::valid(),
         'cookieSecret' => uniqid(),
@@ -22,14 +22,13 @@ beforeEach(function (): void {
     $this->client = new HttpClient($this->config, HttpClient::CONTEXT_MANAGEMENT_CLIENT);
 
     $this->httpResponse200 = HttpResponseGenerator::create('{"status": "ok"}', 200);
-    $this->httpResponse429 = HttpResponseGenerator::create('{"error": "too_many_requests", "error_description": "Rate limit exceeded"}',
-        429);
+    $this->httpResponse429 = HttpResponseGenerator::create('{"error": "too_many_requests", "error_description": "Rate limit exceeded"}', 429);
 });
 
-test('a 429 response is not retried if httpMaxRetries is zero', function (): void {
+test('a 429 response is not retried if httpMaxRetries is zero', function(): void {
     $this->config->setHttpMaxRetries(0);
 
-    for ($i = 0; $i < 3; $i++) {
+    for ($i=0; $i < 3; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
@@ -44,15 +43,15 @@ test('a 429 response is not retried if httpMaxRetries is zero', function (): voi
     expect($requestCount)->toEqual(1);
 });
 
-test('a 429 response is not retried more than the hard cap', function (): void {
+test('a 429 response is not retried more than the hard cap', function(): void {
     $this->config->setHttpMaxRetries(HttpRequest::MAX_REQUEST_RETRIES * 2);
 
-    for ($i = 0; $i < 11; $i++) {
+    for ($i=0; $i < 11; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
     $response = $this->client->method('get')
-        ->addPath(['client'])
+    ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -62,21 +61,21 @@ test('a 429 response is not retried more than the hard cap', function (): void {
     expect($requestCount)->toEqual(10);
 });
 
-test('an exponential back-off and jitter are being applied', function (): void {
+test('an exponential back-off and jitter are being applied', function(): void {
     $this->config->setHttpMaxRetries(10);
 
     $baseWaits = [0];
     $baseWaitSum = 0;
 
-    for ($i = 0; $i < 10; $i++) {
+    for ($i=0; $i < 10; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
-        $baseWait = (int)(100 * pow(2, $i));
+        $baseWait = (int) (100 * pow(2, $i));
         $baseWaits[] = $baseWait;
         $baseWaitSum += $baseWait;
     }
 
     $response = $this->client->method('get')
-        ->addPath(['client'])
+    ->addPath(['client'])
         ->call();
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
@@ -135,15 +134,15 @@ test('an exponential back-off and jitter are being applied', function (): void {
     expect(array_sum($requestDelays))->toBeLessThanOrEqual(10000);
 });
 
-test('a request is tried 3 times before failing in the event of a 429', function (): void {
-    for ($i = 0; $i < 3; $i++) {
+test('a request is tried 3 times before failing in the event of a 429', function(): void {
+    for ($i=0; $i < 3; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
     $this->client->mockResponse(clone $this->httpResponse200);
 
     $response = $this->client->method('get')
-        ->addPath(['client'])
+    ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -153,7 +152,7 @@ test('a request is tried 3 times before failing in the event of a 429', function
     expect($requestCount)->toEqual(3);
 });
 
-test('a request recovers from a 429 response and returns the successful result', function (): void {
+test('a request recovers from a 429 response and returns the successful result', function(): void {
     $this->client->mockResponses([
         clone $this->httpResponse429,
         clone $this->httpResponse200,
@@ -161,7 +160,7 @@ test('a request recovers from a 429 response and returns the successful result',
     ]);
 
     $response = $this->client->method('get')
-        ->addPath(['client'])
+    ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(200);
@@ -172,7 +171,7 @@ test('a request recovers from a 429 response and returns the successful result',
 });
 
 
-test('the callback of a mock response is called', function (): void {
+test('the callback of a mock response is called', function(): void {
     $count = 0;
 
     $this->client->mockResponse(

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -51,7 +51,7 @@ test('a 429 response is not retried more than the hard cap', function(): void {
     }
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -75,7 +75,7 @@ test('an exponential back-off and jitter are being applied', function(): void {
     }
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
@@ -142,7 +142,7 @@ test('a request is tried 3 times before failing in the event of a 429', function
     $this->client->mockResponse(clone $this->httpResponse200);
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -160,7 +160,7 @@ test('a request recovers from a 429 response and returns the successful result',
     ]);
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(200);
@@ -169,7 +169,6 @@ test('a request recovers from a 429 response and returns the successful result',
 
     expect($requestCount)->toEqual(2);
 });
-
 
 test('the callback of a mock response is called', function(): void {
     $count = 0;

--- a/tests/Unit/Utility/HttpClientTest.php
+++ b/tests/Unit/Utility/HttpClientTest.php
@@ -11,7 +11,7 @@ use Auth0\Tests\Utilities\MockDomain;
 
 uses()->group('utility', 'utility.http_client', 'networking');
 
-beforeEach(function(): void {
+beforeEach(function (): void {
     $this->config = new SdkConfiguration([
         'domain' => MockDomain::valid(),
         'cookieSecret' => uniqid(),
@@ -22,13 +22,14 @@ beforeEach(function(): void {
     $this->client = new HttpClient($this->config, HttpClient::CONTEXT_MANAGEMENT_CLIENT);
 
     $this->httpResponse200 = HttpResponseGenerator::create('{"status": "ok"}', 200);
-    $this->httpResponse429 = HttpResponseGenerator::create('{"error": "too_many_requests", "error_description": "Rate limit exceeded"}', 429);
+    $this->httpResponse429 = HttpResponseGenerator::create('{"error": "too_many_requests", "error_description": "Rate limit exceeded"}',
+        429);
 });
 
-test('a 429 response is not retried if httpMaxRetries is zero', function(): void {
+test('a 429 response is not retried if httpMaxRetries is zero', function (): void {
     $this->config->setHttpMaxRetries(0);
 
-    for ($i=0; $i < 3; $i++) {
+    for ($i = 0; $i < 3; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
@@ -43,15 +44,15 @@ test('a 429 response is not retried if httpMaxRetries is zero', function(): void
     expect($requestCount)->toEqual(1);
 });
 
-test('a 429 response is not retried more than the hard cap', function(): void {
+test('a 429 response is not retried more than the hard cap', function (): void {
     $this->config->setHttpMaxRetries(HttpRequest::MAX_REQUEST_RETRIES * 2);
 
-    for ($i=0; $i < 11; $i++) {
+    for ($i = 0; $i < 11; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -61,21 +62,21 @@ test('a 429 response is not retried more than the hard cap', function(): void {
     expect($requestCount)->toEqual(10);
 });
 
-test('an exponential back-off and jitter are being applied', function(): void {
+test('an exponential back-off and jitter are being applied', function (): void {
     $this->config->setHttpMaxRetries(10);
 
     $baseWaits = [0];
     $baseWaitSum = 0;
 
-    for ($i=0; $i < 10; $i++) {
+    for ($i = 0; $i < 10; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
-        $baseWait = (int) (100 * pow(2, $i));
+        $baseWait = (int)(100 * pow(2, $i));
         $baseWaits[] = $baseWait;
         $baseWaitSum += $baseWait;
     }
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     $requestCount = $this->client->getLastRequest()->getRequestCount();
@@ -134,15 +135,15 @@ test('an exponential back-off and jitter are being applied', function(): void {
     expect(array_sum($requestDelays))->toBeLessThanOrEqual(10000);
 });
 
-test('a request is tried 3 times before failing in the event of a 429', function(): void {
-    for ($i=0; $i < 3; $i++) {
+test('a request is tried 3 times before failing in the event of a 429', function (): void {
+    for ($i = 0; $i < 3; $i++) {
         $this->client->mockResponse(clone $this->httpResponse429);
     }
 
     $this->client->mockResponse(clone $this->httpResponse200);
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(429);
@@ -152,7 +153,7 @@ test('a request is tried 3 times before failing in the event of a 429', function
     expect($requestCount)->toEqual(3);
 });
 
-test('a request recovers from a 429 response and returns the successful result', function(): void {
+test('a request recovers from a 429 response and returns the successful result', function (): void {
     $this->client->mockResponses([
         clone $this->httpResponse429,
         clone $this->httpResponse200,
@@ -160,7 +161,7 @@ test('a request recovers from a 429 response and returns the successful result',
     ]);
 
     $response = $this->client->method('get')
-    ->addPath(['client'])
+        ->addPath(['client'])
         ->call();
 
     expect(HttpResponse::getStatusCode($response))->toEqual(200);
@@ -168,4 +169,22 @@ test('a request recovers from a 429 response and returns the successful result',
     $requestCount = $this->client->getLastRequest()->getRequestCount();
 
     expect($requestCount)->toEqual(2);
+});
+
+
+test('the callback of a mock response is called', function (): void {
+    $count = 0;
+
+    $this->client->mockResponse(
+        clone $this->httpResponse200,
+        function ($request) use (&$count) {
+            $count++;
+        }
+    );
+
+    $response = $this->client->method('get')
+        ->addPath(['client'])
+        ->call();
+
+    expect($count)->toEqual(1);
 });


### PR DESCRIPTION
### Changes

'callback' is a property not a method of $mockedResponse

Changed the method_exists check to a property_exists check in the HttpRequest class. This adjustment ensures that 'callback' is an accessible property of the object before attempting to invoke it. This change improves code reliability, specifically for the cases where HttpRequest is used in unit tests with mock responses.

### References

[#768 Callback Never Called](https://github.com/auth0/auth0-PHP/issues/768)

### Testing

A test has been added to assert the fix is working as expected

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
