### PR TITLE
Adding client credentials support

### DIFF
--- a/src/API/Management/Clients.php
+++ b/src/API/Management/Clients.php
@@ -124,6 +124,11 @@ final class Clients extends ManagementEndpoint implements ClientsInterface
 
         /** @var array<null|int|string> $parameters */
 
+        // If the 'q' parameter is provided, ensure it's correctly passed in the query
+        if (isset($parameters['q'])) {
+            [$parameters['q']] = Toolkit::filter([$parameters['q']])->string()->trim();
+        }
+
         return $this->getHttpClient()
             ->method('get')
             ->addPath(['clients'])

--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -289,6 +289,7 @@ final class Organizations extends ManagementEndpoint implements OrganizationsInt
 
     public function getClientGrants(
         string $id,
+        string $grantIds,
         ?RequestOptions $options = null,
     ): ResponseInterface {
         [$id] = Toolkit::filter([$id])->string()->trim();
@@ -299,6 +300,7 @@ final class Organizations extends ManagementEndpoint implements OrganizationsInt
 
         return $this->getHttpClient()
             ->method('get')->addPath(['organizations', $id, 'client-grants'])
+            ->withParams(['grant_ids' => $grantIds])
             ->withOptions($options)
             ->call();
     }

--- a/src/API/Management/Organizations.php
+++ b/src/API/Management/Organizations.php
@@ -289,8 +289,8 @@ final class Organizations extends ManagementEndpoint implements OrganizationsInt
 
     public function getClientGrants(
         string $id,
-        string $grantIds,
         ?RequestOptions $options = null,
+        ?string $grantIds = null,
     ): ResponseInterface {
         [$id] = Toolkit::filter([$id])->string()->trim();
 

--- a/src/API/Management/ResourceServers.php
+++ b/src/API/Management/ResourceServers.php
@@ -80,10 +80,16 @@ final class ResourceServers extends ManagementEndpoint implements ResourceServer
 
     public function getAll(
         ?RequestOptions $options = null,
+        ?array $parameters = null,
     ): ResponseInterface {
+        [$parameters] = Toolkit::filter([$parameters])->array()->trim();
+
+        /** @var array<null|int|string> $parameters */
+
         return $this->getHttpClient()
             ->method('get')
             ->addPath(['resource-servers'])
+            ->withParams($parameters)
             ->withOptions($options)
             ->call();
     }

--- a/src/Contract/API/Management/OrganizationsInterface.php
+++ b/src/Contract/API/Management/OrganizationsInterface.php
@@ -230,16 +230,16 @@ interface OrganizationsInterface
      * Required scope: `read:organization_client_grants`.
      *
      * @param string              $id       Organization (by ID) that the connection is associated with
-     * @param string              $grantIds Client Grant (by ID) to associate with the organization.
      * @param null|RequestOptions $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these.)
+     * @param string              $grantIds Client Grant (by ID) to associate with the organization.
      *
      * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` or `connectionId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException  when the API request fails due to a network error
      */
     public function getClientGrants(
         string $id,
-        string $grantIds,
         ?RequestOptions $options = null,
+        ?string $grantIds = null,
     ): ResponseInterface;
 
     /**

--- a/src/Contract/API/Management/OrganizationsInterface.php
+++ b/src/Contract/API/Management/OrganizationsInterface.php
@@ -229,14 +229,16 @@ interface OrganizationsInterface
      * Get client grants associated to an organization.
      * Required scope: `read:organization_client_grants`.
      *
-     * @param string              $id      Organization (by ID) that the connection is associated with
-     * @param null|RequestOptions $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these.)
+     * @param string              $id       Organization (by ID) that the connection is associated with
+     * @param string              $grantIds Client Grant (by ID) to associate with the organization.
+     * @param null|RequestOptions $options  Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these.)
      *
      * @throws \Auth0\SDK\Exception\ArgumentException when an invalid `id` or `connectionId` are provided
      * @throws \Auth0\SDK\Exception\NetworkException  when the API request fails due to a network error
      */
     public function getClientGrants(
         string $id,
+        string $grantIds,
         ?RequestOptions $options = null,
     ): ResponseInterface;
 

--- a/src/Contract/API/Management/ResourceServersInterface.php
+++ b/src/Contract/API/Management/ResourceServersInterface.php
@@ -66,7 +66,8 @@ interface ResourceServersInterface
      * Get all Resource Servers, by page if desired.
      * Required scope: `read:resource_servers`.
      *
-     * @param null|RequestOptions $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     * @param null|RequestOptions        $options    Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     * @param null|int[]|null[]|string[] $parameters Optional. Additional query parameters to pass with the API request. See @see for supported options.
      *
      * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
      *
@@ -74,6 +75,7 @@ interface ResourceServersInterface
      */
     public function getAll(
         ?RequestOptions $options = null,
+        ?array $parameters = null,
     ): ResponseInterface;
 
     /**

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -493,7 +493,7 @@ test('addClientGrant() issues an appropriate request', function(): void {
 test('getClientGrants() issues an appropriate request', function(): void {
     $organization = 'org_' . uniqid();
 
-    $this->endpoint->getClientGrants($organization);
+    $this->endpoint->getClientGrants($organization, '');
 
     expect($this->api->getRequestMethod())->toEqual('GET');
     expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/organizations/' . $organization . '/client-grants');
@@ -507,4 +507,17 @@ test('removeClientGrant() issues an appropriate request', function(): void {
 
     expect($this->api->getRequestMethod())->toEqual('DELETE');
     expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/organizations/' . $organization . '/client-grants/' . $grant);
+});
+
+test('getClientGrants() issues an appropriate request with grant_ids', function (): void {
+    $orgId = uniqid();
+    $grantIds = 'cgr_12345,cgr_67890'; // Comma-separated grant IDs
+  
+    $this->endpoint->getClientGrants($orgId, $grantIds);
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/organizations/' . $orgId . '/client-grants');
+
+    $query = $this->api->getRequestQuery(null);
+    expect($query)->toContain('grant_ids=' . rawurlencode($grantIds));
 });

--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -493,7 +493,7 @@ test('addClientGrant() issues an appropriate request', function(): void {
 test('getClientGrants() issues an appropriate request', function(): void {
     $organization = 'org_' . uniqid();
 
-    $this->endpoint->getClientGrants($organization, '');
+    $this->endpoint->getClientGrants($organization, null , null);
 
     expect($this->api->getRequestMethod())->toEqual('GET');
     expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/organizations/' . $organization . '/client-grants');
@@ -513,7 +513,7 @@ test('getClientGrants() issues an appropriate request with grant_ids', function 
     $orgId = uniqid();
     $grantIds = 'cgr_12345,cgr_67890'; // Comma-separated grant IDs
   
-    $this->endpoint->getClientGrants($orgId, $grantIds);
+    $this->endpoint->getClientGrants($orgId, null, $grantIds);
 
     expect($this->api->getRequestMethod())->toEqual('GET');
     expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/organizations/' . $orgId . '/client-grants');

--- a/tests/Unit/API/Management/ResourceServersTest.php
+++ b/tests/Unit/API/Management/ResourceServersTest.php
@@ -73,3 +73,27 @@ test('delete() issues an appropriate request', function(string $id): void {
 })->with(['mocked id' => [
     fn() => uniqid(),
 ]]);
+
+test('getAll() issues an appropriate request with identifiers array', function(): void {
+    $identifiers = ['https://tst.api.com/api/v1/', 'https://tst.api.com/api/v2/'];
+    
+    $this->endpoint->getAll(null, ['identifiers' => $identifiers]);
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/resource-servers');
+
+    expect($this->api->getRequestUrl())->toContain(rawurlencode('identifiers[0]') .'='. rawurlencode('https://tst.api.com/api/v1/'));
+    expect($this->api->getRequestUrl())->toContain(rawurlencode('identifiers[1]') .'='. rawurlencode('https://tst.api.com/api/v2/'));
+});
+
+test('getAll() supports checkpoint pagination parameters', function(): void {
+    $this->paginatedRequest->setFrom('indexIdentifier')->setTake(50);
+    
+    $this->endpoint->getAll($this->requestOptions, null);
+
+    expect($this->api->getRequestMethod())->toEqual('GET');
+    expect($this->api->getRequestUrl())->toStartWith('https://' . $this->api->mock()->getConfiguration()->getDomain() . '/api/v2/resource-servers');
+
+    expect($this->api->getRequestQuery())->toContain('&from=indexIdentifier');
+    expect($this->api->getRequestQuery())->toContain('&take=50');
+});


### PR DESCRIPTION
### Changes

- Support for Default Organisation in clients

    a.  Added new field default_organization to GET/PATCH endpoints /api/v2/clients/{id}
    b. Added new field default_organization to POST endpoints /api/v2/clients/

- Support query param q for GET /api/v2/clients

    a. q=client_grant.organization_id:org_<uniq_id>
    b. q=client_grant.allow_any_organization:true

- Support query param grant_ids for GET /api/v2/organizations/{org_id}/client-grants

- Support query param identifiers for GET /api/v2/resource-servers

### References

[Management API Documentation](https://sus.auth0.com/docs/api/management/v2/organizations/post-organizations)
[Internal Reference](https://oktawiki.atlassian.net/wiki/spaces/IAMPS/pages/3052704289/Organizations+for+Client+Credentials+GA+SDK+Changes)

### Testing

Added test cases for testing above end-points.
Tested the implementation manually according to this [internal document](https://oktawiki.atlassian.net/wiki/spaces/IAMPS/pages/3028125865/Demo+-+Default+Organizations)


- [x] This change adds unit test coverage

- [] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
