### PR TITLE
Adding Support For CYOK

### DIFF
--- a/src/API/Management.php
+++ b/src/API/Management.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Auth0\SDK\API;
 
-use Auth0\SDK\API\Management\{Actions, AttackProtection, Blacklists, ClientGrants, Clients, Connections, DeviceCredentials, EmailTemplates, Emails, Grants, Guardian, Jobs, LogStreams, Logs, Organizations, ResourceServers, Roles, Rules, Stats, Tenants, Tickets, UserBlocks, Users, UsersByEmail};
+use Auth0\SDK\API\Management\{Actions, AttackProtection, Blacklists, ClientGrants, Clients, Connections, DeviceCredentials, EmailTemplates, Emails, Grants, Guardian, Jobs, Keys, LogStreams, Logs, Organizations, ResourceServers, Roles, Rules, Stats, Tenants, Tickets, UserBlocks, Users, UsersByEmail};
 use Auth0\SDK\Configuration\SdkConfiguration;
-use Auth0\SDK\Contract\API\Management\{ActionsInterface, AttackProtectionInterface, BlacklistsInterface, ClientGrantsInterface, ClientsInterface, ConnectionsInterface, DeviceCredentialsInterface, EmailTemplatesInterface, EmailsInterface, GrantsInterface, GuardianInterface, JobsInterface, LogStreamsInterface, LogsInterface, OrganizationsInterface, ResourceServersInterface, RolesInterface, RulesInterface, StatsInterface, TenantsInterface, TicketsInterface, UserBlocksInterface, UsersByEmailInterface, UsersInterface};
+use Auth0\SDK\Contract\API\Management\{ActionsInterface, AttackProtectionInterface, BlacklistsInterface, ClientGrantsInterface, ClientsInterface, ConnectionsInterface, DeviceCredentialsInterface, EmailTemplatesInterface, EmailsInterface, GrantsInterface, GuardianInterface, JobsInterface, KeysInterface, LogStreamsInterface, LogsInterface, OrganizationsInterface, ResourceServersInterface, RolesInterface, RulesInterface, StatsInterface, TenantsInterface, TicketsInterface, UserBlocksInterface, UsersByEmailInterface, UsersInterface};
 use Auth0\SDK\Contract\API\{AuthenticationInterface, ManagementInterface};
 use Auth0\SDK\Utility\{HttpClient, HttpResponse, HttpResponsePaginator};
 use Psr\Cache\CacheItemPoolInterface;
@@ -180,6 +180,11 @@ final class Management extends ClientAbstract implements ManagementInterface
     public function jobs(): JobsInterface
     {
         return Jobs::instance($this->getHttpClient());
+    }
+
+    public function keys(): KeysInterface
+    {
+        return Keys::instance($this->getHttpClient());
     }
 
     public function logs(): LogsInterface

--- a/src/API/Management/Keys.php
+++ b/src/API/Management/Keys.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\API\Management;
+
+use Auth0\SDK\Contract\API\Management\KeysInterface;
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Handles requests to the Keys endpoint of the v2 Management API.
+ *
+ * @see https://auth0.com/docs/api/management/v2/keys
+ */
+final class Keys extends ManagementEndpoint implements KeysInterface
+{
+    public function postEncryptionRekey(
+        ?RequestOptions $options = null,
+    ): ResponseInterface {
+        return $this->getHttpClient()
+            ->method('post')
+            ->addPath(['keys', 'encryption', 'rekey'])
+            ->withOptions($options)
+            ->call();
+    }
+}

--- a/src/Contract/API/Management/KeysInterface.php
+++ b/src/Contract/API/Management/KeysInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\SDK\Contract\API\Management;
+
+use Auth0\SDK\Utility\Request\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+interface KeysInterface
+{
+    /**
+     * Perform rekeying operation on the key hierarchy.
+     * Required scope: `create:encryption_keys`, `update:encryption_keys`.
+     *
+     * @param null|RequestOptions $options Optional. Additional request options to use, such as a field filtering or pagination. (Not all endpoints support these. See @see for supported options.)
+     *
+     * @throws \Auth0\SDK\Exception\NetworkException when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/api/management/v2#!/keys/post-encryption-rekey
+     */
+    public function postEncryptionRekey(
+        ?RequestOptions $options = null,
+    ): ResponseInterface;
+}

--- a/tests/Unit/API/Management/KeysTest.php
+++ b/tests/Unit/API/Management/KeysTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Auth0\SDK\Exception\ArgumentException;
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Utility\HttpClient;
+use Auth0\SDK\Utility\HttpRequest;
+use Auth0\SDK\Utility\HttpResponse;
+use Auth0\Tests\Utilities\HttpResponseGenerator;
+use Auth0\Tests\Utilities\MockDomain;
+
+uses()->group('management', 'management.keys');
+
+beforeEach(function(): void {
+    $this->config = new SdkConfiguration([
+        'domain' => MockDomain::valid(),
+        'cookieSecret' => uniqid(),
+        'clientId' => uniqid(),
+        'redirectUri' => uniqid()
+    ]);
+
+    $this->client = new HttpClient($this->config, HttpClient::CONTEXT_MANAGEMENT_CLIENT);
+    $this->endpoint = $this->api->mock()->keys();
+});
+
+test('postEncryptionRekey() issues an appropriate request', function(): void {
+
+    $this->endpoint->postEncryptionRekey();
+
+    $a =$this->api->getRequestUrl();
+    print_r($a);
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/keys/encryption/rekey');
+
+    $headers = $this->api->getRequestHeaders();
+    expect($headers['Content-Type'][0])->toEqual('application/json');
+});
+
+test('postEncryptionRekey() returns 204 on success', function(): void {
+
+    // Mock the API response for successful rekey with status 204
+    $this->httpResponse204 = HttpResponseGenerator::create('success', 204);
+
+    // Mock the client to return the mocked 204 response
+    $this->client->mockResponse($this->httpResponse204);
+    $response = $this->client->method('post')
+        ->addPath(['keys', 'encryption', 'rekey'])
+        ->call();
+    expect($response->getStatusCode())->toEqual(204);
+});

--- a/tests/Unit/API/Management/KeysTest.php
+++ b/tests/Unit/API/Management/KeysTest.php
@@ -28,8 +28,6 @@ test('postEncryptionRekey() issues an appropriate request', function(): void {
 
     $this->endpoint->postEncryptionRekey();
 
-    $a =$this->api->getRequestUrl();
-    print_r($a);
     expect($this->api->getRequestMethod())->toEqual('POST');
     expect($this->api->getRequestUrl())->toEndWith('/api/v2/keys/encryption/rekey');
 
@@ -39,10 +37,10 @@ test('postEncryptionRekey() issues an appropriate request', function(): void {
 
 test('postEncryptionRekey() returns 204 on success', function(): void {
 
-    // Mock the API response for successful rekey with status 204
+    // Mocked the API response for successful rekey with status 204
     $this->httpResponse204 = HttpResponseGenerator::create('success', 204);
 
-    // Mock the client to return the mocked 204 response
+    // Mocked the client to return the mocked 204 response
     $this->client->mockResponse($this->httpResponse204);
     $response = $this->client->method('post')
         ->addPath(['keys', 'encryption', 'rekey'])


### PR DESCRIPTION
### Changes

- Added postEncryptionRekey() method in KeysManager related to the /keys/encryption/rekey endpoint.

### References

- [Public docs](https://auth0.com/docs/secure/highly-regulated-identity/customer-managed-keys#control-your-own-key)

- [API docs](https://auth0.com/docs/api/management/v2/keys/post-encryption-rekey#scopes)

### Testing

- [x] This change adds test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
