### PR TITLE
Validation Test Case For Show as Button Parameter

### DIFF
--- a/tests/Unit/API/Management/OrganizationsTest.php
+++ b/tests/Unit/API/Management/OrganizationsTest.php
@@ -521,3 +521,36 @@ test('getClientGrants() issues an appropriate request with grant_ids', function 
     $query = $this->api->getRequestQuery(null);
     expect($query)->toContain('grant_ids=' . rawurlencode($grantIds));
 });
+
+test('create() issues an appropriate request with show as button parameter in enabled connections', function(): void {
+    $mock = (object) [
+        'id' => uniqid(),
+        'name' => uniqid(),
+        'branding' => [
+            'logo_url' => uniqid(),
+        ],
+        'metadata' => [
+            'test' => uniqid()
+        ],
+        'body' => [
+            'enabled_connections' => [
+                'connection_id' => uniqid(),
+                'show_as_button' => true
+            ]
+        ]
+    ];
+
+    $this->endpoint->create($mock->id, $mock->name, $mock->branding, $mock->metadata, $mock->body);
+
+    expect($this->api->getRequestMethod())->toEqual('POST');
+    expect($this->api->getRequestUrl())->toEndWith('/api/v2/organizations');
+
+    $body = $this->api->getRequestBody();
+
+    $this->assertArrayHasKey('enabled_connections', $body);
+    $this->assertArrayHasKey('show_as_button', $body['enabled_connections']);
+    expect($body['enabled_connections']['show_as_button'])->toEqual($mock->body['enabled_connections']['show_as_button']);
+
+    $body = $this->api->getRequestBodyAsString();
+    expect($body)->toEqual(json_encode(array_merge(['name' => $mock->id, 'display_name' => $mock->name, 'branding' => $mock->branding, 'metadata' => $mock->metadata], $mock->body)));
+});


### PR DESCRIPTION
### Changes

- Added a test case for newly added `show_as_button parameter` in the [Organization Post API ](https://auth0.com/docs/api/management/v2/organizations/post-organizations)

### References

-[Organization Post API ](https://auth0.com/docs/api/management/v2/organizations/post-organizations)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
