### PR TITLE
docs: Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ We drop support for PHP versions when they reach end-of-life and cease receiving
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:
 
-- [Contribution Guide](./CONTRIBUTING.md)
+- [Contribution Guide](./.github/CONTRIBUTING.md)
 - [Auth0's General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 - [Auth0's Code of Conduct Guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We also have tailored SDKs for [Laravel](https://github.com/auth0/laravel-auth0)
 Ensure you have [the necessary dependencies](#requirements) installed, then add the SDK to your application using [Composer](https://getcomposer.org/):
 
 ```
-composer require auth0/auth0-php --no-dev
+composer require auth0/auth0-php
 ```
 
 ### Configure Auth0


### PR DESCRIPTION
### Changes

- The link to the contribution guide didn't work anymore after the file had been removed.
- `composer require` doesn't have a `--no-dev` option. There's `--update-no-dev`, but its behavior doesn't make sense in this case.

### References

https://getcomposer.org/doc/03-cli.md#require-r

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
