### PR TITLE
Conservative update of composer.json require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
   "homepage": "https://github.com/auth0/auth0-PHP",
   "require": {
     "php": "^8.1",
-    "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "php-http/multipart-stream-builder": "^1",
@@ -42,15 +41,15 @@
     "ergebnis/composer-normalize": "~2.43.0",
     "friendsofphp/php-cs-fixer": "~3.59.0",
     "mockery/mockery": "~1.6.0",
-    "pestphp/pest": "~2.34.0",
-    "phpstan/phpstan": "~1.11.0",
+    "pestphp/pest": "~2.35.0",
+    "phpstan/phpstan": "~1.12.0",
     "phpstan/phpstan-strict-rules": "~1.6.0",
     "psr-mock/http": "~1.0.0",
     "rector/rector": "~0.17.0",
     "spatie/ray": "~1.41.0",
-    "symfony/cache": "^4 || ^5 || ^6",
-    "symfony/event-dispatcher": "^4 || ^5 || ^6",
-    "vimeo/psalm": "~5.25.0",
+    "symfony/cache": "^5.4 || ^6.4",
+    "symfony/event-dispatcher": "^5.4 || ^6.4",
+    "vimeo/psalm": "~5.26.0",
     "wikimedia/composer-merge-plugin": "~2.1.0"
   },
   "suggest": {


### PR DESCRIPTION
### Changes

- Specifying ext-json is no longer needed since PHP8.0. Explained here: https://php.watch/versions/8.0/ext-json . Fixes https://github.com/auth0/auth0-PHP/issues/791
- pestphp/pest: 2.34 -> 2.35. (2.36 upgrades indirect dependencies and needs a test fix)
- phpstan/phpstan: 1.11 -> 1.12
- symfony: v4 no longer has security versions. Only 5.4 and 6.4 still do.
- vimeo/psalm: 5.25 -> 5.26

This is a very conservative update, without changes to any other file, just raising the bare minimum versions.
It's probably wise to do major upgrades of at least Rector and PHPStan in a next PR. Especially Rector v1 would require a big config change. Rector 0 blocks upgrades of PHPStan.

### References

Fixes https://github.com/auth0/auth0-PHP/issues/791

### Testing

The tests still pass.

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
