### PR TITLE
Remove unused variable '$token'

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -202,7 +202,6 @@ final class Auth0 implements Auth0Interface
         }
 
         $response = HttpResponse::decodeContent($response);
-        $token = null;
 
         /** @var array{access_token?: string, scope?: string, refresh_token?: string, id_token?: string, expires_in?: int|string} $response */
         if (isset($response['id_token'])) {


### PR DESCRIPTION
Remove unused variable '$token' from Auth0.php.

### Changes

<!--
  Please outline the changes made in this pull request.
-->

### References

<!--
  Link to any associated issues, pull requests, or other resources.
-->

### Testing

<!--
  Tests must be added for new functionality.
  Existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

- [x] I agree to adhere to the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I agree to uphold the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
