### PR TITLE
fix: regenerate session ID on login and logout to prevent session fixation

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -9,6 +9,7 @@ use Auth0\SDK\Configuration\{SdkConfiguration, SdkState};
 use Auth0\SDK\Contract\API\{AuthenticationInterface, ManagementInterface};
 use Auth0\SDK\Contract\{Auth0Interface, StoreInterface, TokenInterface};
 use Auth0\SDK\Exception\ConfigurationException;
+use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Utility\{HttpResponse, PKCE, Toolkit, TransientStoreHandler};
 use Throwable;
 
@@ -264,6 +265,14 @@ final class Auth0 implements Auth0Interface
         /** @var null|array<array<mixed>|int|string> $user */
         $this->setUser($user ?? []);
         $this->deferStateSaving(false);
+
+        // Rotate the session ID now that the auth state has changed, to prevent
+        // session fixation. Only applies when using PHP session-backed storage.
+        $sessionStorage = $this->configuration()->getSessionStorage();
+
+        if ($sessionStorage instanceof SessionStore) {
+            $sessionStorage->regenerate();
+        }
 
         return true;
     }
@@ -588,6 +597,14 @@ final class Auth0 implements Auth0Interface
         }
 
         $this->clear();
+
+        // Rotate the session ID on logout so a new ID is issued for the next
+        // authentication, preventing session fixation across login/logout cycles.
+        $sessionStorage = $this->configuration()->getSessionStorage();
+
+        if ($sessionStorage instanceof SessionStore) {
+            $sessionStorage->regenerate();
+        }
 
         return $this->authentication()->getLogoutLink($returnUri, $params);
     }

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -111,6 +111,22 @@ final readonly class SessionStore implements StoreInterface
     }
 
     /**
+     * Regenerate the session ID while preserving session data.
+     * Called on authentication state changes to prevent session fixation.
+     */
+    public function regenerate(): void
+    {
+        $this->start();
+
+        // @codeCoverageIgnoreStart
+        if (! defined('AUTH0_TESTS_DIR') && PHP_SESSION_ACTIVE === session_status()) {
+            session_regenerate_id(true);
+        }
+
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
      * Persists $value on $_SESSION, identified by $key.
      *
      * @param string $key   session key to set

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -11,6 +11,7 @@ use Auth0\SDK\Contract\TokenInterface;
 use Auth0\SDK\Exception\ConfigurationException;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Exception\StateException;
+use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Token;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
 use Auth0\Tests\Utilities\TokenGenerator;
@@ -369,6 +370,21 @@ test('logout() returns a a valid logout url', function(): void {
             ->toContain('returnTo=' . $returnUrl)
             ->toContain('client_id=' . $this->configuration['clientId'])
             ->toContain('rand=' . $randomParam);
+});
+
+test('logout() succeeds when using SessionStore', function(): void {
+    $auth0 = new Auth0($this->configuration);
+    $auth0->configuration()->setSessionStorage(new SessionStore($auth0->configuration()));
+
+    $returnUrl = uniqid();
+
+    $url = parse_url($auth0->logout($returnUrl));
+
+    expect($url)
+        ->scheme->toEqual('https')
+        ->host->toEqual($this->configuration['domain'])
+        ->path->toEqual('/v2/logout')
+        ->query->toContain('returnTo=' . $returnUrl);
 });
 
 test('getBackchannel() retrieves a setBackchannel() assignment', function(): void {
@@ -760,6 +776,28 @@ test('exchange() succeeds with a valid id token', function(): void {
     expect($auth0->getAccessTokenScope())->toEqual(['test:part1','test:part2','test:part3']);
     expect($auth0->getAccessTokenExpiration())->toBeGreaterThan(time());
     expect($auth0->getRefreshToken())->toEqual('4.5.6');
+});
+
+test('exchange() succeeds and regenerates the session when using SessionStore', function(): void {
+    $auth0 = new Auth0($this->configuration);
+    $auth0->configuration()->setSessionStorage(new SessionStore($auth0->configuration()));
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6"}'),
+        HttpResponseGenerator::create('{"sub":"__test_sub__"}'),
+    ]);
+
+    $_GET['code'] = uniqid();
+    $_GET['state'] = '__test_state__';
+
+    $auth0->configuration()->getTransientStorage()->set('state', '__test_state__');
+    $auth0->configuration()->getTransientStorage()->set('code_verifier', '__test_code_verifier__');
+
+    expect($auth0->exchange())->toBeTrue();
+    expect($auth0->getUser()['sub'])->toEqual('__test_sub__');
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
 });
 
 test('exchange() succeeds with no id token', function(): void {

--- a/tests/Unit/Store/SessionStoreTest.php
+++ b/tests/Unit/Store/SessionStoreTest.php
@@ -74,3 +74,15 @@ test('purge() clears values as expected', function(string $key, string $value): 
     fn() => uniqid(),
     fn() => uniqid(),
 ]]);
+
+test('regenerate() preserves stored values', function(string $key, string $value): void {
+    $this->store->set($key, $value);
+    expect($this->store->get($key))->toEqual($value);
+
+    $this->store->regenerate();
+
+    expect($this->store->get($key))->toEqual($value);
+})->with(['mocked data' => [
+    fn() => uniqid(),
+    fn() => uniqid(),
+]]);


### PR DESCRIPTION
### Changes

The `SessionStore` never called `session_regenerate_id()` at any point in the authentication lifecycle. When an application uses PHP native sessions for storage, the `PHPSESSID` a browser holds before authentication was reused unchanged after `exchange()` stored the tokens and user profile - meaning a session identifier established prior to login remained valid for the authenticated session. This is a session fixation weakness.

This PR rotates the session identifier whenever the authentication state changes:

**🔒 Security Fix:**

- Added a `regenerate()` method to `SessionStore` that calls `session_regenerate_id(true)`, issuing a fresh `PHPSESSID` and destroying the previous session so a pre-authentication identifier cannot be replayed
- `Auth0::exchange()` now regenerates the session ID after a successful token exchange (login)
- `Auth0::logout()` now regenerates the session ID after clearing session data, so a fresh identifier is issued for the next authentication
- Regeneration is gated behind an `instanceof SessionStore` check, so the default `CookieStore` and any custom `StoreInterface` implementations are untouched

### Breaking Changes

This affects only applications that have explicitly configured `SessionStore` (PHP native sessions) as their session storage. The default `CookieStore` is unaffected.

For those applications, the `PHPSESSID` cookie value now changes on login (`exchange()`) and on `logout()`. Existing session data is preserved and users remain authenticated across the rotation. However, any external state keyed to the literal pre-rotation session ID - for example a separately established WebSocket handshake, a background job, or a cached reference to the old `PHPSESSID` - will no longer resolve after login or logout and must be re-read from the current session ID.

No migration is required for applications using the default cookie-based storage.

### Testing

- Added `regenerate() preserves stored values` to the `SessionStore` unit tests
- Added integration tests asserting `exchange()` and `logout()` succeed when `SessionStore` is the configured session storage

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)