### PR TITLE
chore: fix PHPStan and Rector failures from newer tool versions on v9

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,6 +193,12 @@ parameters:
 			path: src/Token/Verifier.php
 
 		-
+			message: '#^Casting to \*NEVER\* something that''s already \*NEVER\*\.$#'
+			identifier: cast.useless
+			count: 2
+			path: src/Token/Verifier.php
+
+		-
 			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Utility/Assert.php
+++ b/src/Utility/Assert.php
@@ -51,9 +51,6 @@ final class Assert
     }
 
     /**
-     * @param mixed $name
-     * @param mixed $arguments
-     *
      * @throws BadMethodCallException
      */
     public static function __callStatic(string $name, array $arguments): void
@@ -6643,7 +6640,7 @@ final class Assert
      */
     public static function positiveInteger($value, $message = ''): void
     {
-        if (! (is_int($value) && $value > 0)) {
+        if (! is_int($value) || $value <= 0) {
             self::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a positive integer. Got: %s',
                 self::valueToString($value),


### PR DESCRIPTION
### Changes

CI installs its dev tools (PHPStan and Rector) from open version ranges and there is no committed `composer.lock`, so it recently pulled in newer versions of both. Those newer versions flag existing code that was fine before, which is why the PHPStan and Rector jobs started failing on `v9` even on unrelated changes. This PR settles both.

**PHPStan**

The newer PHPStan now sees that inside the HMAC and RSA branches of `Token\Verifier::verify()`, the `$alg` value can only be one of the known algorithm constants. That makes the `default => throw` arm of each inner `match` look unreachable, so it reports two "Casting to NEVER something that's already NEVER" errors in `src/Token/Verifier.php`. Those `default` arms are deliberate guards against a bad `alg` header, so we keep them and add the two findings to `phpstan-baseline.neon`, the same way the other similar findings in this file are already handled.

**Rector**

In `src/Utility/Assert.php`, the newer Rector removes two `@param mixed` doc tags that the native parameter types already cover, and rewrites one negated condition in `positiveInteger()` to a simpler form. Neither changes behavior; this is just the cleanup the newer Rector applies under the rules the repo already uses.

### Testing

Ran `composer phpstan`, `composer rector`, `composer phpcs`, and `composer psalm` against the same tool versions CI resolves. All pass with no errors.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)