### PR TITLE
chore: resolve Rector rule conflict from newer tool versions

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
@@ -10,6 +11,8 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         __DIR__ . '/src/API/Management',
+        // Conflicts with RemoveDefaultValueFromAssignedPropertyRector on properties initialized in the constructor.
+        InlineConstructorDefaultToPropertyRector::class,
     ])
     ->withPhpSets(php82: true)
     ->withPreparedSets(

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -90,7 +90,7 @@ final class CookieStore implements StoreInterface
      *
      * @var array<mixed>
      */
-    private array $store = [];
+    private array $store;
 
     /**
      * CookieStore constructor.
@@ -104,6 +104,7 @@ final class CookieStore implements StoreInterface
         private readonly SdkConfiguration $configuration,
         private readonly string $namespace = 'auth0',
     ) {
+        $this->store = [];
         $this->getState();
     }
 

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -17,7 +17,7 @@ final class Parser
     /**
      * State.
      */
-    private bool $parsed = false;
+    private bool $parsed;
 
     /**
      * Decoded claims contained within the JWT.
@@ -62,6 +62,7 @@ final class Parser
         private readonly SdkConfiguration $configuration,
         private readonly string $token,
     ) {
+        $this->parsed = false;
         $this->parse();
     }
 


### PR DESCRIPTION
### Changes

CI installs its dev tools from open version ranges and there is no committed `composer.lock`, so it recently pulled in a newer Rector. That version enables two rules that contradict each other on the same code, which is why the Rector job started failing on `v9` even on unrelated changes.

- `RemoveDefaultValueFromAssignedPropertyRector` wants the default removed from a property that the constructor assigns, while `InlineConstructorDefaultToPropertyRector` wants that same default moved back onto the property. No arrangement satisfies both, so the job fails whichever way the code is written.
- This affected `src/Store/CookieStore.php` (`$store`) and `src/Token/Parser.php` (`$parsed`), where each property is read inside a method the constructor calls before it would otherwise be assigned.
- Skipped `InlineConstructorDefaultToPropertyRector` and kept `RemoveDefaultValueFromAssignedPropertyRector`. `InlineConstructorDefaultToPropertyRector` is a stable rule that is safe to reference in `withSkip()`, whereas the other rule is absent from some resolved Rector versions and referencing it there would itself error.
- Both properties are now initialized in the constructor before they are read, so the retained rule is satisfied and behavior is unchanged.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)