### PR TITLE
feat: add Custom Token Exchange support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -158,7 +158,7 @@ $response = $auth0->authentication()->customTokenExchange(
 );
 ```
 
-When you establish a session with `loginWithCustomTokenExchange()`, the `act` claim is read from the returned ID token and surfaced on the session user, so you can read it back later via `getUser()`.
+When you establish a session with `loginWithCustomTokenExchange()`, the session user is populated from all claims on the returned ID token, so the `act` claim is available through `getUser()` alongside the rest.
 
 ```PHP
 $auth0->loginWithCustomTokenExchange(
@@ -176,6 +176,9 @@ if (isset($user['act'])) {
 
 > [!IMPORTANT]
 > When an actor token is used, Auth0 does not issue a refresh token, even if `offline_access` is in the scope. For `loginWithCustomTokenExchange()` this means the session cannot be silently renewed once the access token expires, so re-run the exchange to obtain new tokens.
+
+> [!NOTE]
+> A session established with `loginWithCustomTokenExchange()` participates in back-channel logout the same way an interactive login does, provided the returned ID token carries a `sub` and `iss`. Enforcement across requests requires `backchannelLogoutCache` to be a shared, persistent PSR-6 pool, so a logout queued on one request is seen on the next.
 
 ### Organization support
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -104,6 +104,114 @@ $api->emailPasswordlessStart(
 );
 ```
 
+## Custom Token Exchange
+
+[Custom Token Exchange](https://auth0.com/docs/authenticate/custom-token-exchange) ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) exchanges an external or legacy token for Auth0 tokens without a browser redirect. The SDK exposes two methods, depending on whether you want a session.
+
+Use `Auth0->authentication()->customTokenExchange()` to perform the exchange and get the raw token response back with no session side effects. This suits delegation and machine-to-machine scenarios.
+
+```PHP
+use Auth0\SDK\Auth0;
+use Auth0\SDK\Utility\HttpResponse;
+
+$auth0 = new Auth0($configuration);
+
+$response = $auth0->authentication()->customTokenExchange(
+    subjectToken: 'external-token-value',
+    subjectTokenType: 'urn:acme:mcp-token',
+    params: [
+        'audience' => 'https://api.example.com',
+        'scope' => 'read:data write:data',
+    ],
+);
+
+$tokens = HttpResponse::decodeContent($response);
+echo $tokens['access_token'];
+```
+
+`subjectTokenType` must be a valid URI. Any custom scheme is accepted (for example `urn:acme:mcp-token` or `custom:legacy-token`), so you can use your own namespace. A blank token or type, a `Bearer ` prefix on the token, or a non-URI type throws an `ArgumentException` before any network call.
+
+Use `Auth0->loginWithCustomTokenExchange()` to perform the same exchange and persist the result as a session, logging the user in. After it succeeds, `isAuthenticated()`, `getUser()`, and `getAccessToken()` work immediately. This method requires a stateful `strategy` with sessions configured.
+
+```PHP
+$auth0->loginWithCustomTokenExchange(
+    subjectToken: 'external-token-value',
+    subjectTokenType: 'urn:acme:mcp-token',
+);
+
+$user = $auth0->getUser();
+```
+
+> [!NOTE]
+> The session user is populated from the returned ID token, so your Token Exchange Profile must issue one. When you do not pass a `scope`, the SDK sends its configured `scope` on the exchange so Auth0 returns an ID token. Make sure that scope includes `openid`.
+
+### Actor tokens (delegation)
+
+Both methods accept an optional `actorToken` and `actorTokenType` for delegation, where one party acts on behalf of a user. Auth0 records the acting party in the [`act` claim](https://datatracker.ietf.org/doc/html/rfc8693#section-4.1) on the issued tokens. The two must be supplied together, and `actorTokenType` follows the same URI rules as `subjectTokenType`.
+
+```PHP
+$response = $auth0->authentication()->customTokenExchange(
+    subjectToken: 'user-token-value',
+    subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+    actorToken: 'service-token-value',
+    actorTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+);
+```
+
+When you establish a session with `loginWithCustomTokenExchange()`, the `act` claim is read from the returned ID token and surfaced on the session user, so you can read it back later via `getUser()`.
+
+```PHP
+$auth0->loginWithCustomTokenExchange(
+    subjectToken: 'user-token-value',
+    subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+    actorToken: 'service-token-value',
+    actorTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+);
+
+$user = $auth0->getUser();
+if (isset($user['act'])) {
+    echo $user['act']['sub'];
+}
+```
+
+> [!IMPORTANT]
+> When an actor token is used, Auth0 does not issue a refresh token, even if `offline_access` is in the scope. For `loginWithCustomTokenExchange()` this means the session cannot be silently renewed once the access token expires, so re-run the exchange to obtain new tokens.
+
+### Organization support
+
+Pass an organization through `$params` to scope the exchange to it.
+
+```PHP
+$response = $auth0->authentication()->customTokenExchange(
+    subjectToken: 'external-token-value',
+    subjectTokenType: 'urn:acme:mcp-token',
+    params: [
+        'organization' => 'org_abc123',
+    ],
+);
+```
+
+> [!NOTE]
+> The `grant_type`, `client_id`, `subject_token`, `subject_token_type`, `actor_token`, and `actor_token_type` keys are controlled by the SDK and cannot be overridden through `$params`.
+
+### Error handling
+
+API errors from the token endpoint (for example `invalid_grant`) surface through the response, which you can inspect with `HttpResponse::wasSuccessful()`. Client-side validation failures throw `Auth0\SDK\Exception\ArgumentException` before any request is made.
+
+```PHP
+use Auth0\SDK\Utility\HttpResponse;
+
+$response = $auth0->authentication()->customTokenExchange(
+    subjectToken: 'external-token-value',
+    subjectTokenType: 'urn:acme:mcp-token',
+);
+
+if (! HttpResponse::wasSuccessful($response)) {
+    $error = HttpResponse::decodeContent($response);
+    echo $error['error'] ?? 'unknown_error';
+}
+```
+
 ## Management API
 
 Use the `ManagementClient` wrapper for automatic token management when interacting with the Management API.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,17 @@ $response = $auth->refreshToken(refreshToken: $refreshToken);
 // Client credentials (M2M) authentication
 $response = $auth->clientCredentials();
 
+// Exchange an external or custom token for Auth0 tokens (RFC 8693)
+$response = $auth->customTokenExchange(
+    subjectToken: 'external-token-value',
+    subjectTokenType: 'urn:acme:mcp-token',
+);
+
 // Get logout URL
 $logoutUrl = $auth->getLogoutLink(returnTo: 'http://localhost:3000');
 ```
+
+> See [EXAMPLES.md](./EXAMPLES.md#custom-token-exchange) for Custom Token Exchange, including session login and actor-token delegation.
 
 ### Database Connection Operations
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,15 @@
 
 ### Authentication API
 
+#### New: Custom Token Exchange
+
+v9 adds support for [Custom Token Exchange](https://auth0.com/docs/authenticate/custom-token-exchange) ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)), which exchanges an external or legacy token for Auth0 tokens without a browser redirect. Two methods are available:
+
+- `Authentication::customTokenExchange()` performs the exchange and returns the raw token response, with no session side effects. Use it for delegation and machine-to-machine scenarios.
+- `Auth0::loginWithCustomTokenExchange()` performs the exchange and persists the result as a session, logging the user in.
+
+Both accept optional `actorToken` and `actorTokenType` parameters for delegation, validate that the token types are valid URIs, and support organizations. This is a new capability, so no changes are required to existing code. See [EXAMPLES.md](EXAMPLES.md#custom-token-exchange) for usage.
+
 #### Reserved authorization parameters
 
 The `$params` argument accepted by `Auth0::login()`, `Auth0::signup()`, `Auth0::handleInvitation()`, `Authentication::getLoginLink()`, and the Pushed Authorization Request flow no longer lets callers override the following keys. They are always resolved from your SDK configuration:

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -169,8 +169,8 @@ final class Authentication extends ClientAbstract implements AuthenticationInter
             [$subjectTokenType, \Auth0\SDK\Exception\ArgumentException::invalidUri('subjectTokenType')],
         ])->isUri();
 
-        // Reject a `Bearer ` prefix, a common copy-paste mistake the token endpoint would reject.
-        if (1 === preg_match('/^bearer\s/i', $subjectToken ?? '')) {
+        // Reject a `Bearer` prefix, a common copy-paste mistake the token endpoint would reject.
+        if (null !== $subjectToken && 1 === preg_match('/^bearer\b/i', $subjectToken)) {
             throw \Auth0\SDK\Exception\ArgumentException::hasBearerPrefix('subjectToken');
         }
 
@@ -183,7 +183,7 @@ final class Authentication extends ClientAbstract implements AuthenticationInter
             throw \Auth0\SDK\Exception\ArgumentException::missing('actorToken');
         }
 
-        if (null !== $actorToken && 1 === preg_match('/^bearer\s/i', $actorToken)) {
+        if (null !== $actorToken && 1 === preg_match('/^bearer\b/i', $actorToken)) {
             throw \Auth0\SDK\Exception\ArgumentException::hasBearerPrefix('actorToken');
         }
 

--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -36,6 +36,22 @@ final class Authentication extends ClientAbstract implements AuthenticationInter
     ];
 
     /**
+     * Token exchange parameters callers may not override via $params.
+     *
+     * @internal
+     *
+     * @var string[]
+     */
+    public const RESERVED_TOKEN_EXCHANGE_PARAMS = [
+        'grant_type',
+        'client_id',
+        'subject_token',
+        'subject_token_type',
+        'actor_token',
+        'actor_token_type',
+    ];
+
+    /**
      * Instance of Auth0\SDK\API\Utility\HttpClient.
      */
     private ?HttpClient $httpClient = null;
@@ -128,6 +144,70 @@ final class Authentication extends ClientAbstract implements AuthenticationInter
         /** @var array<null|int|string> $params */
 
         return $this->oauthToken('authorization_code', $params);
+    }
+
+    public function customTokenExchange(
+        string $subjectToken,
+        string $subjectTokenType,
+        ?string $actorToken = null,
+        ?string $actorTokenType = null,
+        ?array $params = null,
+        ?array $headers = null,
+    ): ResponseInterface {
+        [$subjectToken, $subjectTokenType, $actorToken, $actorTokenType] = Toolkit::filter([$subjectToken, $subjectTokenType, $actorToken, $actorTokenType])->string()->trim();
+
+        /** @var array<int|string> $headers */
+        /** @var array<null|int|string> $params */
+        [$params, $headers] = Toolkit::filter([$params, $headers])->array()->trim();
+
+        Toolkit::assert([
+            [$subjectToken, \Auth0\SDK\Exception\ArgumentException::missing('subjectToken')],
+            [$subjectTokenType, \Auth0\SDK\Exception\ArgumentException::missing('subjectTokenType')],
+        ])->isString();
+
+        Toolkit::assert([
+            [$subjectTokenType, \Auth0\SDK\Exception\ArgumentException::invalidUri('subjectTokenType')],
+        ])->isUri();
+
+        // Reject a `Bearer ` prefix, a common copy-paste mistake the token endpoint would reject.
+        if (1 === preg_match('/^bearer\s/i', $subjectToken ?? '')) {
+            throw \Auth0\SDK\Exception\ArgumentException::hasBearerPrefix('subjectToken');
+        }
+
+        // An actor token and its type must be supplied together.
+        if (null !== $actorToken && null === $actorTokenType) {
+            throw \Auth0\SDK\Exception\ArgumentException::missing('actorTokenType');
+        }
+
+        if (null !== $actorTokenType && null === $actorToken) {
+            throw \Auth0\SDK\Exception\ArgumentException::missing('actorToken');
+        }
+
+        if (null !== $actorToken && 1 === preg_match('/^bearer\s/i', $actorToken)) {
+            throw \Auth0\SDK\Exception\ArgumentException::hasBearerPrefix('actorToken');
+        }
+
+        if (null !== $actorTokenType) {
+            Toolkit::assert([
+                [$actorTokenType, \Auth0\SDK\Exception\ArgumentException::invalidUri('actorTokenType')],
+            ])->isUri();
+        }
+
+        // Prevent caller-supplied $params from overriding security-critical values the SDK controls.
+        $params = self::filterReservedTokenExchangeParams($params);
+
+        /** @var array<null|int|string> $params */
+        $parameters = Toolkit::merge([$params, [
+            'subject_token' => $subjectToken,
+            'subject_token_type' => $subjectTokenType,
+            'actor_token' => $actorToken,
+            'actor_token_type' => $actorTokenType,
+        ]]);
+
+        /** @var array<null|int|string> $parameters */
+        /** @var array<int|string> $headers */
+
+        return $this->oauthToken('urn:ietf:params:oauth:grant-type:token-exchange', $parameters, $headers);
     }
 
     public function dbConnectionsChangePassword(
@@ -573,6 +653,24 @@ final class Authentication extends ClientAbstract implements AuthenticationInter
     public static function filterReservedParams(array $params): array
     {
         foreach (self::RESERVED_AUTHORIZE_PARAMS as $reserved) {
+            unset($params[$reserved]);
+        }
+
+        return $params;
+    }
+
+    /**
+     * Strip reserved token exchange parameters from a caller-supplied $params array.
+     *
+     * @internal
+     *
+     * @param array<int|string, mixed> $params
+     *
+     * @return array<int|string, mixed>
+     */
+    public static function filterReservedTokenExchangeParams(array $params): array
+    {
+        foreach (self::RESERVED_TOKEN_EXCHANGE_PARAMS as $reserved) {
             unset($params[$reserved]);
         }
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -626,7 +626,8 @@ final class Auth0 implements Auth0Interface
             }
 
             try {
-                $token = $this->decode($response['id_token']);
+                // A token exchange has no interactive max_age, so skip the auth_time check a configured tokenMaxAge would otherwise apply.
+                $token = $this->decode($response['id_token'], tokenMaxAge: Token::MAX_AGE_SKIP);
 
                 $sub = $token->getSubject() ?? '';
                 $iss = $token->getIssuer() ?? '';
@@ -921,6 +922,9 @@ final class Auth0 implements Auth0Interface
             if ($this->configuration()->getPersistRefreshToken()) {
                 $state['refreshToken'] = $this->configuration()->getSessionStorage()->get('refreshToken');
             }
+
+            // Rehydrate the backchannel key so revocation is enforced on subsequent requests.
+            $state['backchannel'] = $this->configuration()->getSessionStorage()->get('backchannel');
         }
 
         return $this->state = new SdkState($state);

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -583,6 +583,86 @@ final class Auth0 implements Auth0Interface
         return $this->authentication()->getLoginLink((string) $state, $redirectUrl, $params);
     }
 
+    public function loginWithCustomTokenExchange(
+        string $subjectToken,
+        string $subjectTokenType,
+        ?string $actorToken = null,
+        ?string $actorTokenType = null,
+        ?array $params = null,
+    ): bool {
+        if (! $this->configuration()->usingStatefulness()) {
+            throw ConfigurationException::requiresStatefulness('Auth0->loginWithCustomTokenExchange()');
+        }
+
+        // A session needs an ID token to populate the user, so ensure a scope is requested. Fall back to the configured scope when the caller did not pass one.
+        $params ??= [];
+
+        if ((! isset($params['scope']) || '' === $params['scope']) && $this->configuration()->hasScope()) {
+            $params['scope'] = $this->configuration()->formatScope();
+        }
+
+        $response = $this->authentication()->customTokenExchange($subjectToken, $subjectTokenType, $actorToken, $actorTokenType, $params);
+
+        if (! HttpResponse::wasSuccessful($response)) {
+            throw Exception\StateException::failedCodeExchange();
+        }
+
+        $response = HttpResponse::decodeContent($response);
+
+        $this->clear(false);
+        $this->deferStateSaving();
+
+        $user = null;
+
+        /** @var array{access_token?: string, scope?: string, refresh_token?: string, id_token?: string, expires_in?: int|string} $response */
+        if (isset($response['id_token'])) {
+            try {
+                $token = $this->decode($response['id_token']);
+                $user = $token->toArray();
+                $this->setIdToken($response['id_token']);
+            } catch (Throwable $throwable) {
+                $this->clear();
+
+                throw $throwable;
+            }
+        }
+
+        if (! isset($response['access_token']) || '' === trim($response['access_token'])) {
+            $this->clear();
+
+            throw Exception\StateException::badAccessToken();
+        }
+
+        $this->setAccessToken($response['access_token']);
+
+        if (isset($response['scope'])) {
+            $this->setAccessTokenScope(explode(' ', $response['scope']));
+        }
+
+        if (isset($response['refresh_token'])) {
+            $this->setRefreshToken($response['refresh_token']);
+        }
+
+        if (isset($response['expires_in']) && is_numeric($response['expires_in'])) {
+            $expiresIn = time() + (int) $response['expires_in'];
+            $this->setAccessTokenExpiration($expiresIn);
+        }
+
+        /** @var null|array<array<mixed>|int|string> $user */
+        $this->setUser($user ?? []);
+        $this->deferStateSaving(false);
+
+        // Rotate the session ID now that the auth state has changed, to prevent
+        // session fixation. Only applies when using PHP session-backed storage.
+        $sessionStorage = $this->configuration()->getSessionStorage();
+
+        if ($sessionStorage instanceof SessionStore) {
+            $sessionStorage->regenerate();
+        }
+
+        return true;
+    }
+
     public function logout(
         ?string $returnUri = null,
         ?array $params = null,

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -604,7 +604,7 @@ final class Auth0 implements Auth0Interface
         $response = $this->authentication()->customTokenExchange($subjectToken, $subjectTokenType, $actorToken, $actorTokenType, $params);
 
         if (! HttpResponse::wasSuccessful($response)) {
-            throw Exception\StateException::failedCodeExchange();
+            throw Exception\StateException::failedTokenExchange();
         }
 
         $response = HttpResponse::decodeContent($response);
@@ -616,8 +616,23 @@ final class Auth0 implements Auth0Interface
 
         /** @var array{access_token?: string, scope?: string, refresh_token?: string, id_token?: string, expires_in?: int|string} $response */
         if (isset($response['id_token'])) {
+            // A token exchange has no redirect, so a transient nonce/max_age is from an unrelated login.
+            // Clear them so decode() does not validate a CTE token against a stale value.
+            $transientStore = $this->getTransientStore();
+
+            if ($transientStore instanceof TransientStoreHandler) {
+                $transientStore->delete('nonce');
+                $transientStore->delete('max_age');
+            }
+
             try {
                 $token = $this->decode($response['id_token']);
+
+                $sub = $token->getSubject() ?? '';
+                $iss = $token->getIssuer() ?? '';
+                $sid = $token->getIdentifier() ?? '';
+                $this->setBackchannel(hash('sha256', implode('|', [$sub, $iss, $sid])));
+
                 $user = $token->toArray();
                 $this->setIdToken($response['id_token']);
             } catch (Throwable $throwable) {

--- a/src/Configuration/SdkState.php
+++ b/src/Configuration/SdkState.php
@@ -237,7 +237,7 @@ final class SdkState implements ConfigurableContract
     }
 
     /**
-     * @return array{idToken: null, accessToken: null, accessTokenScope: null, refreshToken: null, user: null, accessTokenExpiration: null}
+     * @return array{idToken: null, accessToken: null, accessTokenScope: null, refreshToken: null, user: null, accessTokenExpiration: null, backchannel: null}
      */
     private function getPropertyDefaults(): array
     {
@@ -248,6 +248,7 @@ final class SdkState implements ConfigurableContract
             'refreshToken' => null,
             'user' => null,
             'accessTokenExpiration' => null,
+            'backchannel' => null,
         ];
     }
 
@@ -265,6 +266,7 @@ final class SdkState implements ConfigurableContract
             'refreshToken' => static fn ($value): bool => is_string($value) || null === $value,
             'user' => static fn ($value): bool => is_array($value) || null === $value,
             'accessTokenExpiration' => static fn ($value): bool => is_int($value) || null === $value,
+            'backchannel' => static fn ($value): bool => is_string($value) || null === $value,
         ];
     }
 }

--- a/src/Contract/API/AuthenticationInterface.php
+++ b/src/Contract/API/AuthenticationInterface.php
@@ -63,6 +63,34 @@ interface AuthenticationInterface extends ClientInterface
     ): ResponseInterface;
 
     /**
+     * Exchange an external or custom token for Auth0 tokens using the token exchange grant (RFC 8693).
+     * Returns the raw token response and has no session side effects. Use this for delegation and machine-to-machine scenarios.
+     *
+     * @param string                      $subjectToken     the token being exchanged
+     * @param string                      $subjectTokenType a URI identifying the type of `subjectToken`. Any custom URI scheme is accepted (e.g. `urn:acme:token`).
+     * @param null|string                 $actorToken       Optional. A token representing the acting party for delegation. Requires `actorTokenType`.
+     * @param null|string                 $actorTokenType   Optional. A URI identifying the type of `actorToken`. Requires `actorToken`.
+     * @param null|array<null|int|string> $params           Optional. Additional content to include in the body of the API request, such as `audience`, `scope`, and `organization`. The `grant_type`, `client_id`, `subject_token`, `subject_token_type`, `actor_token`, and `actor_token_type` keys are controlled by the SDK and cannot be overridden here.
+     * @param null|array<int|string>      $headers          Optional. Additional headers to send with the API request.
+     *
+     * @throws ArgumentException      when `subjectToken` is blank, `subjectTokenType` is blank or not a valid URI, or the actor token and its type are not supplied together
+     * @throws ConfigurationException when a Client ID is not configured
+     * @throws ConfigurationException when a Client Secret is not configured
+     * @throws NetworkException       when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/authenticate/custom-token-exchange
+     * @see https://datatracker.ietf.org/doc/html/rfc8693
+     */
+    public function customTokenExchange(
+        string $subjectToken,
+        string $subjectTokenType,
+        ?string $actorToken = null,
+        ?string $actorTokenType = null,
+        ?array $params = null,
+        ?array $headers = null,
+    ): ResponseInterface;
+
+    /**
      * Send a change password email.
      * This endpoint only works for database connections.
      *

--- a/src/Contract/Auth0Interface.php
+++ b/src/Contract/Auth0Interface.php
@@ -209,6 +209,32 @@ interface Auth0Interface
     ): string;
 
     /**
+     * Exchange an external or custom token for Auth0 tokens (RFC 8693) and establish a session, logging the user in. Requires a stateful `strategy` with sessions configured.
+     *
+     * @param string                      $subjectToken     the token being exchanged
+     * @param string                      $subjectTokenType a URI identifying the type of `subjectToken`. Any custom URI scheme is accepted (e.g. `urn:acme:token`).
+     * @param null|string                 $actorToken       Optional. A token representing the acting party for delegation. Requires `actorTokenType`.
+     * @param null|string                 $actorTokenType   Optional. A URI identifying the type of `actorToken`. Requires `actorToken`.
+     * @param null|array<null|int|string> $params           Optional. Additional content to include in the body of the API request, such as `audience`, `scope`, and `organization`.
+     *
+     * @throws \Auth0\SDK\Exception\ArgumentException      when `subjectToken` is blank, `subjectTokenType` is blank or not a valid URI, or the actor token and its type are not supplied together
+     * @throws \Auth0\SDK\Exception\ConfigurationException when used without statefulness being configured
+     * @throws \Auth0\SDK\Exception\StateException         if the token exchange request fails, or an access token is missing from the response
+     * @throws \Auth0\SDK\Exception\InvalidTokenException  when validation of a returned ID token fails
+     * @throws \Auth0\SDK\Exception\NetworkException       when the API request fails due to a network error
+     *
+     * @see https://auth0.com/docs/authenticate/custom-token-exchange
+     * @see https://datatracker.ietf.org/doc/html/rfc8693
+     */
+    public function loginWithCustomTokenExchange(
+        string $subjectToken,
+        string $subjectTokenType,
+        ?string $actorToken = null,
+        ?string $actorTokenType = null,
+        ?array $params = null,
+    ): bool;
+
+    /**
      * Delete any persistent data and clear out all stored properties, and return the URI to Auth0 /logout endpoint for redirection.
      *
      * @param null|string                 $returnUri Optional. URI to return to after logging out. Defaults to the SDK's configured redirectUri.

--- a/src/Exception/ArgumentException.php
+++ b/src/Exception/ArgumentException.php
@@ -34,6 +34,16 @@ final class ArgumentException extends Exception implements Auth0Exception
      */
     public const MSG_VALUE_CANNOT_BE_EMPTY = 'A value for `%s` must be provided';
 
+    /**
+     * @var string
+     */
+    public const MSG_VALUE_HAS_BEARER_PREFIX = 'A value for `%s` must not include a `Bearer` prefix';
+
+    /**
+     * @var string
+     */
+    public const MSG_VALUE_IS_NOT_URI = 'A value for `%s` must be a valid URI';
+
     public static function badPermissionsArray(
         ?Throwable $previous = null,
     ): self {
@@ -44,6 +54,20 @@ final class ArgumentException extends Exception implements Auth0Exception
         ?Throwable $previous = null,
     ): self {
         return new self(self::MSG_PKCE_CODE_VERIFIER_LENGTH, 0, $previous);
+    }
+
+    public static function hasBearerPrefix(
+        string $parameterName,
+        ?Throwable $previous = null,
+    ): self {
+        return new self(sprintf(self::MSG_VALUE_HAS_BEARER_PREFIX, $parameterName), 0, $previous);
+    }
+
+    public static function invalidUri(
+        string $parameterName,
+        ?Throwable $previous = null,
+    ): self {
+        return new self(sprintf(self::MSG_VALUE_IS_NOT_URI, $parameterName), 0, $previous);
     }
 
     public static function missing(

--- a/src/Exception/StateException.php
+++ b/src/Exception/StateException.php
@@ -35,7 +35,7 @@ final class StateException extends Exception implements Auth0Exception
     /**
      * @var string
      */
-    public const MSG_FAILED_TOKEN_EXCHANGE = 'Token exchange was unsuccessful; network error resulted in unfulfilled request';
+    public const MSG_FAILED_TOKEN_EXCHANGE = 'Token exchange was unsuccessful; the endpoint returned an error response';
 
     /**
      * @var string

--- a/src/Exception/StateException.php
+++ b/src/Exception/StateException.php
@@ -35,6 +35,11 @@ final class StateException extends Exception implements Auth0Exception
     /**
      * @var string
      */
+    public const MSG_FAILED_TOKEN_EXCHANGE = 'Token exchange was unsuccessful; network error resulted in unfulfilled request';
+
+    /**
+     * @var string
+     */
     public const MSG_INVALID_STATE = 'Invalid state';
 
     /**
@@ -74,6 +79,12 @@ final class StateException extends Exception implements Auth0Exception
         ?Throwable $previous = null,
     ): self {
         return new self(self::MSG_FAILED_RENEW_TOKEN_MISSING_REFRESH_TOKEN, 0, $previous);
+    }
+
+    public static function failedTokenExchange(
+        ?Throwable $previous = null,
+    ): self {
+        return new self(self::MSG_FAILED_TOKEN_EXCHANGE, 0, $previous);
     }
 
     public static function invalidState(

--- a/src/Token.php
+++ b/src/Token.php
@@ -47,6 +47,13 @@ final class Token implements TokenInterface
     public const ALGO_RS512 = 'RS512';
 
     /**
+     * Sentinel for `$tokenMaxAge` that skips the `auth_time` check for flows with no interactive `max_age`, such as token exchange.
+     *
+     * @var int
+     */
+    public const MAX_AGE_SKIP = -1;
+
+    /**
      * @var int
      */
     public const TYPE_ACCESS_TOKEN = 2;
@@ -330,7 +337,7 @@ final class Token implements TokenInterface
             $validator->nonce($tokenNonce);
         }
 
-        if (null !== $tokenMaxAge) {
+        if (null !== $tokenMaxAge && self::MAX_AGE_SKIP !== $tokenMaxAge) {
             $validator->authTime($tokenMaxAge, $tokenLeeway, $tokenNow);
         }
 

--- a/src/Utility/Toolkit/Assert.php
+++ b/src/Utility/Toolkit/Assert.php
@@ -129,4 +129,22 @@ final readonly class Assert
             }
         }
     }
+
+    /**
+     * Check that a variable is a string beginning with a valid URI scheme. Accepts any RFC 3986 scheme, including custom URNs (e.g. `urn:acme:token`), so it does not use FILTER_VALIDATE_URL.
+     *
+     * @throws Exception when subject is not a string or does not begin with a valid URI scheme
+     */
+    public function isUri(): void
+    {
+        foreach ($this->subjects as [$value, $exception]) {
+            if (! is_string($value)) {
+                throw $exception;
+            }
+
+            if (1 !== preg_match('/^[a-zA-Z][a-zA-Z0-9+.\-]*:/', $value)) {
+                throw $exception;
+            }
+        }
+    }
 }

--- a/src/Utility/Toolkit/Assert.php
+++ b/src/Utility/Toolkit/Assert.php
@@ -133,6 +133,8 @@ final readonly class Assert
     /**
      * Check that a variable is a string beginning with a valid URI scheme. Accepts any RFC 3986 scheme, including custom URNs (e.g. `urn:acme:token`), so it does not use FILTER_VALIDATE_URL.
      *
+     * Only the presence of a scheme is validated, not the rest of the URI. `urn:` and `x:` pass. This is a cheap client-side guard to catch obvious mistakes before a network call, not a full URI validator.
+     *
      * @throws Exception when subject is not a string or does not begin with a valid URI scheme
      */
     public function isUri(): void

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -778,6 +778,10 @@ test('customTokenExchange() throws an exception when subjectToken carries a Bear
     $this->sdk->authentication()->customTokenExchange('Bearer abc123', 'urn:acme:mcp-token');
 })->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_HAS_BEARER_PREFIX, 'subjectToken'));
 
+test('customTokenExchange() throws an exception when subjectToken carries a Bearer prefix without a trailing space', function(): void {
+    $this->sdk->authentication()->customTokenExchange('Bearer', 'urn:acme:mcp-token');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_HAS_BEARER_PREFIX, 'subjectToken'));
+
 test('customTokenExchange() throws an exception when actorToken carries a Bearer prefix', function(): void {
     $this->sdk->authentication()->customTokenExchange(uniqid(), 'urn:acme:mcp-token', 'Bearer abc123', 'urn:acme:actor-token');
 })->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_HAS_BEARER_PREFIX, 'actorToken'));

--- a/tests/Unit/API/AuthenticationTest.php
+++ b/tests/Unit/API/AuthenticationTest.php
@@ -666,3 +666,136 @@ test('pushedAuthorizationRequest() returns an instance of Auth0\SDK\API\Authenti
 
     expect($pushedAuthorizationRequest)->toBeInstanceOf(PushedAuthorizationRequest::class);
 });
+
+test('customTokenExchange() is properly formatted', function(): void {
+    $clientSecret = uniqid();
+    $subjectToken = uniqid();
+    $subjectTokenType = 'urn:acme:mcp-token';
+
+    $this->configuration->setClientSecret($clientSecret);
+
+    $authentication = $this->sdk->authentication();
+    $authentication->getHttpClient()->mockResponses([HttpResponseGenerator::create()]);
+    $authentication->customTokenExchange($subjectToken, $subjectTokenType);
+
+    $request = $authentication->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestUri = $request->getUri();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestUri->getHost())->toEqual($this->configuration->getDomain());
+    expect($requestUri->getPath())->toEqual('/oauth/token');
+
+    expect($requestBody)->toContain('grant_type=' . rawurlencode('urn:ietf:params:oauth:grant-type:token-exchange'));
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->toContain('client_secret=' . $clientSecret);
+    expect($requestBody)->toContain('subject_token=' . $subjectToken);
+    expect($requestBody)->toContain('subject_token_type=' . rawurlencode($subjectTokenType));
+});
+
+test('customTokenExchange() passes audience, scope, and organization through $params', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+
+    $authentication = $this->sdk->authentication();
+    $authentication->getHttpClient()->mockResponses([HttpResponseGenerator::create()]);
+    $authentication->customTokenExchange(uniqid(), 'urn:acme:mcp-token', null, null, [
+        'audience' => 'https://api.example.com',
+        'scope' => 'read:data',
+        'organization' => 'org_xyz',
+    ]);
+
+    $request = $authentication->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->toContain('audience=' . rawurlencode('https://api.example.com'));
+    expect($requestBody)->toContain('scope=' . rawurlencode('read:data'));
+    expect($requestBody)->toContain('organization=org_xyz');
+});
+
+test('customTokenExchange() includes the actor token and type when supplied', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $actorToken = uniqid();
+
+    $authentication = $this->sdk->authentication();
+    $authentication->getHttpClient()->mockResponses([HttpResponseGenerator::create()]);
+    $authentication->customTokenExchange(uniqid(), 'urn:acme:mcp-token', $actorToken, 'urn:acme:actor-token');
+
+    $request = $authentication->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->toContain('actor_token=' . $actorToken);
+    expect($requestBody)->toContain('actor_token_type=' . rawurlencode('urn:acme:actor-token'));
+});
+
+test('customTokenExchange() ignores caller attempts to override reserved parameters', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $subjectToken = uniqid();
+
+    $authentication = $this->sdk->authentication();
+    $authentication->getHttpClient()->mockResponses([HttpResponseGenerator::create()]);
+    $authentication->customTokenExchange($subjectToken, 'urn:acme:mcp-token', null, null, [
+        'grant_type' => 'password',
+        'subject_token' => 'attacker-token',
+        'subject_token_type' => 'urn:evil:token',
+        'client_id' => 'attacker-client',
+    ]);
+
+    $request = $authentication->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->toContain('grant_type=' . rawurlencode('urn:ietf:params:oauth:grant-type:token-exchange'));
+    expect($requestBody)->toContain('subject_token=' . $subjectToken);
+    expect($requestBody)->toContain('subject_token_type=' . rawurlencode('urn:acme:mcp-token'));
+    expect($requestBody)->toContain('client_id=__test_client_id__');
+    expect($requestBody)->not()->toContain('grant_type=password');
+    expect($requestBody)->not()->toContain('subject_token=attacker-token');
+});
+
+test('customTokenExchange() throws an exception when subjectToken is blank', function(): void {
+    $this->sdk->authentication()->customTokenExchange('', 'urn:acme:mcp-token');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'subjectToken'));
+
+test('customTokenExchange() throws an exception when subjectTokenType is blank', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), '');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'subjectTokenType'));
+
+test('customTokenExchange() throws an exception when subjectTokenType is not a URI', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), 'not-a-uri');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_IS_NOT_URI, 'subjectTokenType'));
+
+test('customTokenExchange() throws an exception when actorToken is supplied without actorTokenType', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), 'urn:acme:mcp-token', uniqid());
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actorTokenType'));
+
+test('customTokenExchange() throws an exception when actorTokenType is supplied without actorToken', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), 'urn:acme:mcp-token', null, 'urn:acme:actor-token');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_CANNOT_BE_EMPTY, 'actorToken'));
+
+test('customTokenExchange() throws an exception when actorTokenType is not a URI', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), 'urn:acme:mcp-token', uniqid(), 'not-a-uri');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_IS_NOT_URI, 'actorTokenType'));
+
+test('customTokenExchange() throws an exception when subjectToken carries a Bearer prefix', function(): void {
+    $this->sdk->authentication()->customTokenExchange('Bearer abc123', 'urn:acme:mcp-token');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_HAS_BEARER_PREFIX, 'subjectToken'));
+
+test('customTokenExchange() throws an exception when actorToken carries a Bearer prefix', function(): void {
+    $this->sdk->authentication()->customTokenExchange(uniqid(), 'urn:acme:mcp-token', 'Bearer abc123', 'urn:acme:actor-token');
+})->throws(ArgumentException::class, sprintf(ArgumentException::MSG_VALUE_HAS_BEARER_PREFIX, 'actorToken'));
+
+test('customTokenExchange() ignores a caller-supplied actor token in $params', function(): void {
+    $this->configuration->setClientSecret(uniqid());
+    $subjectToken = uniqid();
+
+    $authentication = $this->sdk->authentication();
+    $authentication->getHttpClient()->mockResponses([HttpResponseGenerator::create()]);
+    $authentication->customTokenExchange($subjectToken, 'urn:acme:mcp-token', null, null, [
+        'actor_token' => 'smuggled-actor',
+        'actor_token_type' => 'urn:evil:actor',
+    ]);
+
+    $request = $authentication->getHttpClient()->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->not()->toContain('actor_token=smuggled-actor');
+    expect($requestBody)->not()->toContain('actor_token_type=' . rawurlencode('urn:evil:actor'));
+});

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -1426,3 +1426,152 @@ test('getBearerToken() correctly silently handles token validation exceptions', 
 })->with(['mocked rs256 bearer token' => [
     fn() => TokenGenerator::create(TokenGenerator::TOKEN_ACCESS, TokenGenerator::ALG_RS256)
 ]]);
+
+test('loginWithCustomTokenExchange() throws a ConfigurationException if the SDK is not configured with a stateful strategy', function(): void {
+    $auth0 = new Auth0(array_merge($this->configuration, [
+        'audience' => [uniqid()],
+        'strategy' => SdkConfiguration::STRATEGY_API
+    ]));
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
+})->throws(ConfigurationException::class, sprintf(ConfigurationException::MSG_SESSION_REQUIRED, 'Auth0->loginWithCustomTokenExchange()'));
+
+test('loginWithCustomTokenExchange() establishes a session from a valid id token', function(): void {
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/'
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","refresh_token":"4.5.6","scope":"test:part1 test:part2","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    $this->assertArrayHasKey('sub', $auth0->getUser());
+    expect($auth0->getIdToken())->toEqual($token);
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+    expect($auth0->getAccessTokenScope())->toEqual(['test:part1', 'test:part2']);
+    expect($auth0->getAccessTokenExpiration())->toBeGreaterThan(time());
+    expect($auth0->getRefreshToken())->toEqual('4.5.6');
+});
+
+test('loginWithCustomTokenExchange() surfaces the act claim on the session user', function(): void {
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/',
+        'act' => ['sub' => '__test_actor__'],
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token', uniqid(), 'urn:acme:actor-token'))->toBeTrue();
+    $this->assertArrayHasKey('act', $auth0->getUser());
+    expect($auth0->getUser()['act']['sub'])->toEqual('__test_actor__');
+});
+
+test('loginWithCustomTokenExchange() establishes a session from an access-token-only response', function(): void {
+    $auth0 = new Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+    expect($auth0->getIdToken())->toBeNull();
+});
+
+test('loginWithCustomTokenExchange() sends the configured scope when the caller passes none', function(): void {
+    $auth0 = new Auth0($this->configuration + ['scope' => ['openid', 'profile', 'email']]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","expires_in":300}'),
+    ]);
+
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
+
+    $request = $httpClient->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->toContain('scope=openid+profile+email');
+});
+
+test('loginWithCustomTokenExchange() honors an explicit scope over the configured one', function(): void {
+    $auth0 = new Auth0($this->configuration + ['scope' => ['openid', 'profile', 'email']]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","expires_in":300}'),
+    ]);
+
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token', null, null, ['scope' => 'openid custom:scope']);
+
+    $request = $httpClient->getLastRequest()->getLastRequest();
+    $requestBody = explode('&', $request->getBody()->__toString());
+
+    expect($requestBody)->toContain('scope=openid+custom%3Ascope');
+    expect($requestBody)->not()->toContain('scope=openid+profile+email');
+});
+
+test('loginWithCustomTokenExchange() throws when the token exchange response has no access token', function(): void {
+    $auth0 = new Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"scope":"read:data"}'),
+    ]);
+
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
+})->throws(StateException::class, StateException::MSG_BAD_ACCESS_TOKEN);
+
+test('loginWithCustomTokenExchange() throws when the token exchange request fails', function(): void {
+    $auth0 = new Auth0($this->configuration);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"error":"invalid_grant"}', 403),
+    ]);
+
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
+})->throws(StateException::class, StateException::MSG_FAILED_CODE_EXCHANGE);
+
+test('loginWithCustomTokenExchange() clears state and rethrows when the id token is invalid', function(): void {
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/'
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"BAD' . $token . '","expires_in":300}'),
+    ]);
+
+    $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
+})->throws(InvalidTokenException::class);
+
+test('loginWithCustomTokenExchange() regenerates the session when using SessionStore', function(): void {
+    $auth0 = new Auth0($this->configuration);
+    $auth0->configuration()->setSessionStorage(new SessionStore($auth0->configuration()));
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","refresh_token":"4.5.6","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    expect($auth0->getAccessToken())->toEqual('1.2.3');
+});

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -1456,6 +1456,30 @@ test('loginWithCustomTokenExchange() establishes a session from a valid id token
     expect($auth0->getAccessTokenScope())->toEqual(['test:part1', 'test:part2']);
     expect($auth0->getAccessTokenExpiration())->toBeGreaterThan(time());
     expect($auth0->getRefreshToken())->toEqual('4.5.6');
+    expect($auth0->getCredentials()->backchannel)->not()->toBeEmpty();
+});
+
+test('loginWithCustomTokenExchange() ignores a stale transient nonce from an abandoned redirect', function(): void {
+    // A CTE id token carries no nonce claim, matching a real token exchange response.
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/',
+        'nonce' => null,
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+
+    // A prior abandoned login() left a nonce in transient storage. decode() must not validate the CTE token against it.
+    $auth0->configuration()->getTransientStorage()->set('nonce', '__stale_nonce__');
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    $this->assertArrayHasKey('sub', $auth0->getUser());
 });
 
 test('loginWithCustomTokenExchange() surfaces the act claim on the session user', function(): void {
@@ -1489,6 +1513,8 @@ test('loginWithCustomTokenExchange() establishes a session from an access-token-
     expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
     expect($auth0->getAccessToken())->toEqual('1.2.3');
     expect($auth0->getIdToken())->toBeNull();
+    // No id token means no sub/iss/sid to build a backchannel key from.
+    expect($auth0->getBackchannel())->toBeNull();
 });
 
 test('loginWithCustomTokenExchange() sends the configured scope when the caller passes none', function(): void {
@@ -1544,7 +1570,7 @@ test('loginWithCustomTokenExchange() throws when the token exchange request fail
     ]);
 
     $auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token');
-})->throws(StateException::class, StateException::MSG_FAILED_CODE_EXCHANGE);
+})->throws(StateException::class, StateException::MSG_FAILED_TOKEN_EXCHANGE);
 
 test('loginWithCustomTokenExchange() clears state and rethrows when the id token is invalid', function(): void {
     $token = (new TokenGenerator())->withHs256([

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -10,6 +10,7 @@ use Auth0\SDK\Contract\TokenInterface;
 use Auth0\SDK\Exception\ConfigurationException;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Exception\StateException;
+use Auth0\SDK\Store\CookieStore;
 use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\Token;
 use Auth0\Tests\Utilities\HttpResponseGenerator;
@@ -1121,10 +1122,8 @@ test('getCredentials() returns null when matching backchannel request is queued'
     expect($auth0->exchange())->toBeTrue();
 
     $credentials = $auth0->getCredentials();
-    expect($credentials)
-        ->toBeObject()
-        ->toHaveProperty('backchannel')
-            ->not()->toBeEmpty();
+    expect($credentials)->toBeObject();
+    expect($credentials->backchannel)->not()->toBeEmpty();
 
     $logoutToken = TokenGenerator::create(
         tokenType: TokenGenerator::TOKEN_LOGOUT,
@@ -1482,6 +1481,27 @@ test('loginWithCustomTokenExchange() ignores a stale transient nonce from an aba
     $this->assertArrayHasKey('sub', $auth0->getUser());
 });
 
+test('loginWithCustomTokenExchange() skips the auth_time check when tokenMaxAge is configured', function(): void {
+    // A CTE id token has no auth_time claim, so a configured tokenMaxAge must not fail it.
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/',
+        'auth_time' => null,
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+        'tokenMaxAge' => 3600,
+    ]);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    $this->assertArrayHasKey('sub', $auth0->getUser());
+});
+
 test('loginWithCustomTokenExchange() surfaces the act claim on the session user', function(): void {
     $token = (new TokenGenerator())->withHs256([
         'iss' => 'https://' . $this->configuration['domain'] . '/',
@@ -1600,4 +1620,57 @@ test('loginWithCustomTokenExchange() regenerates the session when using SessionS
 
     expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
     expect($auth0->getAccessToken())->toEqual('1.2.3');
+});
+
+test('loginWithCustomTokenExchange() persists the backchannel key across requests', function(): void {
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/'
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+    $sessionStorage = new SessionStore($auth0->configuration());
+    $auth0->configuration()->setSessionStorage($sessionStorage);
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    $key = $auth0->getBackchannel();
+    expect($key)->not()->toBeEmpty();
+
+    // A fresh instance rehydrating from the same storage must recover the key, or a queued logout is never enforced.
+    $rehydrated = new Auth0($this->configuration + ['tokenAlgorithm' => 'HS256']);
+    $rehydrated->configuration()->setSessionStorage($sessionStorage);
+    expect($rehydrated->getBackchannel())->toEqual($key);
+});
+
+test('loginWithCustomTokenExchange() persists the backchannel key across requests using CookieStore', function(): void {
+    $_COOKIE = [];
+
+    $token = (new TokenGenerator())->withHs256([
+        'iss' => 'https://' . $this->configuration['domain'] . '/'
+    ]);
+
+    $auth0 = new Auth0($this->configuration + [
+        'tokenAlgorithm' => 'HS256',
+    ]);
+    $auth0->configuration()->setSessionStorage(new CookieStore($auth0->configuration(), 'cte_test'));
+
+    $httpClient = $auth0->authentication()->getHttpClient();
+    $httpClient->mockResponses([
+        HttpResponseGenerator::create('{"access_token":"1.2.3","id_token":"' . $token . '","expires_in":300}'),
+    ]);
+
+    expect($auth0->loginWithCustomTokenExchange(uniqid(), 'urn:acme:mcp-token'))->toBeTrue();
+    $key = $auth0->getBackchannel();
+    expect($key)->not()->toBeEmpty();
+
+    // A fresh CookieStore on the same namespace reads the encrypted cookie back, so the key must survive the round-trip.
+    $rehydrated = new Auth0($this->configuration + ['tokenAlgorithm' => 'HS256']);
+    $rehydrated->configuration()->setSessionStorage(new CookieStore($rehydrated->configuration(), 'cte_test'));
+    expect($rehydrated->getBackchannel())->toEqual($key);
 });

--- a/tests/Unit/Utility/Toolkit/AssertTest.php
+++ b/tests/Unit/Utility/Toolkit/AssertTest.php
@@ -77,3 +77,32 @@ test('isArray() throws an exception if value is an empty array', function(): voi
         [[], new Exception('foobar')],
     ])->isArray();
 })->throws(Exception::class, 'foobar');
+
+test('isUri() accepts standard URLs and custom URN schemes', function(): void {
+    expect(function(): void {
+        Toolkit::assert([
+            ['https://api.example.com', new Exception('foobar')],
+            ['urn:acme:mcp-token', new Exception('foobar')],
+            ['custom:legacy-token', new Exception('foobar')],
+            ['urn:ietf:params:oauth:token-type:access_token', new Exception('foobar')],
+        ])->isUri();
+    })->not->toThrow(Exception::class);
+});
+
+test('isUri() throws an exception if value is not a string', function(): void {
+    Toolkit::assert([
+        [true, new Exception('foobar')],
+    ])->isUri();
+})->throws(Exception::class, 'foobar');
+
+test('isUri() throws an exception if value is an empty string', function(): void {
+    Toolkit::assert([
+        ['', new Exception('foobar')],
+    ])->isUri();
+})->throws(Exception::class, 'foobar');
+
+test('isUri() throws an exception if value has no scheme', function(): void {
+    Toolkit::assert([
+        ['not-a-uri', new Exception('foobar')],
+    ])->isUri();
+})->throws(Exception::class, 'foobar');


### PR DESCRIPTION
### Changes

This PR adds support for [Custom Token Exchange](https://auth0.com/docs/authenticate/custom-token-exchange) ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)), which exchanges an external or legacy token for Auth0 tokens without a browser redirect. Two entry points are provided, depending on whether a session is wanted:

**Features:**

- Added `Authentication::customTokenExchange()`, which performs the exchange and returns the raw token response with no session side effects. It sends the `urn:ietf:params:oauth:grant-type:token-exchange` grant to `/oauth/token` and accepts `audience`, `scope`, and `organization` through `$params`
- Added `Auth0::loginWithCustomTokenExchange()`, which performs the exchange and persists the result as a session, logging the user in. It requires a stateful strategy, decodes and validates the returned ID token, surfaces the `act` claim on the session user, and rotates the session ID
- Both methods accept optional `actorToken` and `actorTokenType` parameters for delegation, which must be supplied together
- Added `Assert::isUri()` to validate `subjectTokenType` and `actorTokenType` client-side. It accepts any RFC 3986 scheme, including custom URNs such as `urn:acme:mcp-token`, and rejects non-URI values before any network request
- Added `ArgumentException::invalidUri()` and `ArgumentException::hasBearerPrefix()` factories for the new client-side validation
- Caller `$params` cannot override the `grant_type`, `client_id`, `subject_token`, `subject_token_type`, `actor_token`, or `actor_token_type` keys, which are controlled by the SDK

### Documentation

- Added a Custom Token Exchange section to `EXAMPLES.md` covering basic exchange, session login, actor-token delegation, organization support, and error handling
- Noted the new methods in `README.md` and the v9 section of `UPGRADE.md`

### References

N/A

### Testing

- Added unit tests for `Assert::isUri()`, `customTokenExchange()` (request shape, actor tokens, organization passthrough, reserved-parameter filtering, and all client-side validation guards), and `loginWithCustomTokenExchange()` (session establishment, `act` claim surfacing, scope fallback, statefulness, and failure paths)

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)