### PR TITLE
fix(assert): reject the bare `data:` stream wrapper in fileExists

### DIFF
--- a/src/Utility/Assert.php
+++ b/src/Utility/Assert.php
@@ -3956,6 +3956,18 @@ final class Assert
             ));
         }
 
+        // The check above is a denylist of separators, but PHP's stream wrapper resolution
+        // (php_stream_locate_url_wrapper) also special-cases a bare `data:` with a single colon.
+        // "data:text/plain,..." therefore contains no "://" yet fopen() opens it as a wrapper.
+        // realpath() resolves only genuine local filesystem paths and returns false for every
+        // wrapper form, so this second check is an allowlist rather than another spelling.
+        if (false === realpath((string) $value)) {
+            self::reportInvalidArgument(sprintf(
+                $message ?: 'The path %s is not an existing local filesystem path.',
+                self::valueToString($value),
+            ));
+        }
+
         if (! file_exists($value)) {
             self::reportInvalidArgument(sprintf(
                 $message ?: 'The file %s does not exist.',

--- a/tests/Unit/Utility/HttpRequestTest.php
+++ b/tests/Unit/Utility/HttpRequestTest.php
@@ -189,6 +189,19 @@ it('rejects file paths with protocol separators', function(): void {
         ->toThrow(\InvalidArgumentException::class, 'File paths with protocol separators ("://") are not allowed: "php://filter/convert.base64-encode/resource=/etc/passwd"');
 });
 
+it('rejects the bare data: wrapper, which contains no protocol separator', function(): void {
+    $client = new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'post', '/');
+
+    // PHP's stream wrapper resolution special-cases a bare `data:` with a single colon, so
+    // "data:text/plain,..." is opened as a wrapper by fopen() despite containing no "://".
+    // A separator-based check alone does not catch it.
+    expect(fn() => $client->addFile('test', 'data:text/plain,injected'))
+        ->toThrow(\InvalidArgumentException::class);
+
+    expect(fn() => $client->addFile('test', 'data:text/plain;base64,aW5qZWN0ZWQ='))
+        ->toThrow(\InvalidArgumentException::class);
+});
+
 it('rejects file paths for non-existent or unreadable files', function(): void {
     $client = new HttpRequest($this->configuration, HttpClient::CONTEXT_GENERIC_CLIENT, 'post', '/');
     


### PR DESCRIPTION
## Summary

The stream-wrapper guard in `Assert::fileExists()` rejects paths containing `://`. PHP's wrapper
resolution accepts **either** `scheme://` **or** a special-cased bare `data:` with a single colon, so
`data:text/plain,...` passes the check while `fopen()` still opens it as a wrapper.

**This is a hardening PR, not a vulnerability report.** I could not reach the gap through the SDK's
public surface — see *Reachability* below. The concern is that the guard is a denylist that is
already one spelling short.

## The gap

`php_stream_locate_url_wrapper()` in PHP core matches a scheme followed by `://`, **or** the literal
`data:` (four characters plus colon). Measured locally:

| candidate | contains `://` | `realpath()` | `fopen()` |
|---|---|---|---|
| `/tmp/probe.txt` (legitimate) | no | resolves | opens |
| **`data:text/plain,HELLO`** | **no** | **false** | **opens** |
| `data://text/plain,HELLO` | yes | false | opens |
| `php://filter/read=convert.base64-encode/resource=/etc/passwd` | yes | false | opens |
| `compress.zlib:///tmp/probe.txt` | yes | false | opens |
| `http://example.com/x` | yes | false | fails |

Row 2 is the gap: no `://`, so the guard passes it, and `fopen()` opens it as a wrapper.

## Reachability — why this is filed as hardening

At `HttpRequest::addFile()` the call is:

```php
Assert::fileExists($file_path);   // guarded
Assert::readable($file_path);     // not guarded
```

`file_exists()` returns **false** for `data:` (the wrapper implements no `url_stat`), so the bare
form is rejected today — by the existence check, not by the wrapper guard. Those are the only two
call sites of these asserts in the SDK, and `fileExists` always runs first, so I found no reachable
bypass.

The guard is therefore load-bearing only if any of these change: `file_exists()` behaviour for
`data:`, the ordering in `addFile()`, or a future call site that uses `Assert::readable()`,
`Assert::file()` or `Assert::writable()` alone — none of which carry the wrapper rejection.

## The change

Adds a `realpath()` check **beneath** the existing one:

```php
if (false === realpath((string) $value)) {
    self::reportInvalidArgument(sprintf(
        $message ?: 'The path %s is not an existing local filesystem path.',
        self::valueToString($value),
    ));
}
```

`realpath()` resolves only genuine local filesystem paths and returns `false` for **every** wrapper
form in the table above. That makes it an allowlist rather than another denylist spelling, so it does
not need extending when a new wrapper appears.

**I first tried `stream_is_local()`, which looks purpose-built and is wrong**: it returns `true` for
`php://filter/...` and `compress.zlib://`. Worth recording so nobody reaches for it later.

## Compatibility

Strictly additive, +25/−0:

- The existing `://` check and **its exact error message** are untouched, so
  `HttpRequestTest::'rejects file paths with protocol separators'` continues to pass unmodified.
- Legitimate local paths are unaffected (verified against a real file).
- `realpath()` also returns `false` for non-existent paths, which the following `file_exists()` check
  already rejected — so no new rejection class for ordinary input.

## Verification

```
/tmp/a0_probe.txt                                          ACCEPTED
data:text/plain,HELLO                                      rejected  The path ... is not an existing local filesystem path.
file:///etc/passwd                                         rejected  File paths with protocol separators ("://") are not allowed
php://filter/convert.base64-encode/resource=/etc/passwd    rejected  File paths with protocol separators ("://") are not allowed
http://example.com/file.txt                                rejected  File paths with protocol separators ("://") are not allowed
```

Note the message split: pre-existing cases keep the original message; only the previously-accepted
`data:` form uses the new one.

Adds a regression test covering the plain and base64 `data:` forms, alongside the existing separator
test.

## Optional follow-up (not in this PR)

`Assert::readable()`, `Assert::file()` and `Assert::writable()` carry no wrapper rejection. They are
not reachable with caller-supplied paths today, so I left them alone rather than widen the diff —
happy to extend if you would prefer the guard applied consistently across the path asserts.
