### PR TITLE
chore: prep CI and docs for v9 GA cutover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,22 @@ permissions:
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
 
 jobs:
-  # rl-scanner:
-  #   uses: ./.github/workflows/rl-scanner.yml
-  #   with:
-  #     php-version: 8.1
-  #     artifact-name: 'auth0-php.zip'
-  #   secrets:
-  #     RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
-  #     RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}
-  #     SIGNAL_HANDLER_TOKEN: ${{ secrets.SIGNAL_HANDLER_TOKEN }}
-  #     PRODSEC_TOOLS_USER: ${{ secrets.PRODSEC_TOOLS_USER }}
-  #     PRODSEC_TOOLS_TOKEN: ${{ secrets.PRODSEC_TOOLS_TOKEN }}
-  #     PRODSEC_TOOLS_ARN: ${{ secrets.PRODSEC_TOOLS_ARN }}
+  rl-scanner:
+    uses: ./.github/workflows/rl-scanner.yml
+    with:
+      php-version: 8.1
+      artifact-name: 'auth0-php.zip'
+    secrets:
+      RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
+      RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}
+      SIGNAL_HANDLER_TOKEN: ${{ secrets.SIGNAL_HANDLER_TOKEN }}
+      PRODSEC_TOOLS_USER: ${{ secrets.PRODSEC_TOOLS_USER }}
+      PRODSEC_TOOLS_TOKEN: ${{ secrets.PRODSEC_TOOLS_TOKEN }}
+      PRODSEC_TOOLS_ARN: ${{ secrets.PRODSEC_TOOLS_ARN }}
 
   release:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/')
-    # needs: rl-scanner
+    needs: rl-scanner
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,11 +8,11 @@ on:
       - synchronize
     branches:
       - main
-      - v9
+      - v8
   push:
     branches:
       - main
-      - v9
+      - v8
   schedule:
     - cron: "30 0 1,15 * *"
   workflow_dispatch:
@@ -33,7 +33,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/v9' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/v8' }}
 
 jobs:
   configure:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,17 @@ on:
       - synchronize
     branches:
       - main
-      - v9
+      - v8
   push:
     branches:
       - main
-      - v9
+      - v8
 
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/v9' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/v8' }}
 
 jobs:
   configure:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -28,9 +28,9 @@ $auth0 = new Auth0($configuration);
 
 Available choices are:
 
-- `SdkConfiguration::STRATEGY_REGULAR` (Default) — for stateful applications. Requires `domain`, `clientId` and `cookieSecret` also be configured.
-- `SdkConfiguration::STRATEGY_API` — for stateless applications. Requires `domain` and `audience` also be configured.
-- `SdkConfiguration::STRATEGY_MANAGEMENT_API` — for stateless applications that only interact with the Management API. Requires either `managementToken` or `clientId` and `clientSecret` to also be configured.
+- `SdkConfiguration::STRATEGY_REGULAR` (Default) - for stateful applications. Requires `domain`, `clientId` and `cookieSecret` also be configured.
+- `SdkConfiguration::STRATEGY_API` - for stateless applications. Requires `domain` and `audience` also be configured.
+- `SdkConfiguration::STRATEGY_MANAGEMENT_API` - for stateless applications that only interact with the Management API. Requires either `managementToken` or `clientId` and `clientSecret` to also be configured.
 
 ## Logging out
 
@@ -430,11 +430,11 @@ $auth0 = new Auth0($configuration);
 The following options must also be configured to use a `CookieStore`:
 
 - [`strategy`](#strategy-configuration) must be `SdkConfiguration::STRATEGY_REGULAR`.
-- `cookieSecret` — an encryption key for the session cookie.
-- `cookieDomain` — when sharing session cookies across multiple subdomains, use your FQDN with a dot in front, e.g. `.yourdomain.com`.
-- `cookieExpires` — the expiration time (in seconds) for the session cookie.
-- `cookiePath` — path to use for the session cookie.
-- `cookieSecure` — whether cookies should only be sent over secure connections.
+- `cookieSecret` - an encryption key for the session cookie.
+- `cookieDomain` - when sharing session cookies across multiple subdomains, use your FQDN with a dot in front, e.g. `.yourdomain.com`.
+- `cookieExpires` - the expiration time (in seconds) for the session cookie.
+- `cookiePath` - path to use for the session cookie.
+- `cookieSecure` - whether cookies should only be sent over secure connections.
 
 ## PHP session storage
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ PHP SDK for [Auth0](https://auth0.com) Authentication and Management APIs.
 We also have tailored SDKs for [Laravel](https://github.com/auth0/laravel-auth0), [Symfony](https://github.com/auth0/symfony), and [WordPress](https://github.com/auth0/wordpress). If you are using one of these frameworks, use the tailored SDK for the best integration experience.
 
 - Quickstarts
-  - [Application using Sessions (Stateful)](https://auth0.com/docs/quickstart/webapp/php) — Demonstrates a traditional web application that uses sessions and supports logging in, logging out, and querying user profiles. [The completed source code is also available.](https://github.com/auth0-samples/auth0-php-web-app)
-  - [API using Access Tokens (Stateless)](https://auth0.com/docs/quickstart/backend/php) — Demonstrates a backend API that authorizes endpoints using access tokens provided by a frontend client and returns JSON. [The completed source code is also available.](https://github.com/auth0-samples/auth0-php-api-samples)
-- [PHP Examples](./EXAMPLES.md) — Code samples for common scenarios.
-- [Documentation Hub](https://www.auth0.com/docs) — Learn more about integrating Auth0 with your application.
+  - [Application using Sessions (Stateful)](https://auth0.com/docs/quickstart/webapp/php) - Demonstrates a traditional web application that uses sessions and supports logging in, logging out, and querying user profiles. [The completed source code is also available.](https://github.com/auth0-samples/auth0-php-web-app)
+  - [API using Access Tokens (Stateless)](https://auth0.com/docs/quickstart/backend/php) - Demonstrates a backend API that authorizes endpoints using access tokens provided by a frontend client and returns JSON. [The completed source code is also available.](https://github.com/auth0-samples/auth0-php-api-samples)
+- [PHP Examples](./EXAMPLES.md) - Code samples for common scenarios.
+- [Documentation Hub](https://www.auth0.com/docs) - Learn more about integrating Auth0 with your application.
 
 ## Getting Started
 
@@ -171,7 +171,7 @@ $response = $auth->dbConnectionsChangePassword(
 
 ## Management API Client
 
-The `ManagementClient` wrapper provides a convenient way to interact with the Auth0 Management API with automatic token management. It wraps the generated `Management` client and handles authentication transparently — you get the same sub-client access (`->users`, `->roles`, etc.) without managing tokens yourself.
+The `ManagementClient` wrapper provides a convenient way to interact with the Auth0 Management API with automatic token management. It wraps the generated `Management` client and handles authentication transparently - you get the same sub-client access (`->users`, `->roles`, etc.) without managing tokens yourself.
 
 ### Static Token
 
@@ -237,7 +237,7 @@ $client = new ManagementClient(new ManagementClientOptions(
 $user = $client->users->get('auth0|123');
 ```
 
-Any PSR-6 `CacheItemPoolInterface` implementation works — for example `FilesystemAdapter`, `RedisAdapter`, `ApcuAdapter`, or `Memcached` from `symfony/cache`. The token TTL is set automatically based on the `expires_in` value from Auth0.
+Any PSR-6 `CacheItemPoolInterface` implementation works - for example `FilesystemAdapter`, `RedisAdapter`, `ApcuAdapter`, or `Memcached` from `symfony/cache`. The token TTL is set automatically based on the `expires_in` value from Auth0.
 
 ### Custom Token Provider
 
@@ -313,14 +313,14 @@ When updating resources with PATCH endpoints, the SDK distinguishes between **om
 use Auth0\SDK\API\Management\Users\Requests\UpdateUserRequestContent;
 
 // Constructor only: null properties are OMITTED from the request.
-// This sends {"name": "Jane"} — email is not touched.
+// This sends {"name": "Jane"} - email is not touched.
 $request = new UpdateUserRequestContent([
     'name' => 'Jane',
-    'nickname' => null,  // Omitted — nickname is not changed
+    'nickname' => null,  // Omitted - nickname is not changed
 ]);
 
 // Setter: null properties are INCLUDED in the request.
-// This sends {"name": "Jane", "nickname": null} — nickname is cleared.
+// This sends {"name": "Jane", "nickname": null} - nickname is cleared.
 $request = new UpdateUserRequestContent(['name' => 'Jane']);
 $request->setNickname(null);
 ```
@@ -330,8 +330,8 @@ Setters mark the property as explicitly set, so the serializer includes it even 
 ```php
 $request = (new UpdateUserRequestContent())
     ->setName('Jane')
-    ->setNickname(null)    // Will send null — clears nickname
-    ->setUserMetadata(null); // Will send null — clears user_metadata
+    ->setNickname(null)    // Will send null - clears nickname
+    ->setUserMetadata(null); // Will send null - clears user_metadata
 ```
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We also have tailored SDKs for [Laravel](https://github.com/auth0/laravel-auth0)
 Ensure you have [the necessary dependencies](#requirements) installed, then add the SDK to your application using [Composer](https://getcomposer.org/):
 
 ```
-composer require auth0/auth0-php:9.0.0-beta.2
+composer require auth0/auth0-php:9.0.0-beta.6
 ```
 
 > **Note:** This is a pre-release version. To install it, you must specify the exact version as shown above. Running `composer require auth0/auth0-php` without a version constraint will install the latest stable v8 release.


### PR DESCRIPTION
### Changes

Prepares CI, release workflows, and README for the v9 GA cutover to `main`.

**Release workflow**

- Re-enable the `rl-scanner` job in `release.yml` and restore the `needs: rl-scanner` gate on the `release` job, so releases are again gated on the supply-chain scan. It uses the existing local `./.github/workflows/rl-scanner.yml` reusable workflow.

**CI branch triggers**

- Point the `pull_request` and `push` branch filters and the `cancel-in-progress` refs in `tests.yml` and `snyk.yml` at `v8` instead of `v9`. Once v9 merges to `main`, `v8` becomes the maintenance line and `v9` no longer exists as a target branch.

**README**

- Replace em-dashes with single hyphens throughout `README.md`.

### References

N/A

### Testing

N/A

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)