### PR TITLE
fix: force the Secure cookie flag when SameSite=None applies

### DIFF
--- a/src/Configuration/SdkConfiguration.php
+++ b/src/Configuration/SdkConfiguration.php
@@ -95,7 +95,7 @@ final class SdkConfiguration implements ConfigurableContract
      * @param int                              $cookieExpires                   Defaults to 0. How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
      * @param string                           $cookiePath                      Defaults to '/'. Specifies path on the domain where the cookies will work. Use a single slash ('/') for all paths on the domain.
      * @param null|string                      $cookieSameSite                  Defaults to 'lax'. Specifies whether cookies should be restricted to first-party or same-site context.
-     * @param bool                             $cookieSecure                    Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
+     * @param bool                             $cookieSecure                    Defaults to false. Specifies whether cookies should ONLY be sent over secure connections. Enable this in production so session and token cookies are never sent over plaintext HTTP. When SameSite=None applies (e.g. responseMode 'form_post'), Secure is forced on regardless, as browsers reject SameSite=None cookies without it.
      * @param bool                             $persistUser                     Defaults to true. If true, the user data will persist in session storage.
      * @param bool                             $persistIdToken                  Defaults to true. If true, the Id Token will persist in session storage.
      * @param bool                             $persistAccessToken              Defaults to true. If true, the Access Token will persist in session storage.

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -339,6 +339,11 @@ final class CookieStore implements StoreInterface
             $options['samesite'] = 'Lax';
         }
 
+        // Browsers reject SameSite=None cookies without Secure, so force it on.
+        if ('none' === mb_strtolower($options['samesite'])) {
+            $options['secure'] = true;
+        }
+
         $domain = $this->configuration->getCookieDomain() ?? null;
         $httpHost = $_SERVER['HTTP_HOST'] ?? 'UNAVAILABLE';
 

--- a/src/Store/SessionStore.php
+++ b/src/Store/SessionStore.php
@@ -151,13 +151,16 @@ final readonly class SessionStore implements StoreInterface
         if ('' === $sessionId || false === $sessionId) {
             // @codeCoverageIgnoreStart
             if (! defined('AUTH0_TESTS_DIR')) {
+                $sameSite = 'form_post' === $this->configuration->getResponseMode() ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax';
+
                 session_set_cookie_params([
                     'lifetime' => $this->configuration->getCookieExpires(),
                     'domain' => $this->configuration->getCookieDomain(),
                     'path' => $this->configuration->getCookiePath(),
-                    'secure' => $this->configuration->getCookieSecure(),
+                    // Browsers reject SameSite=None cookies without Secure, so force it on.
+                    'secure' => 'None' === $sameSite ? true : $this->configuration->getCookieSecure(),
                     'httponly' => true,
-                    'samesite' => 'form_post' === $this->configuration->getResponseMode() ? 'None' : $this->configuration->getCookieSameSite() ?? 'Lax',
+                    'samesite' => $sameSite,
                 ]);
             }
 

--- a/tests/Unit/Store/CookieStoreTest.php
+++ b/tests/Unit/Store/CookieStoreTest.php
@@ -222,6 +222,16 @@ test('unsupported configured SameSite() is overwritten by default of `lax`', fun
     expect($options['samesite'])->toEqual('Lax');
 });
 
+test('SameSite=None forces the Secure flag on even when cookieSecure is false', function(): void {
+    $this->configuration->setResponseMode('form_post');
+    $this->configuration->setCookieSecure(false);
+
+    $options = $this->store->getCookieOptions();
+
+    expect($options['samesite'])->toEqual('None');
+    expect($options['secure'])->toBeTrue();
+});
+
 test('toggling encryption works', function(array $state): void {
     expect($this->store->getEncrypted())->toEqual(true);
 


### PR DESCRIPTION
### Changes

When `responseMode` is `form_post`, both `CookieStore` and `SessionStore` unconditionally set the cookie `SameSite` attribute to `None`, because a cross-origin POST callback requires it. However, the `secure` flag was still taken from `cookieSecure` (default `false`), so the SDK could emit a `SameSite=None` cookie without `Secure`. Browsers reject a `SameSite=None` cookie that does not also carry `Secure` (RFC 6265bis), so this combination results in the cookie being dropped on modern browsers.

This PR forces the `Secure` flag on whenever the resolved `SameSite` is `None`:

**🔒 Security Fix:**

- `CookieStore::getCookieOptions()` now sets `secure` to `true` when the resolved `samesite` value is `None`, after the existing `SameSite` normalization, so both `form_post` and an explicit `cookieSameSite` of `None` are covered
- `SessionStore::start()` applies the same rule to the native PHP session cookie params, forcing `secure` on when `SameSite=None` is in effect
- `cookieSecure` still defaults to `false` and is otherwise unchanged. The `$cookieSecure` documentation now notes that `Secure` is forced on when `SameSite=None` applies and recommends enabling it in production

Applications using the default `query` response mode are unaffected, as their cookies keep the same attributes. For `form_post` applications, the session and transient cookies now always carry `Secure` and are therefore only sent over HTTPS. Such deployments should serve the callback over HTTPS.

### References

N/A

### Testing

- Added `SameSite=None forces the Secure flag on even when cookieSecure is false` to the `CookieStore` unit tests, asserting that `form_post` yields `samesite=None` with `secure=true`

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)