### PR TITLE
chore: apply Rector null-coalescing assignment rule from newer tool versions

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -361,9 +361,7 @@ final class Token implements TokenInterface
         $tokenCacheTtl ??= $this->configuration->getTokenCacheTtl();
         $tokenCache ??= $this->configuration->getTokenCache() ?? null;
 
-        if (null === $tokenJwksUri) {
-            $tokenJwksUri = $this->configuration->formatDomain() . '/.well-known/jwks.json';
-        }
+        $tokenJwksUri ??= $this->configuration->formatDomain() . '/.well-known/jwks.json';
 
         $this->getParser()->verify(
             $tokenAlgorithm,

--- a/src/Token/Parser.php
+++ b/src/Token/Parser.php
@@ -224,10 +224,7 @@ final class Parser
 
             // @codeCoverageIgnoreStart
             // This is not currently testable using our JWT encoding test libraries.
-            if (! isset($this->tokenHeaders['typ'])) {
-                $this->tokenHeaders['typ'] = 'JWT';
-            }
-
+            $this->tokenHeaders['typ'] ??= 'JWT';
             // @codeCoverageIgnoreEnd
         }
 

--- a/src/Utility/HttpResponsePaginator.php
+++ b/src/Utility/HttpResponsePaginator.php
@@ -328,9 +328,7 @@ final class HttpResponsePaginator implements Countable, Iterator
                     throw \Auth0\SDK\Exception\PaginatorException::httpBadResponse();
                 }
 
-                if (null === $start) {
-                    $start = $this->position;
-                }
+                $start ??= $this->position;
 
                 $start = (int) $start;
 

--- a/src/Utility/HttpTelemetry.php
+++ b/src/Utility/HttpTelemetry.php
@@ -104,9 +104,7 @@ final class HttpTelemetry
         string $name,
         string $version,
     ): void {
-        if (null === self::$environment) {
-            self::$environment = [];
-        }
+        self::$environment ??= [];
 
         self::$environment[$name] = $version;
     }


### PR DESCRIPTION
### Changes

CI installs its dev tools from open version ranges and there is no committed `composer.lock`, so it recently pulled in a newer Rector (2.6.x). That version enables `IfToNullCoalescingAssignRector`, which is why the Rector job started failing on unrelated PRs.

- The rule rewrites `if (null === $x) { $x = ...; }` guards to `$x ??= ...`, which is equivalent.
- This affected four pre-existing spots: `src/Token.php`, `src/Token/Parser.php`, `src/Utility/HttpResponsePaginator.php`, and `src/Utility/HttpTelemetry.php`.
- In `src/Token/Parser.php` the `@codeCoverageIgnore` markers were kept around the rewritten line, since it remains untestable with the current JWT encoding test libraries.
- Behavior is unchanged.

### References

Unblocks the Rector CI job on open PRs (#852, #853, #861).

### Testing

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)